### PR TITLE
add direct_write_embedding method

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -321,6 +321,11 @@ def _populate_zero_collision_tbe_params(
         enable_optimizer_offloading=True,
         backend_return_whole_row=(backend_type == BackendType.DRAM),
         eviction_policy=eviction_policy,
+        embedding_cache_mode=(
+            config.fused_params.get("embedding_cache_mode", False)
+            if config.fused_params
+            else False
+        ),
     )
 
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/4800

X-link: https://github.com/facebookresearch/FBGEMM/pull/1824

This method will write the input embedding directly without through optimizer

Reviewed By: q10

Differential Revision: D79290124


