### PR TITLE
Integrating PlanLoader within OSS Planner

### DIFF
--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -105,7 +105,10 @@ def create_virtual_table_global_metadata(
             # The param size only has the information for my_rank. In order to
             # correctly calculate the size for other ranks, we need to use the current
             # rank's shard size compared to the shard size of my_rank.
-            curr_rank_rows = (param.size()[0] * metadata.shards_metadata[rank].shard_sizes[0]) // my_rank_shard_size  # pyre-ignore[16]
+            curr_rank_rows = (
+                param.size()[0]  # pyre-ignore[16]
+                * metadata.shards_metadata[rank].shard_sizes[0]
+            ) // my_rank_shard_size
         else:
             curr_rank_rows = (
                 weight_count_per_rank[rank] if weight_count_per_rank is not None else 1


### PR DESCRIPTION
Summary:
Integrate PlanLoader functionality within the EmbeddingShardingPlanner to enable loading and reusing pre-computed sharding plans. This integration extends the OSS planner with plan loading capabilities. 

This diff includes:
* PlanLoader Integration in EmbeddingShardingPlanner:
   - Added optional `plan_loader` parameter to EmbeddingShardingPlanner constructor
   - Integrated plan validation using context hash comparison to ensure loaded plans are compatible with current planner configuration
   - Fallback to normal planning when plan loader returns null

* Plan Loading Workflow:Check if loaded plan context hash matches current planner context
  * If mismatch detected → raise PlannerError
  * If validation passes → load sharding options from storage
  * Map loaded sharding options to current search space using storage_hash
  * Skip planning phase and use pre-computed plan if available

* Search Space Reconstruction:
   * Mapping of loaded sharding options to enumerated search space
   * Preserving all original ShardingOption metadata while replacing shard assignments

Differential Revision: D81279558


