### PR TITLE
Adding support for MOMENTUM_DIFF and ROWWISE_ADAGRAD optimizer states

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -1587,7 +1587,7 @@ class ShardedEmbeddingCollection(
             ):
                 embs = lookup(features)
                 if self.post_lookup_tracker_fn is not None:
-                    self.post_lookup_tracker_fn(features, embs)
+                    self.post_lookup_tracker_fn(self, features, embs)
 
             with maybe_annotate_embedding_event(
                 EmbeddingEvent.OUTPUT_DIST, self._module_fqn, sharding_type

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -10,7 +10,7 @@
 import logging
 from abc import ABC
 from collections import OrderedDict
-from typing import Any, cast, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -208,6 +208,10 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
         )
 
         self.grouped_configs = grouped_configs
+        # Model tracker function to tracker optimizer state
+        self.optim_state_tracker_fn: Optional[
+            Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]
+        ] = None
 
     def _create_embedding_kernel(
         self,
@@ -315,7 +319,13 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
             self._feature_splits,
         )
         for emb_op, features in zip(self._emb_modules, features_by_group):
-            embeddings.append(emb_op(features).view(-1))
+            lookup = emb_op(features).view(-1)
+            embeddings.append(lookup)
+
+            # Model tracker optimizer state function, will only be set called
+            # when model tracker is configured to track optimizer state
+            if self.optim_state_tracker_fn is not None:
+                self.optim_state_tracker_fn(emb_op, features, lookup)
 
         return embeddings_cat_empty_rank_handle(embeddings, self._dummy_embs_tensor)
 
@@ -420,6 +430,19 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
             # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             emb_module.purge()
 
+    def register_optim_state_tracker_fn(
+        self,
+        record_fn: Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None],
+    ) -> None:
+        """
+        Model tracker function to tracker optimizer state
+
+         Args:
+             record_fn (Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]): A custom record function to be called after lookup is done.
+
+        """
+        self.optim_state_tracker_fn = record_fn
+
 
 class GroupedEmbeddingsUpdate(BaseEmbeddingUpdate[KeyedJaggedTensor]):
     """
@@ -519,6 +542,10 @@ class GroupedPooledEmbeddingsLookup(
             if scale_weight_gradients and get_gradient_division()
             else 1
         )
+        # Model tracker function to tracker optimizer state
+        self.optim_state_tracker_fn: Optional[
+            Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]
+        ] = None
 
     def _create_embedding_kernel(
         self,
@@ -678,7 +705,12 @@ class GroupedPooledEmbeddingsLookup(
                         features._weights, self._scale_gradient_factor
                     )
 
-                embeddings.append(emb_op(features))
+                lookup = emb_op(features)
+                embeddings.append(lookup)
+                # Model tracker optimizer state function, will only be set called
+                # when model tracker is configured to track optimizer state
+                if self.optim_state_tracker_fn is not None:
+                    self.optim_state_tracker_fn(emb_op, features, lookup)
 
                 if features.variable_stride_per_key() and len(self._emb_modules) > 1:
                     stride_per_rank_per_key = list(
@@ -810,6 +842,19 @@ class GroupedPooledEmbeddingsLookup(
         for emb_module in self._emb_modules:
             # pyre-fixme[29]: `Union[Module, Tensor]` is not a function.
             emb_module.purge()
+
+    def register_optim_state_tracker_fn(
+        self,
+        record_fn: Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None],
+    ) -> None:
+        """
+        Model tracker function to tracker optimizer state
+
+         Args:
+             record_fn (Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]): A custom record function to be called after lookup is done.
+
+        """
+        self.optim_state_tracker_fn = record_fn
 
 
 class MetaInferGroupedEmbeddingsLookup(

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -391,7 +391,7 @@ class ShardedEmbeddingModule(
         self._lookups: List[nn.Module] = []
         self._output_dists: List[nn.Module] = []
         self.post_lookup_tracker_fn: Optional[
-            Callable[[KeyedJaggedTensor, torch.Tensor], None]
+            Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]
         ] = None
         self.post_odist_tracker_fn: Optional[Callable[..., None]] = None
 
@@ -444,14 +444,14 @@ class ShardedEmbeddingModule(
 
     def register_post_lookup_tracker_fn(
         self,
-        record_fn: Callable[[KeyedJaggedTensor, torch.Tensor], None],
+        record_fn: Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None],
     ) -> None:
         """
         Register a function to be called after lookup is done. This is used for
         tracking the lookup results and optimizer states.
 
         Args:
