### PR TITLE
refactor train_pipeline_tests for tracing

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipeline_tracing.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipeline_tracing.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import parameterized
+
+import torch
+from torch import nn
+
+from torchrec.distributed.train_pipeline.pipeline_context import TrainPipelineContext
+
+from torchrec.distributed.train_pipeline.tracing import (
+    _get_leaf_module_names,
+    ArgInfo,
+    ArgInfoStepFactory,
+    CallArgs,
+    NodeArgsHelper,
+    PipelinedPostproc,
+    Tracer,
+)
+from torchrec.distributed.types import NullShardedModuleContext, ShardedModule
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class TestNodeArg(unittest.TestCase):
+
+    @parameterized.parameterized.expand(
+        [
+            (
+                CallArgs(
+                    args=[],
+                    kwargs={
+                        "id_list_features": ArgInfo(steps=[ArgInfoStepFactory.noop()]),
+                        # Empty attrs to ignore any attr based logic.
+                        "id_score_list_features": ArgInfo(
+                            steps=[ArgInfoStepFactory.noop()]
+                        ),
+                    },
+                ),
+                0,
+                ["id_list_features", "id_score_list_features"],
+            ),
+            (
+                CallArgs(
+                    args=[
+                        # Empty attrs to ignore any attr based logic.
+                        ArgInfo(steps=[ArgInfoStepFactory.noop()]),
+                        ArgInfo(steps=[]),
+                    ],
+                    kwargs={},
+                ),
+                2,
+                [],
+            ),
+            (
+                CallArgs(
+                    args=[
+                        # Empty attrs to ignore any attr based logic.
+                        ArgInfo(
+                            steps=[ArgInfoStepFactory.noop()],
+                        )
+                    ],
+                    kwargs={"id_score_list_features": ArgInfo(steps=[])},
+                ),
+                1,
+                ["id_score_list_features"],
+            ),
+        ]
+    )
+    def test_build_args_kwargs(
+        self,
+        fwd_args: CallArgs,
+        args_len: int,
+        kwarges_keys: List[str],
+    ) -> None:
+        args, kwargs = fwd_args.build_args_kwargs("initial_input")
+        self.assertEqual(len(args), args_len)
+        self.assertEqual(list(kwargs.keys()), kwarges_keys)
+
+    def test_get_node_args_helper_call_module_kjt(self) -> None:
+        graph = torch.fx.Graph()
+        kjt_args = []
+
+        kjt_args.append(
+            torch.fx.Node(graph, "values", "placeholder", "torch.Tensor", (), {})
+        )
+        kjt_args.append(
+            torch.fx.Node(graph, "lengths", "placeholder", "torch.Tensor", (), {})
+        )
+        kjt_args.append(
+            torch.fx.Node(
+                graph, "weights", "call_module", "PositionWeightedModule", (), {}
+            )
+        )
+
+        kjt_node = torch.fx.Node(
+            graph,
+            "keyed_jagged_tensor",
+            "call_function",
+            KeyedJaggedTensor,
+            tuple(kjt_args),
+            {},
+        )
+
+        node_args_helper = NodeArgsHelper(MagicMock(), TrainPipelineContext(), False)
+
+        _, num_found = node_args_helper.get_node_args(kjt_node)
+
+        # Weights is call_module node, so we should only find 2 args unmodified
+        self.assertEqual(num_found, len(kjt_args) - 1)


### PR DESCRIPTION
Summary:
# context
* previous work in torchrec train_pipeline to refactoring the utils file
* tracing was separated from the utils
* here we also move the corresponding tests into a new file.

Differential Revision: D80882439


