### PR TITLE
Remove torch._running_with_deploy() from fbcode

### DIFF
--- a/torchrec/distributed/train_pipeline/tracing.py
+++ b/torchrec/distributed/train_pipeline/tracing.py
@@ -12,7 +12,6 @@ from itertools import chain
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import torch
-
 from torch.distributed._composable.fsdp.fully_shard import FSDPModule as FSDP2
 
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP


### PR DESCRIPTION
Summary: As per https://fb.workplace.com/groups/pytorch.dev/permalink/1828123831099422 we can now safely remove “torch.is_deploy_running”. This commit does this!

Differential Revision: D78525065


