### PR TITLE
Fix interaction arch sparse feature ordering

### DIFF
--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -209,7 +209,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 10
         keys = ["f1", "f2"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
 
         dense_features = torch.rand((B, D))
 
@@ -227,7 +227,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 20
         keys = ["f1", "f2", "f3", "f4"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
 
         dense_features = torch.rand((B, D))
 
@@ -246,7 +246,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 10
         keys = ["f1", "f2"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
         gm = symbolic_trace(inter_arch)
 
         dense_features = torch.rand((B, D))
@@ -267,7 +267,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 10
         keys = ["f1", "f2"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
         gm = symbolic_trace(inter_arch)
         scripted_gm = torch.jit.script(gm)
 
@@ -288,7 +288,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 25
         keys = ["f1", "f2", "f3", "f4", "f5", "f6"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
 
         dense_features = torch.rand((B, D))
 
@@ -347,7 +347,7 @@ class InteractionArchTest(unittest.TestCase):
         B = 6
         keys = ["f1", "f2"]
         F = len(keys)
-        inter_arch = InteractionArch(num_sparse_features=F)
+        inter_arch = InteractionArch(sparse_feature_names=keys)
         torch.manual_seed(0)
         dense_features = torch.randint(0, 10, (B, D))
 


### PR DESCRIPTION
Summary:
- bigning found a bug in our interaction arch, the order of the sparse features is different from the order with which the model was instantiated (https://github.com/facebookresearch/torchrec/blob/0b852038347cc6cc463a63125e99925671d4b374/torchrec/datasets/criteo.py#L41)
```
within interaction arch:
['cat_19', 'cat_0', 'cat_2', 'cat_21', 'cat_9', 'cat_23', 'cat_14', 'cat_20', 'cat_3', 'cat_10', 'cat_6', 'cat_22',
'cat_11', 'cat_13', 'cat_1', 'cat_7', 'cat_4', 'cat_17', 'cat_5', 'cat_8', 'cat_12', 'cat_15', 'cat_16', 'cat_18',
'cat_24', 'cat_25']
```
- The consequence is that if this model were to be deployed then inference would be broken as the order of the sparse features would be different from the order inside the interaction arch

- This diff reorders the sparse features in the interaction arch's forward call to match the order the model originally had

Reviewed By: bigning

Differential Revision: D34085835