-            record_fn (Callable[[KeyedJaggedTensor, torch.Tensor], None]): A custom record function to be called after lookup is done.
+            record_fn (Callable[[nn.Module, KeyedJaggedTensor, torch.Tensor], None]): A custom record function to be called after lookup is done.
 
         """
         if self.post_lookup_tracker_fn is not None:

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1671,7 +1671,7 @@ class ShardedEmbeddingBagCollection(
             ):
                 embs = lookup(features)
                 if self.post_lookup_tracker_fn is not None:
-                    self.post_lookup_tracker_fn(features, embs)
+                    self.post_lookup_tracker_fn(self, features, embs)
 
             with maybe_annotate_embedding_event(
                 EmbeddingEvent.OUTPUT_DIST,

--- a/torchrec/distributed/model_tracker/model_delta_tracker.py
+++ b/torchrec/distributed/model_tracker/model_delta_tracker.py
@@ -8,14 +8,20 @@
 # pyre-strict
 import logging as logger
 from collections import Counter, OrderedDict
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import torch
+from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+from fbgemm_gpu.split_table_batched_embeddings_ops import (
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
 
 from torch import nn
+from torchrec.distributed.batched_embedding_kernel import BatchedFusedEmbedding
 
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.embedding_lookup import (
+    BatchedFusedEmbeddingBag,
     GroupedEmbeddingsLookup,
     GroupedPooledEmbeddingsLookup,
 )
@@ -26,6 +32,8 @@ from torchrec.distributed.model_tracker.types import (
     EmbdUpdateMode,
     TrackingMode,
 )
+from torchrec.distributed.utils import none_throws
+
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 UPDATE_MODE_MAP: Dict[TrackingMode, EmbdUpdateMode] = {
@@ -42,6 +50,14 @@ UPDATE_MODE_MAP: Dict[TrackingMode, EmbdUpdateMode] = {
     # This mode supports approximate top-k delta-row selection, can be
     # obtained by running momentum.norm().topk().
     TrackingMode.MOMENTUM_LAST: EmbdUpdateMode.LAST,
+    # MOMENTUM_DIFF keeps a running sum of the square of the gradients per row.
+    # Within each publishing interval, we track the starting value of this running
+    # sum on all used rows and then do a lookup when ``get_delta`` is called to query
+    # the latest sum. Then we can compute the delta of the two values and return them
+    # together with the row ids.
+    TrackingMode.MOMENTUM_DIFF: EmbdUpdateMode.FIRST,
+    # The same as MOMENTUM_DIFF. Adding for backward compatibility.
+    TrackingMode.ROWWISE_ADAGRAD: EmbdUpdateMode.FIRST,
 }
 
 # Tracking is current only supported for ShardedEmbeddingCollection and ShardedEmbeddingBagCollection.
@@ -99,6 +115,7 @@ class ModelDeltaTracker:
 
         # from module FQN to ShardedEmbeddingCollection/ShardedEmbeddingBagCollection
         self.tracked_modules: Dict[str, nn.Module] = {}
+        self.table_to_fqn: Dict[str, str] = {}
         self.feature_to_fqn: Dict[str, str] = {}
         # Generate the mapping from FQN to feature names.
         self.fqn_to_feature_names()
@@ -180,6 +197,11 @@ class ModelDeltaTracker:
         # In MOMENTUM_LAST mode, we track per feature IDs and corresponding momentum values received in the current batch.
         elif self._mode == TrackingMode.MOMENTUM_LAST:
             self.record_momentum(emb_module, kjt)
+        elif (
+            self._mode == TrackingMode.MOMENTUM_DIFF
+            or self._mode == TrackingMode.ROWWISE_ADAGRAD
+        ):
+            self.record_rowwise_optim_state(emb_module, kjt)
         else:
             raise NotImplementedError(f"Tracking mode {self._mode} is not supported")
 
@@ -278,6 +300,60 @@ class ModelDeltaTracker:
                 states=per_key_states,
             )
 
+    def record_rowwise_optim_state(
+        self,
+        emb_module: nn.Module,
+        kjt: KeyedJaggedTensor,
+    ) -> None:
+        opt_states: List[List[torch.Tensor]] = (
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `split_optimizer_states`.
+            emb_module._emb_module.split_optimizer_states()
+        )
+        proxy: torch.Tensor = torch.cat([state[0] for state in opt_states])
+        states = proxy[kjt.values()]
+        assert (
+            kjt.values().numel() == states.numel()
+        ), f"number of ids and states mismatch, expect {kjt.values()=}, {kjt.values().numel()}, but got {states.numel()} "
+        offsets: torch.Tensor = torch.ops.fbgemm.asynchronous_complete_cumsum(
+            torch.tensor(kjt.length_per_key(), dtype=torch.int64)
+        )
+        for i, key in enumerate(kjt.keys()):
+            fqn = self.feature_to_fqn[key]
+            per_key_states = states[offsets[i] : offsets[i + 1]]
+            self.store.append(
+                batch_idx=self.curr_batch_idx,
+                table_fqn=fqn,
+                ids=kjt[key].values(),
+                states=per_key_states,
+            )
+
+    def get_latest(self) -> Dict[str, torch.Tensor]:
+        ret: Dict[str, torch.Tensor] = {}
+        for module in self.tracked_modules.values():
+            # pyre-fixme[29]:
+            for lookup in module._lookups:
+                for embs_module in lookup._emb_modules:
+                    assert isinstance(
+                        embs_module, (BatchedFusedEmbeddingBag, BatchedFusedEmbedding)
+                    ), f"expect BatchedFusedEmbeddingBag or BatchedFusedEmbedding, but {type(embs_module)} found"
+                    tbe = embs_module._emb_module
+
+                    assert isinstance(tbe, SplitTableBatchedEmbeddingBagsCodegen)
+                    table_names = [t.name for t in embs_module._config.embedding_tables]
+                    opt_states = tbe.split_optimizer_states()
+                    assert len(table_names) == len(opt_states)
+
+                    for i, table_name in enumerate(table_names):
+                        emb_fqn = self.table_to_fqn[table_name]
+                        table_state = opt_states[i][0]
+                        assert (
+                            emb_fqn not in ret
+                        ), f"a table with {emb_fqn} already exists"
+                        ret[emb_fqn] = table_state
+
+        return ret
+
     def get_delta_ids(self, consumer: Optional[str] = None) -> Dict[str, torch.Tensor]:
         """
         Return a dictionary of hit local IDs for each sparse feature. Ids are
