### PR TITLE
Add ZCH modules to TorchRec bento kernel

### DIFF
--- a/torchrec/__init__.py
+++ b/torchrec/__init__.py
@@ -21,6 +21,11 @@ from torchrec.modules.embedding_modules import (  # noqa
     EmbeddingBagCollectionInterface,
     EmbeddingCollection,
 )  # noqa
+from torchrec.modules.hash_mc_modules import HashZchManagedCollisionModule  # noqa
+from torchrec.modules.mc_embedding_modules import (  # noqa
+    ManagedCollisionEmbeddingBagCollection,
+    ManagedCollisionEmbeddingCollection,
+)
 from torchrec.sparse.jagged_tensor import (  # noqa
     JaggedTensor,
     KeyedJaggedTensor,


### PR DESCRIPTION
Summary: Can be used for faster prototyping in notebook

Reviewed By: spmex

Differential Revision: D79439896
