### PR TITLE
Fix QuantEBC for shared sparse features

### DIFF
--- a/torchrec/quant/tests/test_embedding_modules.py
+++ b/torchrec/quant/tests/test_embedding_modules.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from typing import List
 
 import torch
 from torchrec.modules.embedding_configs import (
@@ -21,20 +22,11 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class EmbeddingBagCollectionTest(unittest.TestCase):
-    def test_ebc(self) -> None:
-        eb1_config = EmbeddingBagConfig(
-            name="t1", embedding_dim=16, num_embeddings=10, feature_names=["f1"]
-        )
-        eb2_config = EmbeddingBagConfig(
-            name="t2", embedding_dim=16, num_embeddings=10, feature_names=["f2"]
-        )
-        ebc = EmbeddingBagCollection(tables=[eb1_config, eb2_config])
+    def _test_ebc(
+        self, tables: List[EmbeddingBagConfig], features: KeyedJaggedTensor
+    ) -> None:
+        ebc = EmbeddingBagCollection(tables=tables)
 
-        features = KeyedJaggedTensor(
-            keys=["f1", "f2"],
-            values=torch.as_tensor([0, 1]),
-            lengths=torch.as_tensor([1, 1]),
-        )
         embeddings = ebc(features)
 
         # test forward
@@ -50,23 +42,56 @@ class EmbeddingBagCollectionTest(unittest.TestCase):
         quantized_embeddings = qebc(features)
 
         self.assertEqual(embeddings.keys(), quantized_embeddings.keys())
-        self.assertEqual(embeddings["f1"].shape, quantized_embeddings["f1"].shape)
-        self.assertTrue(
-            torch.allclose(
-                embeddings["f1"].cpu(),
-                quantized_embeddings["f1"].cpu().float(),
-                atol=1,
+        for key in embeddings.keys():
+            self.assertEqual(embeddings[key].shape, quantized_embeddings[key].shape)
+            self.assertTrue(
+                torch.allclose(
+                    embeddings[key].cpu(),
+                    quantized_embeddings[key].cpu().float(),
+                    atol=1,
+                )
             )
-        )
-        self.assertTrue(
-            torch.allclose(
-                embeddings["f2"].cpu(),
-                quantized_embeddings["f2"].cpu().float(),
-                atol=1,
-            )
-        )
 
         # test state dict
         state_dict = ebc.state_dict()
         quantized_state_dict = qebc.state_dict()
         self.assertEqual(state_dict.keys(), quantized_state_dict.keys())
+
+    def test_ebc(self) -> None:
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=16, num_embeddings=10, feature_names=["f1"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2", embedding_dim=16, num_embeddings=10, feature_names=["f2"]
+        )
+        features = KeyedJaggedTensor(
+            keys=["f1", "f2"],
+            values=torch.as_tensor([0, 1]),
+            lengths=torch.as_tensor([1, 1]),
+        )
+        self._test_ebc([eb1_config, eb2_config], features)
+
+    def test_shared_tables(self) -> None:
+        eb_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=16, num_embeddings=10, feature_names=["f1", "f2"]
+        )
+        features = KeyedJaggedTensor(
+            keys=["f1", "f2"],
+            values=torch.as_tensor([0, 1]),
+            lengths=torch.as_tensor([1, 1]),
+        )
+        self._test_ebc([eb_config], features)
+
+    def test_shared_features(self) -> None:
+        eb1_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=16, num_embeddings=10, feature_names=["f1"]
+        )
+        eb2_config = EmbeddingBagConfig(
+            name="t2", embedding_dim=16, num_embeddings=10, feature_names=["f1"]
+        )
+        features = KeyedJaggedTensor(
+            keys=["f1"],
+            values=torch.as_tensor([0, 1]),
+            lengths=torch.as_tensor([1, 1]),
+        )
+        self._test_ebc([eb1_config, eb2_config], features)


### PR DESCRIPTION
Summary: A sparse feature can be shared between multiple tables. Fix QuantEBC for shared sparse features

Reviewed By: zyan0

Differential Revision: D34220554

