### PR TITLE
disable a flaky test

### DIFF
--- a/torchrec/modules/tests/test_itep_embedding_modules.py
+++ b/torchrec/modules/tests/test_itep_embedding_modules.py
@@ -523,7 +523,9 @@ class TestITEPEmbeddingBagCollection(unittest.TestCase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least one GPU",
     )
-    def test_error_handling_invalid_iter_tensor_values_cuda(self) -> None:
+    def test_error_handling_invalid_iter_tensor_values_cuda_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
         """Test behavior with invalid iter tensor values."""
         itep_module = GenericITEPModule(
             table_name_to_unpruned_hash_sizes=self._table_name_to_unpruned_hash_sizes,


### PR DESCRIPTION
Summary:
# context
* we found this test is flaky in OSS/Github action: [example job](https://github.com/pytorch/torchrec/actions/runs/18104978459/job/51517201520)
<img width="3728" height="2252" alt="image" src="https://github.com/user-attachments/assets/ed289a4f-949a-4151-b6dd-dd0e20a1465c" />
* once a `cudaErrorAssert` is triggerred, all the following tests are failing too
* after
<img width="3434" height="1660" alt="image" src="https://github.com/user-attachments/assets/27ea33c4-7be8-4368-bad8-c9e38eaaa573" />


Differential Revision: D83495599


