### PR TITLE
1/N: CPU Offloaded Rec Metric Module Foundation

### DIFF
--- a/torchrec/metrics/metric_job_types.py
+++ b/torchrec/metrics/metric_job_types.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import concurrent
+from typing import Any, Dict
+
+import torch
+from torchrec.metrics.metric_module import MetricValue
+from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+
+
+class MetricUpdateJob:
+    """
+    Encapsulates metric update job for CPU processing:
+    update each metric state tensors with intermediate model outputs
+    """
+
+    __slots__ = ["model_out", "transfer_completed_event", "kwargs"]
+
+    def __init__(
+        self,
+        model_out: Dict[str, torch.Tensor],
+        transfer_completed_event: torch.cuda.Event,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Args:
+            model_out: intermediate model outputs to be used for metric updates
+            transfer_completed_event: cuda event to track when the transfer to CPU is completed
+            kwargs: additional arguments from the trainer platform
+        """
+
+        self.model_out: Dict[str, torch.Tensor] = model_out
+        self.transfer_completed_event: torch.cuda.Event = transfer_completed_event
+        self.kwargs: Dict[str, Any] = kwargs
+
+
+class MetricComputeJob:
+    """
+    Encapsulates metric compute job for CPU processing: perform an
+    all gather across ranks, compute metrics, and return the result to be
+    published.
+    """
+
+    __slots__ = ["future", "metric_state_snapshot"]
+
+    def __init__(
+        self,
+        future: concurrent.futures.Future[Dict[str, MetricValue]],
+        metric_state_snapshot: MetricStateSnapshot,
+    ) -> None:
+        """
+        Args:
+            future: future to set the result of the compute job. Contains the computed metrics.
+            metric_state_snapshot: snapshot of metric state tensors across all metrics types.
+        """
+        self.future: concurrent.futures.Future[Dict[str, MetricValue]] = future
+        self.metric_state_snapshot: MetricStateSnapshot = metric_state_snapshot
+
+
+class SynchronizationMarker:
+    """
+    Represents the synchronization marker that is stored in the update queue. This is the point
+    we want to synchronize across all ranks to compute metrics.
+    When processed, this marker will convert to a MetricComputeJob in the compute queue.
+
+    This separation of synchronization marker and compute job is so that the metric compute job
+    accurately includes all of the metric jobs that were scheduled before it.
+    """
+
+    __slots__ = "future"
+
+    def __init__(
+        self,
+        future: concurrent.futures.Future[Dict[str, MetricValue]],
+    ) -> None:
+        """
+        Args:
+            future: future to set the result of the compute job. Passed to the MetricComputeJob.
+        """
+        self.future: concurrent.futures.Future[Dict[str, MetricValue]] = future

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -10,6 +10,7 @@
 #!/usr/bin/env python3
 
 import abc
+import concurrent
 import logging
 import time
 from collections import defaultdict
@@ -56,7 +57,7 @@ from torchrec.metrics.output import OutputMetric
 from torchrec.metrics.precision import PrecisionMetric
 from torchrec.metrics.precision_session import PrecisionSessionMetric
 from torchrec.metrics.rauc import RAUCMetric
-from torchrec.metrics.rec_metric import RecMetric, RecMetricList
+from torchrec.metrics.rec_metric import RecMetric, RecMetricException, RecMetricList
 from torchrec.metrics.recall import RecallMetric
 from torchrec.metrics.recall_session import RecallSessionMetric
 from torchrec.metrics.scalar import ScalarMetric
@@ -485,6 +486,14 @@ class RecMetricModule(nn.Module):
             ]
             for name, buf in self.throughput_metric.named_buffers():  # pyre-ignore[16]
                 buf.copy_(states[name])
+
+    def shutdown(self) -> None:
+        logger.info("Initiating graceful shutdown...")
+
+    def async_compute(
+        self, future: concurrent.futures.Future[Dict[str, MetricValue]]
+    ) -> None:
+        raise RecMetricException("async_compute is not supported in RecMetricModule")
 
 
 def _generate_rec_metrics(

--- a/torchrec/metrics/metric_state_snapshot.py
+++ b/torchrec/metrics/metric_state_snapshot.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import copy
+from typing import Any, cast, Dict, Optional
+
+from torch import nn
+
+from torchrec.metrics.rec_metric import (
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricList,
+)
+from torchrec.metrics.throughput import ThroughputMetric
+
+
+class MetricStateSnapshot:
+    """
+    Encapsulates both rec metrics reduced states and throughput metric snapshots
+    for thread-safe CPU offloaded metric computation (updates and computes).
+    """
+
+    def __init__(
+        self,
+        metric_states: Dict[str, Any],
+        throughput_metric: Optional[ThroughputMetric],
+    ) -> None:
+        """
+        Args:
+            metric_states (Dict[str, Any]): Reduced states from rec metrics
+            throughput_metric (Optional[ThroughputMetric]): Deep copy of throughput metric
+        """
+        self.metric_states = metric_states
+        self.throughput_metric = throughput_metric
+
+    @classmethod
+    def from_metrics(
+        cls,
+        rec_metrics: RecMetricList,
+        throughput_metric: Optional[ThroughputMetric] = None,
+    ) -> "MetricStateSnapshot":
+        """
+        Generate a MetricStateSnapshot before performing an all gather. This provides a consistent
+        view of the local metric states without accessing the original references.
+
+        Apply reductions BEFORE queuing to reduce memory footprint. For instance, AUC holds a list of
+        tensors which can be reduced to a list of a single tensor. Only reduce lists for
+        fused mode compatibility.
+        """
+        reduced_states: Dict[str, Any] = {}
+
+        for metric in rec_metrics.rec_metrics:
+            metric = cast(RecMetric, metric)
+            compute_mode = metric._compute_mode
+            if (
+                compute_mode == RecComputeMode.FUSED_TASKS_COMPUTATION
+                or compute_mode == RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION
+            ):
+                computation = metric._metrics_computations[0]
+                _load_into_reduced_states(
+                    compute_mode.name, computation, reduced_states
+                )
+            else:
+                for task, computation in zip(
+                    metric._tasks, metric._metrics_computations
+                ):
+                    _load_into_reduced_states(task.name, computation, reduced_states)
+
+        # Snapshot throughput metric
+        throughput_snapshot = None
+        if throughput_metric:
+            throughput_snapshot = copy.deepcopy(throughput_metric)
+
+        return cls(
+            metric_states=reduced_states,
+            throughput_metric=throughput_snapshot,
+        )
+
+
+def _load_into_reduced_states(
+    prefix: str,
+    computation: nn.Module,
+    reduced_states: Dict[str, Any],
+) -> None:
+    """
+    Load the reduced states into the reduced_states dict.
+
+    Args:
+        prefix (str): prefix for the metric computation
+        computation (nn.Module): metric computation
+        reduced_states (Dict[str, Any]): reduced states dict to load into
+    """
+    computation = cast(RecMetricComputation, computation)
+    computation_name = f"{prefix}_{computation.__class__.__name__}"
+
+    for attr_name in computation._reductions:
+        cache_key = f"{computation_name}_{attr_name}"
+        original_value = getattr(computation, attr_name)
+        reduction_fn = computation._reductions[attr_name]
+        if callable(reduction_fn) and isinstance(original_value, list):
+            reduced_value = reduction_fn(original_value)
+        else:
+            reduced_value = original_value
+
+        reduced_states[cache_key] = reduced_value

--- a/torchrec/metrics/test_utils/mock_metrics.py
+++ b/torchrec/metrics/test_utils/mock_metrics.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Callable, cast, Dict, List, Optional, Union
+from unittest.mock import MagicMock
+
+import torch
+from torchrec.metrics.metrics_namespace import MetricNamespaceBase
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecModelOutput,
+    RecTaskInfo,
+)
+
+
+class MockRecMetricComputation(RecMetricComputation):
+    """
+    A mock RecMetricComputation that provides controllable behavior for testing.
+
+    State tensors are in the form of:
+        - torch.Tensor: a single tensor (used for most RecMetrics such as NE)
+        - List[torch.Tensor]: a list of tensors (i.e. AUC)
+    """
+
+    def __init__(
+        self,
+        initial_states: Optional[Dict[str, Any]] = None,
+        reduction_fn: Union[
+            str, Callable[[List[torch.Tensor], int], List[torch.Tensor]]
+        ] = "sum",
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            initial_states (Dict[str, Any]): initial states of the mock metric.
+            reduction_fn (str): reduction function of computation to be applied
+                before and after distributed syncs.
+            kwargs: other arguments to pass to RecMetricComputation.
+        """
+        super().__init__(**kwargs)
+
+        if initial_states:
+            for state_name, initial_value in initial_states.items():
+                super().add_state(
+                    name=state_name,
+                    default=initial_value,
+                    dist_reduce_fx=reduction_fn,
+                    persistent=True,
+                )
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def _compute(self) -> List[MetricComputationReport]:
+        return []
+
+
+class MockRecMetric(RecMetric):
+    """
+    A mock RecMetric that uses MockRecMetricComputation for testing. This class
+    focuses primarily on creating mock RecMetricComputation and controlling
+    the internal state of RecMetrics.
+    """
+
+    _computation_class = MockRecMetricComputation
+    _namespace: MetricNamespaceBase = MagicMock()
+
+    def __init__(
+        self,
+        world_size: int,
+        my_rank: int,
+        batch_size: int,
+        tasks: List[RecTaskInfo],
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        reduction_fn: Union[
+            str, Callable[[List[torch.Tensor], int], List[torch.Tensor]]
+        ] = "sum",
+        initial_states: Union[Dict[str, Any], None] = None,
+        is_tensor_list: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Same args as RecMetric except for:
+            - initial_states (Dict[str, Any]): initial states of the mock metric.
+            - reduction_fn (str): reduction function of computation to be applied.
+            - is_tensor_list (bool): whether the mock metric's state tensors should be tensor lists.
+        """
+
+        # If initial_states is not provided, create a default set of states.
+        initial_states = initial_states or create_tensor_states(
+            ["state_1", "state_2", "state_3"]
+        )
+
+        # torchmetric.Metric's add_state() enforces that tensor lists must be initialized
+        # with an empty list. Set it to the initial states after construction.
+        default_states = (
+            {state_name: [] for state_name in initial_states.keys()}
+            if is_tensor_list
+            else initial_states
+        )
+
+        super().__init__(
+            world_size=world_size,
+            my_rank=my_rank,
+            batch_size=batch_size,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            **{
+                **kwargs,
+                "initial_states": default_states,
+                "reduction_fn": reduction_fn,
+            },
+        )
+
+        if is_tensor_list:
+            self.set_computation_states(initial_states)
+
+        self.update_called_count = 0
+        self.predictions_update_calls: List[RecModelOutput] = []
+        self.labels_update_calls: List[RecModelOutput] = []
+        self.weights_update_calls: List[Optional[RecModelOutput]] = []
+        self._compute_called = False
+
+    def update(
+        self,
+        *,
+        predictions: RecModelOutput,
+        labels: RecModelOutput,
+        weights: Optional[RecModelOutput],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        self.update_called_count += 1
+        self.predictions_update_calls.append(predictions)
+        self.labels_update_calls.append(labels)
+        self.weights_update_calls.append(weights)
+
+    def update_called(self) -> bool:
+        return self.update_called_count > 0
+
+    def compute(self) -> Dict[str, torch.Tensor]:
+        self._compute_called = True
+        return {}
+
+    def compute_called(self) -> bool:
+        return self._compute_called
+
+    def reset(self) -> None:
+        self.update_called_count = 0
+        self.predictions_update_calls = []
+        self.labels_update_calls = []
+        self.weights_update_calls = []
+
+        self._compute_called = False
+
+    def get_computation_states(self) -> Dict[str, Any]:
+        """
+        Returns:
+            Dict[str, Any]: a dictionary of computation states.
+        """
+        states = {}
+        for computation in self._metrics_computations:
+            computation = cast(RecMetricComputation, computation)
+            for reduction in computation._reductions:
+                if hasattr(computation, reduction):
+                    states[reduction] = getattr(computation, reduction)
+        return states
+
+    def set_computation_states(self, states: Dict[str, Any]) -> None:
+        """
+        Args:
+            states (Dict[str, Any]): a dictionary of computation states to set.
+        """
+        for computation in self._metrics_computations:
+            computation = cast(RecMetricComputation, computation)
+            for state_name, value in states.items():
+                if state_name in computation._reductions:
+                    setattr(computation, state_name, value)
+
+    def add_to_computation_states(self, states: Dict[str, torch.Tensor]) -> None:
+        """
+        Add tensors to existing computation states.
+        Args:
+            states (Dict[str, Any]): a dictionary of computation states to add.
+        """
+        for computation in self._metrics_computations:
+            computation = cast(RecMetricComputation, computation)
+            for state_name, value in states.items():
+                if state_name in computation._reductions:
+                    original_tensor = getattr(computation, state_name)
+                    original_tensor += value
+
+    def append_to_computation_states(self, states: Dict[str, torch.Tensor]) -> None:
+        """
+        Append computation states to the end of the state tensor list.
+        Args:
+            states (Dict[str, Any]): a dictionary of computation states to append.
+        """
+        for computation in self._metrics_computations:
+            computation = cast(RecMetricComputation, computation)
+            for state_name, value in states.items():
+                if state_name in computation._reductions:
+                    getattr(computation, state_name).append(value)
+
+    def verify_sync_disabled(self) -> bool:
+        """
+        Verify that sync is disabled for all computations. torchmetrics.Metric
+        uses _to_sync and process_group to control sync.
+        """
+        for computation in self._metrics_computations:
+            computation = cast(RecMetricComputation, computation)
+            if computation._to_sync or computation.process_group:
+                return False
+
+        return True
+
+
+def create_metric_states_dict(
+    metric_prefix: str,
+    computation_name: str,
+    metric_states: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a dictionary of metric states with the given prefix and computation name.
+
+    Args:
+        metric_prefix (str): prefix of the metric, either a RecTask name or RecComputationMode.
+        computation_name (str): name of the RecMetricComputation.
+        metric_states (Dict[str, Any]): expected states of the metric.
+
+    Returns:
+        Dict[str, Any]: a dictionary of metric states.
+    """
+    states = {}
+    for state_name, value in metric_states.items():
+        key = f"{metric_prefix}_{computation_name}_{state_name}"
+        states[key] = value
+    return states
+
+
+def assert_tensor_dict_equals(
+    actual_states: Dict[str, Any],
+    expected_states: Dict[str, Any],
+) -> None:
+    """
+    Verify that the actual states are equal to the expected states.
+
+    Args:
+        test_case (unittest.TestCase): test case object.
+        actual_states (Dict[str, Any]): actual states of the metric.
+        expected_states (Dict[str, Any]): expected states of the metric.
+    """
+    assert set(actual_states.keys()) == set(
+        expected_states.keys()
+    ), f"Keys mismatch. Expected {set(expected_states.keys())}, got {set(actual_states.keys())}"
+
+    for key in expected_states:
+        actual = actual_states[key]
+        expected = expected_states[key]
+
+        if isinstance(expected, torch.Tensor):
+            device = expected.device
+            actual = actual.to(device)
+            torch.testing.assert_close(
+                actual,
+                expected,
+                msg=f"Mismatch for key {key}. Expected {expected}, got {actual}",
+            )
+        elif isinstance(expected, list):
+            assert len(actual) == len(
+                expected
+            ), f"Length mismatch for key {key}. Expected {len(expected)}, got {len(actual)}"
+
+            for i, (actual_item, expected_item) in enumerate(zip(actual, expected)):
+                if isinstance(expected_item, torch.Tensor):
+                    device = expected_item.device
+                    actual_item = actual_item.to(device)
+                    torch.testing.assert_close(
+                        actual_item, expected_item, msg=f"Mismatch for key {key}[{i}]"
+                    )
+                else:
+                    assert (
+                        actual_item == expected_item
+                    ), f"Mismatch for key {key}[{i}]. Expected {expected_item}, got {actual_item}"
+        else:
+            assert (
+                actual == expected
+            ), f"Mismatch for key {key}. Expected {expected}, got {actual}"
+
+
+def create_tensor_states(keys: List[str], n_tasks: int = 1) -> Dict[str, Any]:
+    """Create random tensor states for testing (like NE metrics)."""
+    return {key: torch.rand(n_tasks) for key in keys}
+
+
+def create_tensor_list_states(keys: List[str]) -> Dict[str, Any]:
+    """Create simple tensor list states for testing (like AUC metrics)."""
+    return {key: [torch.rand(1, 2)] for key in keys}

--- a/torchrec/metrics/tests/test_metric_state_snapshot.py
+++ b/torchrec/metrics/tests/test_metric_state_snapshot.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+from torchrec.metrics.auc import _state_reduction
+from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetricList
+from torchrec.metrics.test_utils import gen_test_tasks
+from torchrec.metrics.test_utils.mock_metrics import (
+    assert_tensor_dict_equals,
+    create_metric_states_dict,
+    create_tensor_list_states,
+    create_tensor_states,
+    MockRecMetric,
+)
+from torchrec.metrics.throughput import ThroughputMetric
+
+
+class MetricStateSnapshotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.world_size = 2
+        self.batch_size = 4
+        self.my_rank = 0
+        self.tasks = gen_test_tasks(["test_task"])
+
+    def test_init(self) -> None:
+        """Test basic initialization of MetricStateSnapshot."""
+        initial_states = create_tensor_states(["test_state_tensor"])
+        throughput_metric = ThroughputMetric(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            window_seconds=10,
+        )
+
+        snapshot = MetricStateSnapshot(
+            metric_states=initial_states,
+            throughput_metric=throughput_metric,
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, initial_states)
+        self.assertEqual(snapshot.throughput_metric, throughput_metric)
+
+    def test_from_metrics_initial_states(self) -> None:
+        """Test creating snapshot from metric with tensor states."""
+        initial_states = create_tensor_states(["test_state_tensor"])
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+            reduction_fn=torch.sum,
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="test_task",
+            computation_name="MockRecMetricComputation",
+            metric_states=initial_states,
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+    def test_from_metrics_with_list_states(self) -> None:
+        """Test creating snapshot from metric with list states (AUC-like)."""
+        initial_states = {
+            "predictions": [torch.tensor([[1.0, 2.0]])],
+            "labels": [torch.tensor([[0.0, 1.0]])],
+        }
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+            reduction_fn=_state_reduction,
+            is_tensor_list=True,
+        )
+        mock_metric.append_to_computation_states(
+            {
+                "predictions": torch.tensor([[3.0]]),
+                "labels": torch.tensor([[5.0]]),
+            }
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="test_task",
+            computation_name="MockRecMetricComputation",
+            # concat initial with appended states.
+            metric_states={
+                "predictions": [torch.tensor([[1.0, 2.0, 3.0]])],
+                "labels": [torch.tensor([[0.0, 1.0, 5.0]])],
+            },
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+    def test_from_metrics_with_throughput(self) -> None:
+        """
+        Test creating snapshot with throughput metric.
+
+        ThroughputMetric must be a deep copy of the original metric to prevent
+        concurrent access to the same object.
+        """
+        initial_states = create_tensor_states(["test_state_tensor"])
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+            reduction_fn="sum",
+        )
+
+        throughput_metric = ThroughputMetric(
+            batch_size=4,
+            world_size=2,
+            window_seconds=10,
+        )
+        self.assertEqual(throughput_metric.total_examples, 0)
+        # bump total examples to world_size * batch_size
+        throughput_metric.update()
+        self.assertEqual(throughput_metric.total_examples, 8)
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics, throughput_metric)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="test_task",
+            computation_name="MockRecMetricComputation",
+            metric_states=initial_states,
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+        self.assertNotEqual(snapshot.throughput_metric, throughput_metric)
+        self.assertIsNotNone(snapshot.throughput_metric)
+        self.assertEqual(snapshot.throughput_metric.total_examples, 8)
+
+    def test_from_metrics_fused_tasks_state_tensors(self) -> None:
+        """Test state tensors with FUSED_TASKS computation mode."""
+        initial_states = {
+            "cross_entropy_sum": torch.tensor(1.0),
+            "weighted_num_samples": torch.tensor(2.0),
+        }
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=gen_test_tasks(["task1", "task2"]),
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            initial_states=initial_states,
+            reduction_fn="sum",
+        )
+
+        # Increment tensors
+        mock_metric.add_to_computation_states(
+            {
+                "cross_entropy_sum": torch.tensor(3.0),
+                "weighted_num_samples": torch.tensor(4.0),
+            }
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="FUSED_TASKS_COMPUTATION",
+            computation_name="MockRecMetricComputation",
+            metric_states={
+                "cross_entropy_sum": torch.tensor(4.0),
+                "weighted_num_samples": torch.tensor(6.0),
+            },
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+    def test_from_metrics_fused_tasks_state_tensor_lists(self) -> None:
+        """Test state tensor lists with FUSED_TASKS computation mode."""
+
+        initial_states = {
+            "predictions": [
+                torch.tensor(
+                    [
+                        [1.0],
+                        [2.0],
+                    ]
+                )
+            ],
+            "labels": [
+                torch.tensor(
+                    [
+                        [1.0],
+                        [3.0],
+                    ]
+                )
+            ],
+        }
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=gen_test_tasks(["task3", "task4"]),
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+            initial_states=initial_states,
+            reduction_fn=_state_reduction,
+            is_tensor_list=True,
+        )
+
+        # Append to tensor lists which will be concatenated with initial states
+        mock_metric.append_to_computation_states(
+            {
+                "predictions": torch.tensor(
+                    [
+                        [3.0],
+                        [4.0],
+                    ]
+                ),
+                "labels": torch.tensor(
+                    [
+                        [2.0],
+                        [4.0],
+                    ]
+                ),
+            }
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="FUSED_TASKS_COMPUTATION",
+            computation_name="MockRecMetricComputation",
+            metric_states={
+                "predictions": [
+                    torch.tensor(
+                        [
+                            [1.0, 3.0],
+                            [2.0, 4.0],
+                        ]
+                    )
+                ],
+                "labels": [
+                    torch.tensor(
+                        [
+                            [1.0, 2.0],
+                            [3.0, 4.0],
+                        ]
+                    )
+                ],
+            },
+        )
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+    def test_from_metrics_multiple_metrics(self) -> None:
+        """Test creating snapshot from multiple metrics."""
+        tensor_states = create_tensor_states(["test_state_tensor"])
+        tensor_list_states = create_tensor_list_states(["test_state_tensor_list"])
+
+        task1 = gen_test_tasks(["task1"])
+        task2 = gen_test_tasks(["task2"])
+
+        tensor_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=task1,
+            initial_states=tensor_states,
+            reduction_fn="sum",
+        )
+
+        tensor_list_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=task2,
+            initial_states=tensor_list_states,
+            reduction_fn=_state_reduction,
+            is_tensor_list=True,
+        )
+
+        rec_metrics = RecMetricList([tensor_metric, tensor_list_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        # Verify both metrics' states are captured
+        expected_tensor_states = create_metric_states_dict(
+            metric_prefix="task1",
+            computation_name="MockRecMetricComputation",
+            metric_states=tensor_states,
+        )
+
+        expected_tensor_list_states = create_metric_states_dict(
+            metric_prefix="task2",
+            computation_name="MockRecMetricComputation",
+            metric_states=tensor_list_states,
+        )
+
+        expected_all_states = {**expected_tensor_states, **expected_tensor_list_states}
+        assert_tensor_dict_equals(snapshot.metric_states, expected_all_states)
+
+    def test_from_metrics_multiple_tasks(self) -> None:
+        """Test creating snapshot from metric with multiple tasks."""
+        multi_tasks = gen_test_tasks(["task1", "task2", "task3"])
+        initial_states = {"cross_entropy_sum": torch.tensor(5.5)}
+
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=multi_tasks,
+            initial_states=initial_states,
+            reduction_fn="sum",
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        expected_states = {}
+        for task in ["task1", "task2", "task3"]:
+            task_states = create_metric_states_dict(
+                metric_prefix=task,
+                computation_name="MockRecMetricComputation",
+                metric_states=initial_states,
+            )
+            expected_states.update(task_states)
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+    def test_from_metrics_no_throughput_metric(self) -> None:
+        """Test creating snapshot with None throughput metric."""
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states={"cross_entropy_sum": torch.tensor(1.0)},
+            reduction_fn="sum",
+        )
+
+        rec_metrics = RecMetricList([mock_metric])
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        self.assertIsNone(snapshot.throughput_metric)
+
+        expected_states = create_metric_states_dict(
+            metric_prefix="test_task",
+            computation_name="MockRecMetricComputation",
+            metric_states={"cross_entropy_sum": torch.tensor(1.0)},
+        )
+
+        assert_tensor_dict_equals(snapshot.metric_states, expected_states)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/utils/percentile_logger.py
+++ b/torchrec/utils/percentile_logger.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+
+import torch
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class PercentileLogger:
+    """
+    Used to log percentiles of a metric over a window of samples.
+    """
+
+    def __init__(
+        self, metric_name: str, window_size: int = 1000, log_interval: int = 100
+    ) -> None:
+        """
+        Args:
+            metric_name: name of the metric to log.
+            window_size: number of samples to keep in the window.
+            log_interval: number of samples between logging events.
+        """
+        self.metric_name = metric_name
+        self.window_size = window_size
+        self.values: torch.Tensor = torch.zeros(window_size)
+        self.index = 0
+        self.count = 0
+        self.log_interval = log_interval
+        self.update_count = 0
+
+    def add(self, value: float) -> None:
+        self.values[self.index] = value
+        self.index = (self.index + 1) % self.window_size
+        self.count = min(self.count + 1, self.window_size)
+        self.update_count += 1
+
+        if self.update_count % self.log_interval == 0:
+            self.log_percentiles()
+
+    def log_percentiles(self) -> None:
+        if self.count == 0:
+            return
+
+        active_values = self.values[: self.count]
+        p50 = torch.quantile(active_values, 0.50).item()
+        p90 = torch.quantile(active_values, 0.90).item()
+        p99 = torch.quantile(active_values, 0.99).item()
+        p999 = torch.quantile(active_values, 0.999).item()
+
+        logger.info(
+            f"{self.metric_name} percentiles: "
+            f"p50={p50:.2f}, p90={p90:.2f}, p99={p99:.2f}, p999={p999:.2f}, "
+            f"samples={self.count}"
+        )


### PR DESCRIPTION
Summary:
This diff adds the basic building blocks for a zero overhead RecMetrics implementation. Follow up patches will contain integration with users of torchrec.

One of the main pain points of using RecMetricModule is that metric updates and computes are done synchronously. In training jobs, there has been cases where metric updates take +20% of a training iteration. Metric computations, although less frequent, can takes over a couple of seconds.

CPUOffloadedRecMetricModule aims to perform all metric updates/computes asynchronously, completely removing them from the critical path.

This patch adds three classes:
- MetricStateSnapshot: Encapsulation of metric state tensors that will be used to load into comms module for all gathers.
- MetricUpdateJob/MetricComputeJob/SynchronizationMarker: classes to be enqueued to metric and compute queues in the future
- PercentileLogger: utility class to log percentiles of queue sizes, queue times

Reviewed By: iamzainhuda

Differential Revision: D83173329


