### PR TITLE
remove py3.9 from CI

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -63,8 +63,9 @@ def main():
         if entry["desired_cuda"] == "cu130":
             # fbgemm only supports cuda 12.6, 12.8 and 12.9
             continue
-        if entry["python_version"] == "3.14":
-            # it seems stuck `conda create myenv python=3.14 -c conda-forge`
+        if entry["python_version"] in ("3.14", "3.9"):
+            # stop python3.9 support, and will add python3.14 when it's ready
+            # https://devguide.python.org/versions/
             continue
         new_matrix_entries.append(entry)
 

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -30,8 +30,6 @@ jobs:
         os:
           - linux.g5.12xlarge.nvidia.gpu
         python:
-          - version: "3.9"
-            tag: "py39"
           - version: "3.10"
             tag: "py310"
           - version: "3.11"

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -25,8 +25,6 @@ jobs:
         os:
           - linux.2xlarge
         python:
-          - version: "3.9"
-            tag: "py39"
           - version: "3.10"
             tag: "py310"
           - version: "3.11"


### PR DESCRIPTION
Summary:
# context
* python 3.9 is out of support soon ([python versions](https://devguide.python.org/versions/))
* we observe current CI issues in python3.9 ([failed job](https://github.com/pytorch/torchrec/actions/runs/17518564173/job/49759302149)) and found out it's due to fbgemm also stopped python3.9 build, so the recent changes are not included in the fbgemm library.
* we also remove python3.9 from our CI jobs.

Differential Revision: D81942031


