### PR TITLE
update colab notebook with prod doc links

### DIFF
--- a/Torchrec_Introduction.ipynb
+++ b/Torchrec_Introduction.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Intro to TorchRec\n",
         "\n",
-        "Frequently, when building recommendation systems, we want to represent entities like products or pages with embeddings. For example, see Meta AI's [Deep learning recommendation model](https://arxiv.org/abs/1906.00091), or DLRM. As the number of entities grow, the size of the embedding tables can exceed a single GPU’s memory. A common practice is to shard the embedding table across devices, a type of model parallelism. To that end, **torchRec introduces its primary API called [`DistributedModelParallel`](https://github.com/facebookresearch/torchrec/blob/main/torchrec/distributed/model_parallel.py#L109), or DMP. Like pytorch’s DistributedDataParallel, DMP wraps a model to enable distributed training.**"
+        "Frequently, when building recommendation systems, we want to represent entities like products or pages with embeddings. For example, see Meta AI's [Deep learning recommendation model](https://arxiv.org/abs/1906.00091), or DLRM. As the number of entities grow, the size of the embedding tables can exceed a single GPU’s memory. A common practice is to shard the embedding table across devices, a type of model parallelism. To that end, **torchRec introduces its primary API called [`DistributedModelParallel`](https://pytorch.org/torchrec/torchrec.distributed.html#torchrec.distributed.model_parallel.DistributedModelParallel), or DMP. Like pytorch’s DistributedDataParallel, DMP wraps a model to enable distributed training.**"
       ]
     },
     {
@@ -166,7 +166,7 @@
         "### From EmbeddingBag to EmbeddingBagCollection\n",
         "Pytorch represents embeddings through [`torch.nn.Embedding`](https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html) and [`torch.nn.EmbeddingBag`](https://pytorch.org/docs/stable/generated/torch.nn.EmbeddingBag.html). EmbeddingBag is a pooled version of Embedding.\n",
         "\n",
-        "TorchRec extends these modules by creating collections of embeddings. We will use [`EmbeddingBagCollection`](https://github.com/facebookresearch/torchrec/blob/main/torchrec/modules/embedding_modules.py#L59) to represent a group of EmbeddingBags.\n",
+        "TorchRec extends these modules by creating collections of embeddings. We will use [`EmbeddingBagCollection`](https://pytorch.org/torchrec/torchrec.modules.html#torchrec.modules.embedding_modules.EmbeddingBagCollection) to represent a group of EmbeddingBags.\n",
         "\n",
         "Here, we create an EmbeddingBagCollection (EBC) with two embedding bags. Each table, `product_table` and `user_table`, is represented by 64 dimension embedding of size 4096. Note how we initially allocate the EBC on device \"meta\". This will tell EBC to not allocate memory yet."
       ],
@@ -207,7 +207,7 @@
       "cell_type": "markdown",
       "source": [
         "### DistributedModelParallel\n",
-        "Now, we’re ready to wrap our model with [`DistributedModelParallel`](https://github.com/facebookresearch/torchrec/blob/main/torchrec/distributed/model_parallel.py#L109) (DMP). Instantiating DMP will:\n",
+        "Now, we’re ready to wrap our model with [`DistributedModelParallel`](https://pytorch.org/torchrec/torchrec.distributed.html#torchrec.distributed.model_parallel.DistributedModelParallel) (DMP). Instantiating DMP will:\n",
         "\n",
         "1. Decide how to shard the model. DMP will collect the available ‘sharders’ and come up with a ‘plan’ of the optimal way to shard the embedding table(s) (i.e, the EmbeddingBagCollection)\n",
         "2. Actually shard the model. This includes allocating memory for each embedding table on the appropriate device(s).\n",
@@ -348,7 +348,7 @@
       "source": [
         "### Representing minibatches with KeyedJaggedTensor\n",
         "\n",
-        "We need an efficient representation of multiple examples of an arbitrary number of entity IDs per feature per example. In order to enable this \"jagged\" representation, we use the torchRec datastructure [`KeyedJaggedTensor`](https://github.com/facebookresearch/torchrec/blob/main/torchrec/sparse/jagged_tensor.py#L431) (KJT).\n",
+        "We need an efficient representation of multiple examples of an arbitrary number of entity IDs per feature per example. In order to enable this \"jagged\" representation, we use the torchRec datastructure [`KeyedJaggedTensor`](https://pytorch.org/torchrec/torchrec.sparse.html#torchrec.sparse.jagged_tensor.JaggedTensor) (KJT).\n",
         "\n",
         "Let's take a look at **how to lookup a collection of two embedding bags**, \"product\" and \"user\".  Assume the minibatch is made up of three examples for three users. The first of which has two product IDs, the second with none, and the third with one product ID.\n",
         "\n",
@@ -455,7 +455,7 @@
       "cell_type": "markdown",
       "source": [
         "## More resources\n",
-        "For more information, please see our [dlrm](https://github.com/facebookresearch/torchrec/tree/main/examples/dlrm) example, which includes multinode training on the criteo terabyte dataset, using Meta’s [DLRM](https://arxiv.org/abs/1906.00091)."
+        "For more information, please see our [dlrm](https://github.com/pytorch/torchrec/tree/main/examples/dlrm) example, which includes multinode training on the criteo terabyte dataset, using Meta’s [DLRM](https://arxiv.org/abs/1906.00091)."
       ],
       "metadata": {
         "id": "ebXfh7oW9fHH"


### PR DESCRIPTION
Summary: replace links to hosted documentation at https://pytorch.org/torchrec

Differential Revision: D34402699