@@ -289,7 +365,13 @@ class ModelDeltaTracker:
         per_table_delta_rows = self.get_delta(consumer)
         return {fqn: delta_rows.ids for fqn, delta_rows in per_table_delta_rows.items()}
 
-    def get_delta(self, consumer: Optional[str] = None) -> Dict[str, DeltaRows]:
+    def get_delta(
+        self,
+        consumer: Optional[str] = None,
+        top_percentage: Optional[float] = 1.0,
+        per_table_percentage: Optional[Dict[str, Tuple[float, str]]] = None,
+        sorted_by_indices: Optional[bool] = True,
+    ) -> Dict[str, DeltaRows]:
         """
         Return a dictionary of hit local IDs and parameter states / embeddings for each sparse feature. The Values are first keyed by submodule FQN.
 
@@ -314,6 +396,17 @@ class ModelDeltaTracker:
         self.per_consumer_batch_idx[consumer] = index_end
         if self._delete_on_read:
             self.store.delete(up_to_idx=min(self.per_consumer_batch_idx.values()))
+
+        if self._mode in (TrackingMode.MOMENTUM_DIFF, TrackingMode.ROWWISE_ADAGRAD):
+            square_sum_map = self.get_latest()
+            for fqn, rows in tracker_rows.items():
+                assert (
+                    fqn in square_sum_map
+                ), f"{fqn} not found in {square_sum_map.keys()}"
+                # pyre-fixme[58]: `-` is not supported for operand types `Tensor`
+                #  and `Optional[Tensor]`.
+                rows.states = square_sum_map[fqn][rows.ids] - rows.states
+
         return tracker_rows
 
     def get_tracked_modules(self) -> Dict[str, nn.Module]:
@@ -330,7 +423,6 @@ class ModelDeltaTracker:
             return self._fqn_to_feature_map
 
         table_to_feature_names: Dict[str, List[str]] = OrderedDict()
-        table_to_fqn: Dict[str, str] = OrderedDict()
         for fqn, named_module in self._model.named_modules():
             split_fqn = fqn.split(".")
             # Skipping partial FQNs present in fqns_to_skip
@@ -356,13 +448,13 @@ class ModelDeltaTracker:
                 # will incorrectly match fqn with all the table names that have the same prefix
                 if table_name in split_fqn:
                     embedding_fqn = self._clean_fqn_fn(fqn)
-                    if table_name in table_to_fqn:
+                    if table_name in self.table_to_fqn:
                         # Sanity check for validating that we don't have more then one table mapping to same fqn.
                         logger.warning(
-                            f"Override {table_to_fqn[table_name]} with {embedding_fqn} for entry {table_name}"
+                            f"Override {self.table_to_fqn[table_name]} with {embedding_fqn} for entry {table_name}"
                         )
-                    table_to_fqn[table_name] = embedding_fqn
-            logger.info(f"Table to fqn: {table_to_fqn}")
+                    self.table_to_fqn[table_name] = embedding_fqn
+            logger.info(f"Table to fqn: {self.table_to_fqn}")
         flatten_names = [
             name for names in table_to_feature_names.values() for name in names
         ]
@@ -375,15 +467,15 @@ class ModelDeltaTracker:
 
         fqn_to_feature_names: Dict[str, List[str]] = OrderedDict()
         for table_name in table_to_feature_names:
-            if table_name not in table_to_fqn:
+            if table_name not in self.table_to_fqn:
                 # This is likely unexpected, where we can't locate the FQN associated with this table.
                 logger.warning(
-                    f"Table {table_name} not found in {table_to_fqn}, skipping"
+                    f"Table {table_name} not found in {self.table_to_fqn}, skipping"
                 )
                 continue
-            fqn_to_feature_names[table_to_fqn[table_name]] = table_to_feature_names[
-                table_name
-            ]
+            fqn_to_feature_names[self.table_to_fqn[table_name]] = (
+                table_to_feature_names[table_name]
+            )
         self._fqn_to_feature_map = fqn_to_feature_names
         return fqn_to_feature_names
 
@@ -449,6 +541,24 @@ class ModelDeltaTracker:
                     assert isinstance(
                         lookup,
                         (GroupedEmbeddingsLookup, GroupedPooledEmbeddingsLookup),
+                    )
+                    lookup.register_optim_state_tracker_fn(self.record_lookup)
+            elif (
+                self._mode == TrackingMode.ROWWISE_ADAGRAD
+                or self._mode == TrackingMode.MOMENTUM_DIFF
+            ):
+                # pyre-ignore[29]:
+                for lookup in module._lookups:
+                    assert isinstance(
+                        lookup,
+                        (GroupedEmbeddingsLookup, GroupedPooledEmbeddingsLookup),
+                    ) and all(
+                        # TorchRec maps ROWWISE_ADAGRAD to EXACT_ROWWISE_ADAGRAD
+                        # pyre-ignore[16]:
+                        emb._emb_module.optimizer == OptimType.EXACT_ROWWISE_ADAGRAD
+                        # pyre-ignore[16]:
+                        or emb._emb_module.optimizer == OptimType.PARTIAL_ROWWISE_ADAM
+                        for emb in lookup._emb_modules
                     )
                     lookup.register_optim_state_tracker_fn(self.record_lookup)
             else:

--- a/torchrec/distributed/model_tracker/tests/test_model_delta_tracker.py
+++ b/torchrec/distributed/model_tracker/tests/test_model_delta_tracker.py
@@ -13,6 +13,9 @@ from typing import cast, Dict, Iterable, List, Optional, Tuple, Type, Union
 import torch
 import torchrec
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
+from fbgemm_gpu.split_table_batched_embeddings_ops import (
+    SplitTableBatchedEmbeddingBagsCodegen,
+)
 
 from parameterized import parameterized
 from torch import nn
@@ -1558,6 +1561,101 @@ class ModelDeltaTrackerTest(MultiProcessTestBase):
             test_params=test_params,
         )
 
+    @parameterized.expand(
+        [
+            (
+                "EC_and_single_feature",
+                ModelDeltaTrackerInputTestParams(
+                    embedding_config_type=EmbeddingConfig,
+                    embedding_tables=[
+                        EmbeddingTableProps(
+                            embedding_table_config=EmbeddingConfig(
+                                name="sparse_table_1",
+                                num_embeddings=NUM_EMBEDDINGS,
+                                embedding_dim=EMBEDDING_DIM,
+                                feature_names=["f1"],
+                            ),
+                            sharding=ShardingType.ROW_WISE,
+                        ),
+                    ],
+                    model_tracker_config=ModelTrackerConfig(
+                        tracking_mode=TrackingMode.MOMENTUM_DIFF,
+                        delete_on_read=True,
+                    ),
+                    model_inputs=[
+                        ModelInput(
+                            keys=["f1"],
+                            values=torch.tensor([0, 2, 4, 6, 8, 10, 12, 14]),
+                            offsets=torch.tensor([0, 2, 2, 4, 6, 7, 8]),
+                        ),
+                        ModelInput(
+                            keys=["f1"],
+                            values=torch.tensor([8, 10, 12, 14, 0, 2, 4, 6]),
+                            offsets=torch.tensor([0, 2, 2, 4, 6, 6, 8]),
+                        ),
+                        ModelInput(
+                            keys=["f1"],
+                            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+                            offsets=torch.tensor([0, 0, 0, 4, 4, 4, 8]),
+                        ),
+                    ],
+                ),
+            ),
+            (
+                "EBC_and_multiple_feature",
+                ModelDeltaTrackerInputTestParams(
+                    embedding_config_type=EmbeddingBagConfig,
+                    embedding_tables=[
+                        EmbeddingTableProps(
+                            embedding_table_config=EmbeddingBagConfig(
+                                name="sparse_table_1",
+                                num_embeddings=NUM_EMBEDDINGS,
+                                embedding_dim=EMBEDDING_DIM,
+                                feature_names=["f1", "f2"],
+                                pooling=PoolingType.SUM,
+                            ),
+                            sharding=ShardingType.ROW_WISE,
+                        ),
+                    ],
+                    model_tracker_config=ModelTrackerConfig(
+                        tracking_mode=TrackingMode.ROWWISE_ADAGRAD,
+                        delete_on_read=True,
+                    ),
+                    model_inputs=[
+                        ModelInput(
+                            keys=["f1", "f2"],
+                            values=torch.tensor([0, 2, 4, 6, 8, 10, 12, 14]),
+                            offsets=torch.tensor([0, 2, 2, 4, 6, 7, 8]),
+                        ),
+                        ModelInput(
+                            keys=["f1", "f2"],
+                            values=torch.tensor([8, 10, 12, 14, 0, 2, 4, 6]),
+                            offsets=torch.tensor([0, 2, 2, 4, 6, 6, 8]),
+                        ),
+                        ModelInput(
+                            keys=["f1", "f2"],
+                            values=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7]),
+                            offsets=torch.tensor([0, 0, 0, 4, 4, 4, 8]),
+                        ),
+                    ],
+                ),
+            ),
+        ]
+    )
+    @skip_if_asan
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @unittest.skipIf(torch.cuda.device_count() < 2, "test requires 2+ GPUs")
+    def test_duplication_with_rowwise_adagrad(
+        self,
+        _test_name: str,
+        test_params: ModelDeltaTrackerInputTestParams,
+    ) -> None:
+        self._run_multi_process_test(
+            callable=_test_duplication_with_rowwise_adagrad,
+            world_size=self.world_size,
+            test_params=test_params,
+        )
+
 
 def _test_fqn_to_feature_names(
     rank: int,
@@ -2003,3 +2101,75 @@ def _test_duplication_with_momentum(
             unittest.TestCase().assertTrue(states is not None)
             unittest.TestCase().assertTrue(ids.numel() == states.numel())
             unittest.TestCase().assertTrue(bool((states != 0).all().item()))
+
+
+def _test_duplication_with_rowwise_adagrad(
+    rank: int,
+    world_size: int,
+    test_params: ModelDeltaTrackerInputTestParams,
+) -> None:
+    with MultiProcessContext(
+        rank=rank,
+        world_size=world_size,
+        backend="nccl" if torch.cuda.is_available() else "gloo",
+    ) as ctx:
+        dt_model, baseline_model = get_models(
+            rank=rank,
+            world_size=world_size,
+            ctx=ctx,
+            embedding_config_type=test_params.embedding_config_type,
+            tables=test_params.embedding_tables,
+            config=test_params.model_tracker_config,
+            optimizer_type=OptimType.EXACT_ROWWISE_ADAGRAD,
+        )
+
+        # read momemtum directly from the table
+        tbe: SplitTableBatchedEmbeddingBagsCodegen = (
+            (
+                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
+                #  attribute `ec`.
+                dt_model._dmp_wrapped_module.module.ec._lookups[0]
+                ._emb_modules[0]
+                .emb_module
+            )
+            if test_params.embedding_config_type == EmbeddingConfig
+            else (
+                dt_model._dmp_wrapped_module.module.ebc._lookups[0]  # pyre-ignore
+                ._emb_modules[0]
+                .emb_module
+            )
+        )
+        assert isinstance(tbe, SplitTableBatchedEmbeddingBagsCodegen)
+        start_momentums = tbe.split_optimizer_states()[0][0].detach().clone()
+
+        dt_model_opt = torch.optim.Adam(dt_model.parameters(), lr=0.1)
+        baseline_opt = torch.optim.Adam(baseline_model.parameters(), lr=0.1)
+        features_list = model_input_generator(test_params.model_inputs, rank)
+
+        dt = dt_model.get_model_tracker()
+        table_fqns = dt.fqn_to_feature_names().keys()
+        table_fqns_list = list(table_fqns)
+
+        for features in features_list:
+            tracked_out = dt_model(features)
+            baseline_out = baseline_model(features)
+            unittest.TestCase().assertTrue(tracked_out.allclose(baseline_out))
+            tracked_out.sum().backward()
+            baseline_out.sum().backward()
+
+            dt_model_opt.step()
+            baseline_opt.step()
+
+        end_momentums = tbe.split_optimizer_states()[0][0].detach().clone()
+
+        delta_rows = dt.get_delta()
+        table_fqn = table_fqns_list[0]
+
+        ids = delta_rows[table_fqn].ids
+        tracked_momentum = none_throws(delta_rows[table_fqn].states)
+        unittest.TestCase().assertTrue(tracked_momentum is not None)
+        unittest.TestCase().assertTrue(ids.numel() == tracked_momentum.numel())
+        unittest.TestCase().assertTrue(bool((tracked_momentum != 0).all().item()))
+
+        expected_momentum = end_momentums[ids] - start_momentums[ids]
+        unittest.TestCase().assertTrue(tracked_momentum.allclose(expected_momentum))

--- a/torchrec/distributed/model_tracker/types.py
+++ b/torchrec/distributed/model_tracker/types.py
@@ -41,13 +41,17 @@ class TrackingMode(Enum):
     Tracking mode for ``ModelDeltaTracker``.
 
     Enums:
-        ID_ONLY: Tracks row IDs only, providing a lightweight option for monitoring.
-        EMBEDDING: Tracks both row IDs and their corresponding embedding values,
-            enabling precise top-k result calculations. However, this option comes with increased memory usage.
+        ID_ONLY:    Tracks row IDs only, providing a lightweight option for monitoring.
+        EMBEDDING:  Tracks both row IDs and their corresponding embedding values,
+                    enabling precise top-k result calculations. However, this option comes
+                    with increased memory usage.
+        MOMENTUM_LAST:  Tracks both row IDs and their corresponding momentum values. This mode
+                        supports approximate top-k delta-row selection.
     """
 
     ID_ONLY = "id_only"
     EMBEDDING = "embedding"
