### PR TITLE
Remove flakiness of test_kv_zch_load_state_dict

### DIFF
--- a/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_ssd_single_gpu.py
@@ -1022,7 +1022,7 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
             "learning_rate": 0.1,
             "stochastic_rounding": stochastic_rounding,
         }
-        is_deterministic = dtype == DataType.FP32 or not stochastic_rounding
+        is_deterministic = dtype == DataType.FP32
         constraints = {
             table.name: ParameterConstraints(
                 sharding_types=[sharding_type],
@@ -1049,9 +1049,15 @@ class ZeroCollisionModelParallelTest(ModelParallelSingleRankBase):
 
         if is_training:
             self._train_models(m1, m2, batch)
-        self._eval_models(m1, m2, batch, is_deterministic=is_deterministic)
+        self._eval_models(
+            m1, m2, batch, is_deterministic=is_deterministic, tolerance=1e-2
+        )
         self._compare_models(
-            m1, m2, is_deterministic=is_deterministic, use_virtual_table=True
+            m1,
+            m2,
+            is_deterministic=is_deterministic,
+            use_virtual_table=True,
+            tolerance=1e-2,
         )
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
Test link: https://www.internalfb.com/intern/test/281475203207916

The test is flaky because KVZCH kernel [guarantees accuracy of 1e-2](https://www.internalfb.com/code/fbsource/[35a43c0e43e5]/fbcode/deeplearning/fbgemm/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_training_test.py?lines=1399-1402) for FP16.
I changed test_model_parallel_base to accept custom tolerance to override default atol/rtol and added the tolerance to this test to resolve the flakiness

Differential Revision: D80457783


