### PR TITLE
Adding eviction metadata tensor fqn

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -698,10 +698,13 @@ class ShardedEmbeddingCollection(
                 weight_key = f"{prefix}embeddings.{table_name}.weight"
                 weight_id_key = f"{prefix}embeddings.{table_name}.weight_id"
                 bucket_key = f"{prefix}embeddings.{table_name}.bucket"
+                metadata_key = f"{prefix}embeddings.{table_name}.metadata"
                 if weight_id_key in state_dict:
                     del state_dict[weight_id_key]
                 if bucket_key in state_dict:
                     del state_dict[bucket_key]
+                if metadata_key in state_dict:
+                    del state_dict[metadata_key]
                 assert weight_key in state_dict
                 assert (
                     len(self._model_parallel_name_to_local_shards[table_name]) == 1
@@ -1037,6 +1040,7 @@ class ShardedEmbeddingCollection(
                         weights_t,
                         weight_ids_sharded_t,
                         id_cnt_per_bucket_sharded_t,
+                        metadata_sharded_t,
                     ) in (
                         lookup.get_named_split_embedding_weights_snapshot()  # pyre-ignore
                     ):
@@ -1048,6 +1052,7 @@ class ShardedEmbeddingCollection(
                             assert (
                                 weight_ids_sharded_t is not None
                                 and id_cnt_per_bucket_sharded_t is not None
+                                and metadata_sharded_t is not None
                             )
                             # The logic here assumes there is only one shard per table on any particular rank
                             # if there are cases each rank has >1 shards, we need to update here accordingly
@@ -1055,12 +1060,14 @@ class ShardedEmbeddingCollection(
                             virtual_table_sharded_t_map[table_name] = (
                                 weight_ids_sharded_t,
                                 id_cnt_per_bucket_sharded_t,
+                                metadata_sharded_t,
                             )
                         else:
                             assert isinstance(weights_t, PartiallyMaterializedTensor)
                             assert (
                                 weight_ids_sharded_t is None
                                 and id_cnt_per_bucket_sharded_t is None
+                                and metadata_sharded_t is None
                             )
                             # The logic here assumes there is only one shard per table on any particular rank
                             # if there are cases each rank has >1 shards, we need to update here accordingly
@@ -1098,6 +1105,12 @@ class ShardedEmbeddingCollection(
                         "bucket",
                         destination,
                         virtual_table_sharded_t_map[table_name][1],
+                    )
+                    update_destination(
+                        table_name,
+                        "metadata",
+                        destination,
+                        virtual_table_sharded_t_map[table_name][2],
                     )
 
         def _post_load_state_dict_hook(

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -381,6 +381,7 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
             Union[ShardedTensor, PartiallyMaterializedTensor],
             Optional[ShardedTensor],
             Optional[ShardedTensor],
+            Optional[ShardedTensor],
         ]
     ]:
         """
@@ -730,6 +731,7 @@ class GroupedPooledEmbeddingsLookup(
         Tuple[
             str,
             Union[ShardedTensor, PartiallyMaterializedTensor],
+            Optional[ShardedTensor],
             Optional[ShardedTensor],
             Optional[ShardedTensor],
         ]

--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -120,11 +120,12 @@ class KeyValueModelParallelTest(ModelParallelSingleRankBase):
 
                     emb1_kv = {
                         t: pmt
-                        for t, pmt, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
+                        for t, pmt, _, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
                         pmt,
+                        _,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
@@ -760,11 +761,12 @@ class KeyValueSequenceModelParallelStateDictTest(ModelParallelSingleRankBase):
 
                     emb1_kv = {
                         t: pmt
-                        for t, pmt, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
+                        for t, pmt, _, _, _ in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
                         pmt,
+                        _,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
@@ -900,12 +902,13 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
                     emb_module2.flush()
 
                     emb1_kv = {
-                        t: (sharded_t, sharded_w_id, bucket)
-                        for t, sharded_t, sharded_w_id, bucket in emb_module1.get_named_split_embedding_weights_snapshot()
+                        t: (sharded_t, sharded_w_id, bucket, metadata)
+                        for t, sharded_t, sharded_w_id, bucket, metadata in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
                         sharded_t2,
+                        _,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
@@ -953,6 +956,7 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
                     for (
                         t,
                         sharded_t,
+                        _,
                         _,
                         _,
                     ) in ssd_emb_module.get_named_split_embedding_weights_snapshot():
@@ -1367,12 +1371,13 @@ class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBas
                     emb_module2.flush()
 
                     emb1_kv = {
-                        t: (sharded_t, sharded_w_id, bucket)
-                        for t, sharded_t, sharded_w_id, bucket in emb_module1.get_named_split_embedding_weights_snapshot()
+                        t: (sharded_t, sharded_w_id, bucket, metadata)
+                        for t, sharded_t, sharded_w_id, bucket, metadata in emb_module1.get_named_split_embedding_weights_snapshot()
                     }
                     for (
                         t,
                         sharded_t2,
+                        _,
                         _,
                         _,
                     ) in emb_module2.get_named_split_embedding_weights_snapshot():
@@ -1421,6 +1426,7 @@ class ZeroCollisionSequenceModelParallelStateDictTest(ModelParallelSingleRankBas
                     for (
                         t,
                         sharded_t,
+                        _,
                         _,
                         _,
                     ) in ssd_emb_module.get_named_split_embedding_weights_snapshot():


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/4611

X-link: https://github.com/facebookresearch/FBGEMM/pull/1646

Adding a new metadata fqn in kvzch ckpt, which is needed for eviction filter in publishing.

Differential Revision: D78768842


