### PR TITLE
Fix Github failing pre-commit

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -895,7 +895,8 @@ class DMPCollection(DistributedModelParallel):
             )
 
             if ctx.module:
-                ctx.sharded_module = self._sharder_map[ctx.module].sharded_module_type  # pyre-ignore[16]
+                # pyre-ignore[16]
+                ctx.sharded_module = self._sharder_map[ctx.module].sharded_module_type
 
         consolidated_plan = copy.deepcopy(self._ctxs[0].plan)
         for ctx in self._ctxs[1:]:
@@ -1195,10 +1196,13 @@ class DMPCollection(DistributedModelParallel):
     ) -> None:
         # Post init DMP, save the embedding kernels, with respect to contexts
         for context in contexts[1:]:
-            context.modules_to_sync = self._group_sharded_module(context.sharded_module)  # pyre-ignore[6]
+            context.modules_to_sync = self._group_sharded_module(
+                context.sharded_module  # pyre-ignore[6]
+            )
 
         # Group leftover embedding kernels, with respect to default context
-        modules_to_skip: List[nn.Module] = [c.sharded_module for c in contexts[1:]]  # pyre-ignore[9]
+        # pyre-ignore[9]
+        modules_to_skip: List[nn.Module] = [c.sharded_module for c in contexts[1:]]
         sharded_modules: List[nn.Module] = []
 
         def _find_sharded_modules(

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -856,7 +856,9 @@ def sharding_single_rank_test_single_process(
                 qcomms_config=qcomms_config,
             )
             sharders.append(sharder)  # pyre-ignore[6]
-            config.plan = planner.collective_plan(local_model, [sharder], pg)  # pyre-ignore[6]
+            config.plan = planner.collective_plan(
+                local_model, [sharder], pg  # pyre-ignore[6]
+            )
 
     """
     Simulating multiple nodes on a single node. However, metadata information and


### PR DESCRIPTION
Summary:
Some of the recent diffs in the TorchRec codebase have errors related to Github pre-commit failure due to `ufmt` formatting rules on a recent code change.

Example error:
https://github.com/pytorch/torchrec/actions/runs/16280345272/job/45968505367
 {F1980271006}

This diff changes the formatting to fix the pre-commit errors.

Differential Revision: D78312884


