### PR TITLE
states vectorization for bucket metrics

### DIFF
--- a/torchrec/metrics/calibration.py
+++ b/torchrec/metrics/calibration.py
@@ -30,19 +30,12 @@ def compute_calibration(
 
 def get_calibration_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
-) -> Dict[str, torch.Tensor]:
-    return {
-        CALIBRATION_NUM: torch.sum(predictions * weights, dim=-1),
-        CALIBRATION_DENOM: torch.sum(labels * weights, dim=-1),
-    }
-
-
-def get_calibration_states_fused(
-    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor
 ) -> torch.Tensor:
     return torch.stack(
         [
+            # state "calibration_num"
             torch.sum(predictions * weights, dim=-1),
+            # state "calibration_denom"
             torch.sum(labels * weights, dim=-1),
         ]
     )
@@ -85,7 +78,7 @@ class CalibrationMetricComputation(RecMetricComputation):
             )
         num_samples = predictions.shape[-1]
 
-        states = get_calibration_states_fused(labels, predictions, weights)
+        states = get_calibration_states(labels, predictions, weights)
         state = getattr(self, self._fused_name)
         state += states
         self._aggregate_window_state(self._fused_name, states, num_samples)

--- a/torchrec/metrics/ne.py
+++ b/torchrec/metrics/ne.py
@@ -58,23 +58,6 @@ def compute_ne(
 
 def get_ne_states(
     labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
-) -> Dict[str, torch.Tensor]:
-    cross_entropy = compute_cross_entropy(
-        labels,
-        predictions,
-        weights,
-        eta,
-    )
-    return {
-        "cross_entropy_sum": torch.sum(cross_entropy, dim=-1),
-        "weighted_num_samples": torch.sum(weights, dim=-1),
-        "pos_labels": torch.sum(weights * labels, dim=-1),
-        "neg_labels": torch.sum(weights * (1.0 - labels), dim=-1),
-    }
-
-
-def get_ne_states_fused(
-    labels: torch.Tensor, predictions: torch.Tensor, weights: torch.Tensor, eta: float
 ) -> torch.Tensor:
     cross_entropy = compute_cross_entropy(
         labels,
@@ -84,9 +67,13 @@ def get_ne_states_fused(
     )
     return torch.stack(
         [
+            # state "cross_entropy_sum"
             torch.sum(cross_entropy, dim=-1),
+            # state "weighted_num_samples"
             torch.sum(weights, dim=-1),
+            # state "pos_labels"
             torch.sum(weights * labels, dim=-1),
+            # state "neg_labels"
             torch.sum(weights * (1.0 - labels), dim=-1),
         ]
     )
@@ -131,7 +118,7 @@ class NEMetricComputation(RecMetricComputation):
             )
         num_samples = predictions.shape[-1]
 
-        states = get_ne_states_fused(labels, predictions, weights, self.eta)
+        states = get_ne_states(labels, predictions, weights, self.eta)
         state = getattr(self, self._fused_name)
         state += states
         self._aggregate_window_state(self._fused_name, states, num_samples)


### PR DESCRIPTION
Summary: This is following the diff D40419238 (https://github.com/pytorch/torchrec/commit/50c861a4debb6d0d8bd55ddb27452e89f2d19d51) to vectorize the states computation for bucket_ne and bucket_calibration metrics.

Differential Revision: D41746076

