### PR TITLE
Support ttl based eviction in feature score eviction policy

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -262,6 +262,7 @@ def _populate_zero_collision_tbe_params(
                     target_eviction_percent_per_table[i] = (
                         policy_t.target_eviction_percent
                     )
+                    ttls_in_mins[i] = policy_t.eviction_ttl_mins
                     if eviction_strategy == -1 or eviction_strategy == 5:
                         eviction_strategy = 5
                     else:

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -219,13 +219,19 @@ class FeatureScoreBasedEvictionPolicy(VirtualTableEvictionPolicy):
     decay_rate: float = 0.99  # default decay by default #TODO: Change to real value
     max_training_id_num_per_rank: int = 0  # max number of training ids per rank
     target_eviction_percent: float = 0.0  # target eviction percent
+    eviction_ttl_mins: int = (
+        0  # if not 0, means we will use timestamp based policy but not feature score policy
+    )
     inference_eviction_feature_score_threshold: Optional[float] = (
         None  # 0 means no eviction
     )
+    inference_eviction_ttl_mins: Optional[int] = None  # 0 means no eviction
 
     def __post_init__(self) -> None:
         if self.inference_eviction_feature_score_threshold is None:
             self.inference_eviction_feature_score_threshold = 0
+        if self.inference_eviction_ttl_mins is None:
+            self.inference_eviction_ttl_mins = self.eviction_ttl_mins
 
 
 @dataclass


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/1773

Support ttl based eviction in feature score eviction policy.

Note:
This is only short-term solution to support multiple eviction policy in one tbe. 
This diff initially aimed to incorporate multiple thresholds into a single policy, but this approach might make the policy overly complex. 

In long-term, we want to break the inheritance between individual eviction policies and their parent class. Within the parent class, we manage the eviction loop, status updates, and other tasks. Instead of initializing a single eviction configuration, we initialize a list of eviction policies, one for each table. But this may require a big refactor of whole eviction code base.

Differential Revision: D80663963


