### PR TITLE
Adding fbgemm repository as a git submodule to TorchRec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/fbgemm"]
+	path = third_party/fbgemm
+	url = https://github.com/pytorch/FBGEMM.git


### PR DESCRIPTION
TorchRec OSS installation currently requires 3 steps:
1. fbgemm_gpu installation
2. Symlink fbgemm_gpu_py.so to the TorchRec directory
3. Run TorchRec's installation

We can simplify this to a single step by bringing in fbgemm_gpu into TorchRec directory