### PR TITLE
Fix test failure: torchrec/distributed/tests/test_quant_sequence_model_parallel.py::QuantSequenceModelParallelTest::test_sharded_quant_kv_zch

### DIFF
--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -213,7 +213,6 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs available",
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
     def test_sharded_quant_kv_zch(self) -> None:
         device = torch.device("cuda:0")
         num_features = 4


### PR DESCRIPTION
Summary:
Fixed the test torchrec/distributed/tests/test_quant_sequence_model_parallel.py::QuantSequenceModelParallelTest::test_sharded_quant_kv_zch

by removing settings , since, test does not use any parameters can be run as dafault unit test without any hypothesis.

Differential Revision: D78356143


