### PR TITLE
enable python 3.13t (freethreading) in binary validation workflow

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -10,13 +10,14 @@ export PYTORCH_CUDA_PKG=""
 export CONDA_ENV="build_binary"
 
 if [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
-    echo "Conda doesn't support 3.13t yet, you can just try \`conda create -n test python=3.13t\`"
-    exit 0
+    # use conda-forge to install python3.13t
+    conda create -y -n "${CONDA_ENV}" python="3.13" python-freethreading -c conda-forge
+    conda run -n "${CONDA_ENV}" python -c "import sys; print(f'python GIL enabled: {sys._is_gil_enabled()}')"
+else
+    conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
 fi
 
-conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
-
-conda run -n build_binary python --version
+conda run -n "${CONDA_ENV}" python --version
 
 # Install pytorch, torchrec and fbgemm as per
 # installation instructions on following page
@@ -83,7 +84,7 @@ conda run -n "${CONDA_ENV}" pip install fbgemm-gpu --index-url "$PYTORCH_URL"
 conda run -n "${CONDA_ENV}" pip install torchmetrics==1.0.3
 
 # install tensordict from pypi
-conda run -n "${CONDA_ENV}" pip install tensordict==0.7.1
+conda run -n "${CONDA_ENV}" pip install tensordict==0.8.1
 
 # install torchrec
 conda run -n "${CONDA_ENV}" pip install torchrec --index-url "$PYTORCH_URL"

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -22,10 +22,6 @@ conda run -n build_binary python --version
 # installation instructions on following page
 # https://github.com/pytorch/torchrec#installations
 
-if [[ ${MATRIX_GPU_ARCH_TYPE} = 'rocm' ]]; then
-    echo "We don't support rocm"
-    exit 0
-fi
 
 # figure out CUDA VERSION
 if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -39,3 +39,4 @@ jobs:
       repository: "pytorch/torchrec"
       smoke_test: "source ./.github/scripts/validate_binaries.sh"
       with_cuda: enable
+      with_rocm: false


### PR DESCRIPTION
Summary:
# context
* python 3.13t was never supported in the github "binary validation" workflow due to lack of conda native support
```
$ conda create -n py313t python=3.13t
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: failed

PackagesNotFoundError: The following packages are not available from current channels:

  - python=3.13t

Current channels:

  - https://repo.anaconda.com/pkgs/main/linux-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/linux-64
  - https://repo.anaconda.com/pkgs/r/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.
```
* therefore the validation workflow for python3.13t is alway skipped (early return)
```
if [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
    echo "Conda doesn't support 3.13t yet, you can just try \`conda create -n test python=3.13t\`"
    exit 0
fi
```
* the workaround is to use conda-forge channel to get the freethreading python
https://conda-forge.org/blog/2024/09/26/python-313/
```
conda create -n py313 python=3.13 python-freethreading -c conda-forge
```

Differential Revision: D76109652


