### PR TITLE
Fix init param test for EBC

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -596,9 +596,8 @@ class ShardedEmbeddingBagCollection(
         if env.process_group and dist.get_backend(env.process_group) != "fake":
             self._initialize_torch_state()
 
-        if module.device not in ["meta", "cpu"] and module.device.type not in [
+        if module.device not in ["meta"] and module.device.type not in [
             "meta",
-            "cpu",
         ]:
             self.load_state_dict(module.state_dict(), strict=False)
 


### PR DESCRIPTION
Summary:
We were skipping loading of state dict for CPU models causing the state dict comparison between sharded and unsharded model to not match.
I removed this condition so that we skip only for meta devices.

https://www.internalfb.com/intern/test/562950052233328

Differential Revision: D81039244


