### PR TITLE
Code Quality fix [E721] [2/n]

### DIFF
--- a/torchrec/distributed/embedding_kernel.py
+++ b/torchrec/distributed/embedding_kernel.py
@@ -105,7 +105,10 @@ def create_virtual_table_global_metadata(
             # The param size only has the information for my_rank. In order to
             # correctly calculate the size for other ranks, we need to use the current
             # rank's shard size compared to the shard size of my_rank.
-            curr_rank_rows = (param.size()[0] * metadata.shards_metadata[rank].shard_sizes[0]) // my_rank_shard_size  # pyre-ignore[16]
+            curr_rank_rows = (
+                param.size()[0]  # pyre-ignore[16]
+                * metadata.shards_metadata[rank].shard_sizes[0]
+            ) // my_rank_shard_size
         else:
             curr_rank_rows = (
                 weight_count_per_rank[rank] if weight_count_per_rank is not None else 1

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -206,7 +206,7 @@ def are_sharded_ebc_modules_identical(
         val2 = getattr(module2, attr)
 
         assert type(val1) is type(val2)
-        if type(val1) is torch.Tensor:
+        if isinstance(val1, torch.Tensor):
             torch.testing.assert_close(val1, val2)
         else:
             assert val1 == val2

--- a/torchrec/linter/module_linter.py
+++ b/torchrec/linter/module_linter.py
@@ -61,8 +61,8 @@ def get_function_args(node: ast.FunctionDef) -> Tuple[List[Any], List[Any]]:
     Returns:
         (non_optional_args, optional_args): named function args
     """
-    assert (
-        type(node) == ast.FunctionDef
+    assert isinstance(
+        node, ast.FunctionDef
     ), "Incorrect node type. Expected ast.FunctionDef, got {}".format(type(node))
     total_args = len(node.args.args)
     default_args = len(node.args.defaults)
@@ -95,15 +95,17 @@ def check_class_definition(python_path: str, node: ast.ClassDef) -> None:
     Returns:
         None
     """
-    assert (
-        type(node) == ast.ClassDef
+    assert isinstance(
+        node, ast.ClassDef
     ), "Received invalid node type. Expected ClassDef, got: {}".format(type(node))
 
     is_TorchRec_module = False
     is_test_file = "tests" in python_path
     for base in node.bases:
         # For now only names and attributes are supported
-        if type(base) != ast.Name and type(base) != ast.Attribute:  # pragma: nocover
+        if not isinstance(base, ast.Name) and not isinstance(
+            base, ast.Attribute
+        ):  # pragma: nocover
             continue
 
         # We assume that TorchRec module has one of the following inheritance patterns:
@@ -164,7 +166,7 @@ def check_class_definition(python_path: str, node: ast.ClassDef) -> None:
     functions: Dict[str, Tuple[List[Any], List[Any]]] = {}
     function_sub_nodes = {}
     for sub_node in node.body:
-        if type(sub_node) == ast.FunctionDef:
+        if isinstance(sub_node, ast.FunctionDef):
             assert isinstance(sub_node, ast.FunctionDef)
             functions[sub_node.name] = get_function_args(sub_node)
             function_sub_nodes[sub_node.name] = sub_node
@@ -310,7 +312,7 @@ def linter_one_file(python_path: str) -> None:
     python_path = python_path.strip()
     try:
         for node in ast.parse(read_file(python_path)).body:
-            if type(node) == ast.ClassDef:
+            if isinstance(node, ast.ClassDef):
                 assert isinstance(node, ast.ClassDef)
                 check_class_definition(python_path, node)
     except SyntaxError as e:  # pragma: nocover

--- a/torchrec/modules/tests/test_lazy_extension.py
+++ b/torchrec/modules/tests/test_lazy_extension.py
@@ -272,7 +272,7 @@ class TestLazyModuleExtensionMixin(unittest.TestCase):
 
         @torch.no_grad()
         def init_weights(m: torch.nn.Module) -> None:
-            if type(m) == TestModule:
+            if isinstance(m, TestModule):
                 m.param.fill_(7.0)
 
         # Case 1: Running `.apply()` without running first forward pass to


### PR DESCRIPTION
Summary:
[E721] compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

See https://www.flake8rules.com/rules/E721.htmlArcLint(FLAKE8)

Differential Revision: D83734895


