### PR TITLE
ignore experimental tests on GHA

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -241,7 +241,7 @@ jobs:
           python -m pip install pytest
         cd torchrec
         conda run -n build_binary \
-          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+          python -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors --ignore-glob="*/experimental/*"
     # Push to Pypi
     - name: Push TorchRec Binary to PYPI
       env:

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -231,4 +231,4 @@ jobs:
         source build_binary_3.8/bin/activate
         pip3 install pytest
         cd torchrec
-        python3 -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors
+        python3 -m pytest -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors --ignore-glob="*/experimental/*"


### PR DESCRIPTION
Summary: don't run experimental features tests (such as torcharrow) on GHA

Differential Revision: D33965029

