### PR TITLE
refactor planner to use device_type

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -490,18 +490,20 @@ class QuantEmbeddingBagCollectionSharder(ModuleSharder[QuantEmbeddingBagCollecti
     def sharding_types(self) -> List[str]:
         return [ShardingType.DATA_PARALLEL.value]
 
-    def compute_kernels(self, sharding_type: str, device: torch.device) -> List[str]:
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
         return [
             EmbeddingComputeKernel.BATCHED_QUANT.value,
         ]
 
     def storage_usage(
-        self, tensor: torch.Tensor, device: torch.device, compute_kernel: str
+        self, tensor: torch.Tensor, compute_device_type: str, compute_kernel: str
     ) -> Dict[str, int]:
         tensor_bytes = tensor.numel() * tensor.element_size() + tensor.shape[0] * 4
-        assert device.type in {"cuda", "cpu"}
+        assert compute_device_type in {"cuda", "cpu"}
         storage_map = {"cuda": ParameterStorage.HBM, "cpu": ParameterStorage.DDR}
-        return {storage_map[device.type].value: tensor_bytes}
+        return {storage_map[compute_device_type].value: tensor_bytes}
 
     def shardable_parameters(
         self, module: QuantEmbeddingBagCollection

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -95,7 +95,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
 
         # 2. Call ShardingPlanner.collective_plan passing all found modules and corresponding sharders.
         if plan is None:
-            planner = EmbeddingShardingPlanner(self._env.world_size, self.device)
+            planner = EmbeddingShardingPlanner(self._env.world_size, self.device.type)
             pg = self._env.process_group
             if pg is not None:
                 plan = planner.collective_plan(module, sharders, pg)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -103,7 +103,7 @@ class ShardingOption:
 @dataclass
 class CostInput:
     param: torch.Tensor
-    device: torch.device
+    compute_device_type: str
     compute_kernel: str
     sharding_type: str
     input_stats: Optional[ParameterInputStats]

--- a/torchrec/distributed/tests/test_model.py
+++ b/torchrec/distributed/tests/test_model.py
@@ -446,7 +446,9 @@ class TestEBCSharder(EmbeddingBagCollectionSharder[EmbeddingBagCollection]):
     Restricts to single impl.
     """
 
-    def compute_kernels(self, sharding_type: str, device: torch.device) -> List[str]:
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
         return [self._kernel_type]
 
     @property

--- a/torchrec/distributed/tests/test_model_parallel_base.py
+++ b/torchrec/distributed/tests/test_model_parallel_base.py
@@ -90,7 +90,7 @@ class ModelParallelTestBase(unittest.TestCase):
             sparse_device=torch.device("meta"),
         )
 
-        planner = EmbeddingShardingPlanner(world_size, device, hints)
+        planner = EmbeddingShardingPlanner(world_size, "cuda", hints)
         plan = planner.collective_plan(local_model, sharders, pg)
 
         local_model = DistributedModelParallel(

--- a/torchrec/distributed/tests/test_quant_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_model_parallel.py
@@ -41,7 +41,9 @@ class TestQuantEBCSharder(QuantEmbeddingBagCollectionSharder):
     def sharding_types(self) -> List[str]:
         return [self._sharding_type]
 
-    def compute_kernels(self, sharding_type: str, device: torch.device) -> List[str]:
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
         return [self._kernel_type]
 
 

--- a/torchrec/distributed/tests/test_train_pipeline.py
+++ b/torchrec/distributed/tests/test_train_pipeline.py
@@ -69,7 +69,9 @@ class TestCustomEBCSharder(EmbeddingBagCollectionSharder[EmbeddingBagCollection]
             ShardingType.TABLE_WISE.value,
         ]
 
-    def compute_kernels(self, sharding_type: str, device: torch.device) -> List[str]:
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
         return [EmbeddingComputeKernel.DENSE.value]
 
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -439,7 +439,9 @@ class ModuleSharder(abc.ABC, Generic[M]):
         """
         return [ShardingType.DATA_PARALLEL.value]
 
-    def compute_kernels(self, sharding_type: str, device: torch.device) -> List[str]:
+    def compute_kernels(
+        self, sharding_type: str, compute_device_type: str
+    ) -> List[str]:
         """
         List of supported compute kernels for a given sharding_type and compute device.
         """
@@ -447,17 +449,18 @@ class ModuleSharder(abc.ABC, Generic[M]):
         return [ComputeKernel.DEFAULT.value]
 
     def storage_usage(
-        self, tensor: torch.Tensor, device: torch.device, compute_kernel: str
+        self, tensor: torch.Tensor, compute_device_type: str, compute_kernel: str
     ) -> Dict[str, int]:
         """
         List of system resources and corresponding usage given a compute device and
         compute kernel
         """
 
-        assert device.type in {"cuda", "cpu"}
+        assert compute_device_type in {"cuda", "cpu"}
         storage_map = {"cuda": ParameterStorage.HBM, "cpu": ParameterStorage.DDR}
         return {
-            storage_map[device.type].value: tensor.element_size() * tensor.nelement()
+            storage_map[compute_device_type].value: tensor.element_size()
+            * tensor.nelement()
         }
 
 


### PR DESCRIPTION
Summary: refactor the planner to take only planner type as we want to decouple plan and DMP callsites for GPU inference

Reviewed By: divchenko

Differential Revision: D31588920

