### PR TITLE
fix python 3.13t version for release binary validation

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -126,7 +126,14 @@ else
     fi
 fi
 
-conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
+if [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
+    # use conda-forge to install python3.13t
+    conda create -y -n "${CONDA_ENV}" python="3.13" python-freethreading -c conda-forge
+    conda run -n "${CONDA_ENV}" python -c "import sys; print(f'python GIL enabled: {sys._is_gil_enabled()}')"
+else
+    conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
+fi
+
 
 conda run -n "${CONDA_ENV}" python --version
 


### PR DESCRIPTION
Summary:
# context
* D76109652 fixed the python 3.13t for the general binary validation but it's also needed for release binary validation
* running binary validation for release using workflow from v1.2.0
 {F1979193721}

Differential Revision: D76596897
