### PR TITLE
Cleanup unused class variable memory_usage_limit_mb as per TODO in torchrec metric_module

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -147,7 +147,6 @@ class RecMetricModule(nn.Module):
         throughput_metric (Optional[ThroughputMetric]): the ThroughputMetric.
         state_metrics (Optional[Dict[str, StateMetric]]): the dict of StateMetrics.
         compute_interval_steps (int): the intervals between two compute calls in the unit of batch number
-        memory_usage_limit_mb (float): [Unused] the memory usage limit for OOM check
 
     Call Args:
         Not supported.
@@ -194,8 +193,6 @@ class RecMetricModule(nn.Module):
         compute_interval_steps: int = 100,
         min_compute_interval: float = 0.0,
         max_compute_interval: float = float("inf"),
-        # Unused, but needed for backwards compatibility. TODO: Remove from callsites
-        memory_usage_limit_mb: float = 512,
     ) -> None:
         super().__init__()
         self.rec_tasks = rec_tasks if rec_tasks else []

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -73,7 +73,6 @@ class TestMetricModule(RecMetricModule):
         compute_interval_steps: int = 100,
         min_compute_interval: float = 0.0,
         max_compute_interval: float = float("inf"),
-        memory_usage_limit_mb: float = 512,
     ) -> None:
         super().__init__(
             batch_size,
@@ -85,7 +84,6 @@ class TestMetricModule(RecMetricModule):
             compute_interval_steps=compute_interval_steps,
             min_compute_interval=min_compute_interval,
             max_compute_interval=max_compute_interval,
-            memory_usage_limit_mb=memory_usage_limit_mb,
         )
 
     def _update_rec_metrics(


### PR DESCRIPTION
Summary: As per the TODO, cleaning up memory_usage_limit_mb class variable and associated call sites.

Reviewed By: aliafzal

Differential Revision: D81322330


