### PR TITLE
cache offsets / lengths on updates

### DIFF
--- a/torchrec/modules/tests/test_kjt_pool_lookup.py
+++ b/torchrec/modules/tests/test_kjt_pool_lookup.py
@@ -9,20 +9,23 @@
 import unittest
 
 import torch
-from torchrec.modules.object_pool_lookups import UVMCachingInt64Lookup
+from torchrec.modules.object_pool_lookups import (
+    UVMCachingInt32Lookup,
+    UVMCachingInt64Lookup,
+)
 from torchrec.sparse.jagged_tensor import JaggedTensor
 
 
 class KeyedJaggedTensorPoolLookupTest(unittest.TestCase):
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
-        "Not enough GPUs, this test requires at least two GPUs",
+        not torch.cuda.is_available(),
+        "This test requires a GPU to run",
     )
     def test_uvm_caching_int64_lookup(
         self,
     ) -> None:
-        device = torch.device("cuda:0")
+        device = torch.device("cuda")
 
         pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
         lookup = UVMCachingInt64Lookup(
@@ -43,10 +46,7 @@ class KeyedJaggedTensorPoolLookupTest(unittest.TestCase):
 
         lookup.update(
             ids=ids,
-            values=JaggedTensor(
-                jt_values,
-                lengths=jt_lengths,
-            ),
+            values=JaggedTensor(jt_values, lengths=jt_lengths),
         )
 
         torch.testing.assert_close(lookup.lookup(ids).values(), jt_values)
@@ -63,3 +63,45 @@ class KeyedJaggedTensorPoolLookupTest(unittest.TestCase):
         torch.testing.assert_close(
             lookup.lookup(ids).values(), jt_values + INT64_VALUE_SHIFT
         )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "This test requires a GPU to run",
+    )
+    def test_uvm_caching_int32_lookup(
+        self,
+    ) -> None:
+        device = torch.device("cuda")
+
+        pool_size, feature_max_lengths = 4, {"f1": 2, "f2": 4}
+        lookup = UVMCachingInt32Lookup(
+            pool_size=pool_size,
+            feature_max_lengths=feature_max_lengths,
+            is_weighted=False,
+            device=device,
+        )
+        ids = torch.tensor([0, 1, 2, 3], device=device)
+        jt_values = torch.tensor(
+            [1, 3, 3, 2, 2, 4, 11, 13, 13, 13, 12, 12, 14, 14, 14, 14],
+            dtype=torch.int32,
+            device=device,
+        )
+        jt_lengths = torch.tensor(
+            [1, 2, 2, 1, 1, 3, 2, 4], dtype=torch.int, device=device
+        )
+
+        lookup.update(
+            ids=ids,
+            values=JaggedTensor(jt_values, lengths=jt_lengths),
+        )
+
+        torch.testing.assert_close(lookup.lookup(ids).values(), jt_values)
+
+        lookup.update(
+            ids=ids,
+            values=JaggedTensor(jt_values, lengths=jt_lengths),
+        )
+
+        torch.testing.assert_close(lookup.lookup(ids).values(), jt_values)
+


### PR DESCRIPTION
# Summary
Currently, in the UVM KJT pools, on every lookup, we recompute offset values for all lengths of the lookup ids. This can be extremely expensive if the pool size is very large and if the id lookup size is large. Furthermore, given that these offsets should only change upon updates to the pool, it should be unnecessary to recompute these values on every read path. Instead, we can compute these offsets on the pool's write path, and reference the offsets at the correct lookup indices, to significantly cut down on lookup latency.

# Testing
```
torchx run -s local_cwd utils.python --script torchrec/modules/tests/test_kjt_pool_lookup.py
```
```
torchx 2025-06-24 16:02:22 INFO     Tracker configurations: {}
torchx 2025-06-24 16:02:22 INFO     Log directory not set in scheduler cfg. Creating a temporary log dir that will be deleted on exit. To preserve log directory set the `log_dir` cfg option
torchx 2025-06-24 16:02:22 INFO     Log directory is: /tmp/torchx_9keqq27r
local_cwd://torchx/torchx_utils_python-q6bc5grqt7hv3c
torchx 2025-06-24 16:02:22 INFO     Waiting for the app to finish...
python/0 torch.cuda.is_available()=True
python/0 ..
python/0 ----------------------------------------------------------------------
python/0 Ran 2 tests in 0.458s
python/0
python/0 OK
torchx 2025-06-24 16:02:31 INFO     Job finished: SUCCEEDED
```