### PR TITLE
enable TLS for gloo tests for OSS

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -58,6 +58,8 @@ class ModelParallelTestBase(unittest.TestCase):
 
     def tearDown(self) -> None:
         torch.use_deterministic_algorithms(False)
+        del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_SOCKET_IFNAME"]
         if torch.cuda.is_available():
             os.unsetenv("CUBLAS_WORKSPACE_CONFIG")
         super().tearDown()

--- a/torchrec/distributed/tests/collective_utils_test.py
+++ b/torchrec/distributed/tests/collective_utils_test.py
@@ -25,10 +25,15 @@ class CollectiveUtilsTest(unittest.TestCase):
     @seed_and_log
     def setUp(self) -> None:
         os.environ["MASTER_ADDR"] = str(MASTER_ADDR)
+        os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
-        os.environ["MASTER_PORT"] = str(get_free_port())
         self.WORLD_SIZE = 2
+
+    def tearDown(self) -> None:
+        del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_SOCKET_IFNAME"]
+        super().tearDown()
 
     def _run_multi_process_test(
         self,

--- a/torchrec/distributed/tests/test_comm.py
+++ b/torchrec/distributed/tests/test_comm.py
@@ -22,10 +22,15 @@ class TestAllToAll(unittest.TestCase):
     @seed_and_log
     def setUp(self) -> None:
         os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
-        os.environ["MASTER_PORT"] = str(get_free_port())
         self.WORLD_SIZE = 2
+
+    def tearDown(self) -> None:
+        del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_SOCKET_IFNAME"]
+        super().tearDown()
 
     def _run_multi_process_test(
         self,

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -168,6 +168,12 @@ class DistDataTestCase(abc.ABC, unittest.TestCase):
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
         self.WORLD_SIZE = 2
 
+    def tearDown(self) -> None:
+        del os.environ["GLOO_DEVICE_TRANSPORT"]
+        del os.environ["NCCL_SOCKET_IFNAME"]
+        # pyre-fixme[16]
+        super().tearDown()
+
     def _run_multi_process_test(
         self,
         _input: Union[List[KeyedJaggedTensor], List[torch.Tensor]],

--- a/torchrec/distributed/tests/test_utils.py
+++ b/torchrec/distributed/tests/test_utils.py
@@ -36,7 +36,6 @@ class UtilsTest(unittest.TestCase):
         os.environ["LOCAL_WORLD_SIZE"] = "1"
         os.environ["MASTER_ADDR"] = str("localhost")
         os.environ["MASTER_PORT"] = str(get_free_port())
-        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         device = torch.device("cpu")
         backend = "gloo"
         dist.init_process_group(backend=backend)


### PR DESCRIPTION
Summary:
clean up environment variables in tests
enable TLS in gloo tests

Differential Revision: D33956567