+    MOMENTUM_LAST = "momentum_last"
 
 
 class EmbdUpdateMode(Enum):

--- a/torchrec/distributed/model_tracker/types.py
+++ b/torchrec/distributed/model_tracker/types.py
@@ -47,11 +47,15 @@ class TrackingMode(Enum):
                     with increased memory usage.
         MOMENTUM_LAST:  Tracks both row IDs and their corresponding momentum values. This mode
                         supports approximate top-k delta-row selection.
+        MOMENTUM_DIFF: Tracks both row IDs and their corresponding momentum difference values.
+        ROWWISE_ADAGRAD: Tracks both row IDs and their corresponding rowwise adagrad states.
     """
 
     ID_ONLY = "id_only"
     EMBEDDING = "embedding"
     MOMENTUM_LAST = "momentum_last"
+    MOMENTUM_DIFF = "momentum_diff"
+    ROWWISE_ADAGRAD = "rowwise_adagrad"
 
 
 class EmbdUpdateMode(Enum):


### PR DESCRIPTION
Summary: This diff extends the Model Delta Tracker to support two new tracking modes: `MOMENTUM_DIFF` and `ROWWISE_ADAGRAD`, which enable tracking of rowwise optimizer states for more sophisticated gradient analysis.

Differential Revision: D76918891


