### PR TITLE
3/N: CPUOffloadedRecMetricModule

### DIFF
--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import logging
+from typing import Any, cast, Dict
+
+from torch import nn
+
+from torch.profiler import record_function
+
+from torchrec.metrics.metric_module import RecMetricModule
+from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+from torchrec.metrics.rec_metric import (
+    RecComputeMode,
+    RecMetric,
+    RecMetricComputation,
+    RecMetricList,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class CPUCommsRecMetricModule(RecMetricModule):
+    """
+    A submodule of CPUOffloadedRecMetricModule.
+
+    The comms module's main purposes are:
+    1. All gather metric state tensors
+    2. Load all gathered metric states
+    3. Compute metrics
+
+    This isolation allows CPUOffloadedRecMetricModule from having
+    to concern about aggregated states and instead focus solely
+    updating local state tensors and dumping snapshots to the comms module
+    for metric aggregations.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        All arguments are the same as RecMetricModule
+        """
+
+        super().__init__(*args, **kwargs)
+
+        rec_metrics_clone = self._clone_rec_metrics()
+        self.rec_metrics: RecMetricList = rec_metrics_clone
+
+        for metric in self.rec_metrics.rec_metrics:
+            # Disable automatic sync for all metrics - handled manually via
+            # RecMetricModule.get_pre_compute_states()
+            metric = cast(RecMetric, metric)
+            for computation in metric._metrics_computations:
+                computation = cast(RecMetricComputation, computation)
+                computation._to_sync = False
+
+    def load_local_metric_state_snapshot(
+        self, state_snapshot: MetricStateSnapshot
+    ) -> None:
+        """
+        Load local metric states before all gather.
+        MetricStateSnapshot provides already-reduced states.
+
+        Args:
+            state_snapshot (MetricStateSnapshot): a snapshot of metric states to load.
+        """
+
+        # Load states into comms module to be shared across ranks.
+
+        with record_function("## CPUCommsRecMetricModule: load_snapshot ##"):
+            for metric in self.rec_metrics.rec_metrics:
+                metric = cast(RecMetric, metric)
+                compute_mode = metric._compute_mode
+                if (
+                    compute_mode == RecComputeMode.FUSED_TASKS_COMPUTATION
+                    or compute_mode == RecComputeMode.FUSED_TASKS_AND_STATES_COMPUTATION
+                ):
+                    prefix = compute_mode.name
+                    computation = metric._metrics_computations[0]
+                    self._load_metric_states(
+                        prefix, computation, state_snapshot.metric_states
+                    )
+                for task, computation in zip(
+                    metric._tasks, metric._metrics_computations
+                ):
+                    self._load_metric_states(
+                        task.name, computation, state_snapshot.metric_states
+                    )
+
+            if state_snapshot.throughput_metric is not None:
+                self.throughput_metric = state_snapshot.throughput_metric
+
+    def _load_metric_states(
+        self, prefix: str, computation: nn.Module, metric_states: Dict[str, Any]
+    ) -> None:
+        """
+        Load metric states after all gather.
+        Uses aggregated states.
+        """
+
+        # All update() calls were done prior. Clear previous computed state.
+        # Otherwise, we get warnings that compute() was called before
+        # update() which is not the case.
+        computation = cast(RecMetricComputation, computation)
+        set_update_called(computation)
+        computation._computed = None
+
+        computation_name = f"{prefix}_{computation.__class__.__name__}"
+        # Restore all cached states from reductions
+        for attr_name in computation._reductions:
+            cache_key = f"{computation_name}_{attr_name}"
+            if cache_key in metric_states:
+                cached_value = metric_states[cache_key]
+                setattr(computation, attr_name, cached_value)
+
+    def _clone_rec_metrics(self) -> RecMetricList:
+        """
+        Clone rec_metrics. We need to keep references to the original tasks
+        and computation to load the state tensors. More importantly, we need to
+        remove the references to the original metrics to prevent concurrent access
+        from the update and compute threads.
+        """
+
+        cloned_metrics = []
+        for metric in self.rec_metrics.rec_metrics:
+            metric = cast(RecMetric, metric)
+            cloned_metric = type(metric)(
+                world_size=metric._world_size,
+                my_rank=metric._my_rank,
+                batch_size=metric._batch_size,
+                tasks=metric._tasks,
+                compute_mode=metric._compute_mode,
+                # Standard initialization passes in the global window size. A RecMetric's
+                # window size is set as the local window size.
+                window_size=metric._window_size * metric._world_size,
+                fused_update_limit=metric._fused_update_limit,
+                compute_on_all_ranks=metric._metrics_computations[
+                    0
+                ]._compute_on_all_ranks,
+                should_validate_update=metric._should_validate_update,
+                # Process group should be none to prevent unwanted distributed syncs.
+                # This is handled manually via RecMetricModule.get_pre_compute_states()
+                process_group=None,
+            )
+            cloned_metrics.append(cloned_metric)
+
+        return RecMetricList(cloned_metrics)
+
+
+def set_update_called(computation: RecMetricComputation) -> None:
+    """
+    Set _update_called to True for RecMetricComputation.
+    This is a workaround for torchmetrics 1.0.3+.
+    """
+    try:
+        computation._update_called = True
+    except AttributeError:
+        # pyre-ignore
+        computation._update_count = 1

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import concurrent
+import logging
+import queue
+import threading
+import time
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
+
+import torch
+from torch import distributed as dist
+from torch.profiler import record_function
+from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
+from torchrec.metrics.metric_job_types import (
+    MetricComputeJob,
+    MetricUpdateJob,
+    SynchronizationMarker,
+)
+from torchrec.metrics.metric_module import MetricValue, RecMetricModule
+from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+from torchrec.metrics.model_utils import parse_task_model_outputs
+from torchrec.metrics.rec_metric import RecMetricException
+
+from torchrec.utils.percentile_logger import PercentileLogger
+from typing_extensions import override
+
+logger: logging.Logger = logging.getLogger(__name__)
+metric_update_thread_name: str = "metric_update"
+metric_compute_thread_name: str = "metric_compute"
+
+
+class CPUOffloadedRecMetricModule(RecMetricModule):
+    """
+    RecMetricModule that offloads metric update() and compute() to CPU using background threads.
+
+    At a high level, this metric module consists of two queues:
+    - update queue: stores metric update jobs and synchronization markers. A worker thread
+        processes the update queue.
+        1. It updates state tensors with intermediate model outputs, and
+        2. On async_compute(), generates a snapshot of the local state tensors and enqueues
+            compute jobs to the compute queue.
+
+    - compute queue: stores metric compute jobs. A worker thread processes the compute queue.
+        1. It loads the state tensors into the CommsRecMetricModule
+        2. Performs a GLOO all gather to gather the state tensors from all ranks
+        3. Computes the metrics and sets the result in the future.
+
+    Why we have two queues:
+    - A MetricComputeJob is compute intensive and causes head of line blocking if processed in
+        the same queue as the MetricUpdateJob. This can lead to large queue sizes.
+    - The SynchronizationMarker acts as a synchronization marker for the compute queue to include
+        all of the MetricUpdateJobs that were scheduled before it so that all ranks use a consistent
+        metric states snapshot during all gather. All ranks will have processed up to 'N' update()
+        jobs before the SynchronizationMarker is processed.
+    """
+
+    def __init__(
+        self,
+        update_queue_size: int = 100,
+        compute_queue_size: int = 100,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            All arguments are the same as RecMetricModule except for
+            - update_queue_size: Maximum size of the update queue. Default is 100.
+            - compute_queue_size: Maximum size of the update queue. Default is 100.
+        """
+        super().__init__(*args, **kwargs)
+        self._shutdown_event = threading.Event()
+
+        self.update_queue: queue.Queue[
+            Union[MetricUpdateJob, SynchronizationMarker]
+        ] = queue.Queue(update_queue_size)
+        self.compute_queue: queue.Queue[MetricComputeJob] = queue.Queue(
+            compute_queue_size
+        )
+
+        self.update_thread = threading.Thread(
+            target=self._update_loop, name=metric_update_thread_name, daemon=True
+        )
+        self.compute_thread = threading.Thread(
+            target=self._compute_loop, name=metric_compute_thread_name, daemon=True
+        )
+
+        self.cpu_process_group: dist.ProcessGroup = dist.new_group(backend="gloo")
+        self.comms_module: CPUCommsRecMetricModule = CPUCommsRecMetricModule(
+            *args,
+            **kwargs,
+        )
+        self.update_thread.start()
+        self.compute_thread.start()
+
+        self.update_queue_size_logger: PercentileLogger = PercentileLogger(
+            metric_name="update_queue_size", log_interval=1000
+        )
+        self.compute_queue_size_logger: PercentileLogger = PercentileLogger(
+            metric_name="compute_queue_size", log_interval=10
+        )
+        self.compute_job_time_logger: PercentileLogger = PercentileLogger(
+            "compute_job_time_ms", log_interval=10
+        )
+        self.compute_metrics_time_logger: PercentileLogger = PercentileLogger(
+            "compute_metrics_time_ms", log_interval=10
+        )
+        self.all_gather_time_logger: PercentileLogger = PercentileLogger(
+            "all_gather_time_ms", log_interval=10
+        )
+
+        logger.info("CPUOffloadedRecMetricModule initialization complete.")
+
+    @override
+    def _update_rec_metrics(
+        self, model_out: Dict[str, torch.Tensor], **kwargs: Any
+    ) -> None:
+        """
+        Called during RecMetricModule.update(). Start a non-blocking transfer of
+        the model outputs and append a MetricUpdateJob to the update queue.
+
+        Args:
+            model_out: intermediate model outputs to be used for metric updates
+            kwargs: additional arguments required when updating metrics
+        """
+
+        if self._shutdown_event.is_set():
+            raise RecMetricException("metric processor thread is shut down.")
+
+        try:
+            cpu_model_out, transfer_completed_event = self._transfer_to_cpu(model_out)
+            self.update_queue.put_nowait(
+                MetricUpdateJob(
+                    model_out=cpu_model_out,
+                    transfer_completed_event=transfer_completed_event,
+                    kwargs=kwargs,
+                )
+            )
+            self.update_queue_size_logger.add(self.update_queue.qsize())
+        except queue.Full:
+            raise RecMetricException("update metric queue is full.")
+
+    def _transfer_to_cpu(
+        self,
+        model_out: Dict[str, torch.Tensor],
+    ) -> Tuple[Dict[str, torch.Tensor], torch.cuda.Event]:
+        """
+        Create a copy of model_out on CPU and return the copy. A cuda event
+        is created to track when the copy is completed.
+
+
+        Args:
+            model_out: intermediate model outputs to be used for metric updates
+        """
+
+        transfer_completed_event = torch.cuda.Event()
+        cpu_model_out = self._move_output_to_cpu(model_out)
+        transfer_completed_event.record()
+
+        return (
+            cpu_model_out,
+            transfer_completed_event,
+        )
+
+    def _move_output_to_cpu(
+        self, output: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Move all tensors in output to CPU and preserve dictionary structure.
+        Args:
+            output: tensors to be moved to CPU
+        """
+        return {
+            k: tensor.to(device="cpu", non_blocking=True)
+            for k, tensor in output.items()
+        }
+
+    def _process_metric_update_job(self, metric_update_job: MetricUpdateJob) -> None:
+        """
+        Process a single metric update job by a worker thread. It first
+        waits until the async transfer to CPU is completed, then updates
+        all metrics.
+
+        Args:
+            metric_update_job: metric update job to be processed
+        """
+
+        with record_function("## CPUOffloadedRecMetricModule:update ##"):
+            try:
+                metric_update_job.transfer_completed_event.synchronize()
+                labels, predictions, weights, required_inputs = (
+                    parse_task_model_outputs(
+                        self.rec_tasks,
+                        metric_update_job.model_out,
+                        self.get_required_inputs(),
+                    )
+                )
+                if required_inputs:
+                    metric_update_job.kwargs["required_inputs"] = required_inputs
+
+                self.rec_metrics.update(
+                    predictions=predictions,
+                    labels=labels,
+                    weights=weights,
+                    **metric_update_job.kwargs,
+                )
+
+                if self.throughput_metric:
+                    self.throughput_metric.update()
+
+            except Exception as e:
+                logger.exception("Error processing metric update: %s", e)
+                raise e
+
+    @override
+    def shutdown(self) -> None:
+        """
+        Stop the worker thread gracefully, processing all remaining queue items.
+        """
+
+        logger.info("Gracefully shutting down CPUOffloadedRecMetricModule...")
+        self._shutdown_event.set()
+
+        if self.update_thread.is_alive():
+            self.update_thread.join(timeout=30.0)
+        if self.compute_thread.is_alive():
+            self.compute_thread.join(timeout=30.0)
+
+        self.update_queue_size_logger.log_percentiles()
+        self.compute_queue_size_logger.log_percentiles()
+        self.compute_job_time_logger.log_percentiles()
+        self.compute_metrics_time_logger.log_percentiles()
+        self.all_gather_time_logger.log_percentiles()
+
+        if self.update_thread.is_alive():
+            raise RecMetricException(
+                f"update thread did not shut down gracefully. remaining queue size: {self.update_queue.qsize()}"
+            )
+        if self.compute_thread.is_alive():
+            raise RecMetricException(
+                f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
+            )
+        logger.info("CPUOffloadedRecMetricModule has been successfully shutdown.")
+
+    @override
+    def compute(self) -> Dict[str, MetricValue]:
+        raise RecMetricException(
+            "compute() is not supported in CPUOffloadedRecMetricModule. Use async_compute() instead."
+        )
+
+    @override
+    def async_compute(
+        self, future: concurrent.futures.Future[Dict[str, MetricValue]]
+    ) -> None:
+        """
+        Entry point for asynchronous metric compute. It enqueues a synchronization marker
+        to the update queue.
+
+        Args:
+            future: Pre-created future where the computed metrics will be set.
+        """
+        if self._shutdown_event.is_set():
+            future.set_exception(
+                RecMetricException("metric processor thread is shut down.")
+            )
+            return
+
+        self.update_queue.put_nowait(SynchronizationMarker(future))
+        self.update_queue_size_logger.add(self.update_queue.qsize())
+
+    def _process_synchronization_marker(
+        self, synchronization_marker: SynchronizationMarker
+    ) -> None:
+        """
+        Process a synchronization marker. It generates a MetricStateSnapshot which includes
+        the local metric states and enqueues a MetricComputeJob to the compute queue.
+
+        Args:
+            synchronization_marker: synchronization marker to be processed
+        """
+
+        with record_function("## CPUOffloadedRecMetricModule:sync_marker ##"):
+            self.compute_count += 1
+            if not self.rec_metrics:
+                raise RecMetricException("No metrics to compute.")
+
+            metric_state_snapshot = MetricStateSnapshot.from_metrics(
+                self.rec_metrics,
+                self.throughput_metric,
+            )
+
+            self.compute_queue.put_nowait(
+                MetricComputeJob(
+                    future=synchronization_marker.future,
+                    metric_state_snapshot=metric_state_snapshot,
+                )
+            )
+            self.compute_queue_size_logger.add(self.compute_queue.qsize())
+
+    def _process_metric_compute_job(
+        self, metric_compute_job: MetricComputeJob
+    ) -> Dict[str, MetricValue]:
+        """
+        Process a metric compute job:
+        1. Comms module performs all gather
+        2. Load aggregated metric states into comms module
+        3. Compute metrics via comms module
+        """
+
+        with record_function("## CPUOffloadedRecMetricModule:compute ##"):
+            start_ms = time.time()
+            self.comms_module.load_local_metric_state_snapshot(
+                metric_compute_job.metric_state_snapshot
+            )
+
+            with record_function("## cpu_all_gather ##"):
+                # Manual distributed sync (replaces TorchMetrics.metric.Metric.sync())
+                all_gather_start_ms = time.time()
+                aggregated_states = self.comms_module.get_pre_compute_states(
+                    self.cpu_process_group
+                )
+                self.all_gather_time_logger.add(
+                    (time.time() - all_gather_start_ms) * 1000
+                )
+
+            with record_function("## cpu_load_states ##"):
+                self.comms_module.load_pre_compute_states(aggregated_states)
+
+            with record_function("## metric_compute ##"):
+                compute_start_ms = time.time()
+                computed_metrics = self.comms_module.compute()
+                self.compute_job_time_logger.add((time.time() - start_ms) * 1000)
+                self.compute_metrics_time_logger.add(
+                    (time.time() - compute_start_ms) * 1000
+                )
+                self.compute_count += 1
+                self._adjust_compute_interval()
+                return computed_metrics
+
+    def _update_loop(self) -> None:
+        """
+        Main worker loop that processes update jobs and synchronization markers.
+        """
+
+        torch.multiprocessing._set_thread_name(metric_update_thread_name)
+        logger.info(f"Started thread {torch.multiprocessing._get_thread_name()}")
+
+        while not self._shutdown_event.is_set():
+            try:
+                self._do_work(self.update_queue)
+            except Exception as e:
+                logger.exception(f"Exception in update loop: {e}")
+                raise e
+
+        remaining = self._flush_remaining_work(self.update_queue)
+        logger.info(f"Flushed {remaining} remaining items during shutdown.")
+
+    def _compute_loop(self) -> None:
+        """
+        Main compute loop that processes compute jobs.
+        """
+        torch.multiprocessing._set_thread_name(metric_compute_thread_name)
+        logger.info(f"Started thread {torch.multiprocessing._get_thread_name()}")
+
+        while not self._shutdown_event.is_set():
+            try:
+                self._do_work(self.compute_queue)
+            except Exception as e:
+                logger.exception(f"Exception in compute loop: {e}")
+                raise e
+
+        remaining = self._flush_remaining_work(self.compute_queue)
+        logger.info(
+            f"Compute thread flushed {remaining} remaining items during shutdown."
+        )
+
+    def _do_work(
+        self,
+        metric_job_queue: Union[
+            queue.Queue[Union[MetricUpdateJob, SynchronizationMarker]],
+            queue.Queue[MetricComputeJob],
+        ],
+    ) -> None:
+        """
+        Process a single item from the queue.
+
+        Args:
+            metric_job_queue: Either the update queue or the compute queue.
+        """
+
+        try:
+            job = metric_job_queue.get(timeout=5.0)
+            if isinstance(job, MetricUpdateJob):
+                self._process_metric_update_job(job)
+            elif isinstance(job, SynchronizationMarker):
+                self._process_synchronization_marker(job)
+            elif isinstance(job, MetricComputeJob):
+                computed_metrics = self._process_metric_compute_job(job)
+                job.future.set_result(computed_metrics)
+            metric_job_queue.task_done()
+        except queue.Empty:
+            pass
+
+    def _flush_remaining_work(
+        self,
+        metric_job_queue: Union[
+            queue.Queue[Union[MetricUpdateJob, SynchronizationMarker]],
+            queue.Queue[MetricComputeJob],
+        ],
+    ) -> int:
+        """
+        Process all remaining items in the queue during shutdown.
+
+        Args:
+            metric_job_queue: queue to process.
+
+        Returns:
+            Number of items processed.
+        """
+        items_processed = 0
+        while not metric_job_queue.empty():
+            job = metric_job_queue.get_nowait()
+            if isinstance(job, MetricUpdateJob):
+                self._process_metric_update_job(job)
+            elif isinstance(job, SynchronizationMarker):
+                self._process_synchronization_marker(job)
+            elif isinstance(job, MetricComputeJob):
+                computed_metrics = self._process_metric_compute_job(job)
+                job.future.set_result(computed_metrics)
+            items_processed += 1
+            metric_job_queue.task_done()
+        return items_processed
+
+    def wait_until_queue_is_empty(
+        self,
+        metric_job_queue: Union[
+            queue.Queue[Union[MetricUpdateJob, SynchronizationMarker]],
+            queue.Queue[MetricComputeJob],
+        ],
+    ) -> None:
+        """
+        Wait until all queued work is completed.
+
+        Args:
+            metric_job_queue: queue to wait for: either update or compute queue.
+        """
+
+        metric_job_queue.join()
+
+    @override
+    def sync(self) -> None:
+        """
+        Sync the metric states across ranks. This is required before checkpointing.
+        """
+
+        # Prepare for checkpointing by waiting for all queued work to complete.
+        # This ensures that the timing of the snapshot is consistent across all ranks.
+        self.wait_until_queue_is_empty(self.update_queue)
+        self.wait_until_queue_is_empty(self.compute_queue)
+        logger.info("Ready for checkpoint.")
+
+        snapshot = MetricStateSnapshot.from_metrics(
+            self.rec_metrics,
+            self.throughput_metric,
+        )
+        self.comms_module.load_local_metric_state_snapshot(snapshot)
+        aggregated_states = self.comms_module.get_pre_compute_states(
+            self.cpu_process_group
+        )
+        self.comms_module.load_pre_compute_states(aggregated_states)
+
+        logger.info("CPUOffloadedRecMetricModule synced.")
+
+    @override
+    def state_dict(
+        self,
+        *args: Any,
+        destination: Optional[Dict[str, Any]] = None,
+        prefix: str = "",
+        keep_vars: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Return the state tensors for all metrics. Returns the comms module's state dict
+        because it stores the aggregated metric states across ranks.
+
+
+        Args are identical to torch.nn.Module.state_dict().
+        """
+        return self.comms_module.state_dict(
+            *args, destination=destination, prefix=prefix, keep_vars=keep_vars
+        )
+
+    @override
+    def load_state_dict(
+        self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False
+    ) -> None:
+        """
+        Load state dict into the offloaded module instead of the comms module.
+
+        The offloaded module will generate a snapshot to load into the comms module
+        during compute() path.
+
+        We need to override this method because we saved the state of the comms module
+        and not the offloaded module during state_dict().
+
+        Args are identical to torch.nn.Module.load_state_dict().
+        """
+        # Temporarily remove comms_module from _modules. Otherwise, it will try to traverse
+        # the submodule tree and load the state dict into the comms module.
+        comms_module = self._modules.pop("comms_module", None)
+
+        try:
+            super().load_state_dict(state_dict, strict=strict, assign=assign)
+        finally:
+            # Restore comms_module
+            if comms_module is not None:
+                self._modules["comms_module"] = comms_module
+
+    @override
+    def unsync(self) -> None:
+        """
+        unsync is not required as the local state tensors in CPUOffloadedRecMetricModule
+        remains untouched. The comms module contains the aggregated state tensors after all gather
+        and is essentially "discarded" after compute().
+        """
+        pass

--- a/torchrec/metrics/tests/test_cpu_comms_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_comms_metric_module.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, List
+
+import torch
+from torchrec.metrics.auc import _state_reduction
+from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
+from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
+from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
+from torchrec.metrics.test_utils import gen_test_tasks
+from torchrec.metrics.test_utils.mock_metrics import (
+    assert_tensor_dict_equals,
+    create_metric_states_dict,
+    create_tensor_states,
+    MockRecMetric,
+)
+
+
+class CPUCommsRecMetricModuleTest(unittest.TestCase):
+    """
+    Tests cloning rec metrics and loading snapshots into CPUCommsRecMetricModule.
+    """
+
+    def setUp(self) -> None:
+        self.world_size = 2
+        self.batch_size = 4
+        self.my_rank = 0
+        self.tasks = gen_test_tasks(["test_task"])
+
+    def test_clone_rec_metrics_reference(self) -> None:
+        """Tests cloned rec metrics upon initialization is a deep copy of the original."""
+
+        mock_metric_1 = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+        )
+
+        mock_metric_2 = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+        )
+
+        rec_metrics = RecMetricList([mock_metric_1, mock_metric_2])
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=rec_metrics,
+        )
+
+        original_metrics = rec_metrics.rec_metrics
+        cloned_metrics = cpu_comms_module.rec_metrics.rec_metrics
+
+        self.assertEqual(len(original_metrics), len(cloned_metrics))
+        for original_metric, cloned_metric in zip(original_metrics, cloned_metrics):
+            original_metric = cast(MockRecMetric, original_metric)
+            cloned_metric = cast(MockRecMetric, cloned_metric)
+
+            # Verify basic properties are preserved
+            self.assertEqual(original_metric._world_size, cloned_metric._world_size)
+            self.assertEqual(original_metric._my_rank, cloned_metric._my_rank)
+            self.assertEqual(original_metric._batch_size, cloned_metric._batch_size)
+            self.assertEqual(original_metric._compute_mode, cloned_metric._compute_mode)
+
+            # State tensor names must be the same in order to load into the correct
+            # state tensors.
+            original_metric_states = set(
+                original_metric.get_computation_states().keys()
+            )
+            cloned_metric_states = set(cloned_metric.get_computation_states().keys())
+            self.assertSetEqual(original_metric_states, cloned_metric_states)
+
+            # Cloned metric should have torchmetric.Metric's sync() disabled to prevent
+            # unwanted distributed syncs. All syncs will be called via cpu_comms_module.
+            self.assertTrue(cloned_metric.verify_sync_disabled())
+
+    def test_load_metric_states(self) -> None:
+        """
+        Test loading metric states into a single metric computation.
+        """
+
+        initial_states = {
+            "state_1": torch.tensor(1.0),
+            "state_2": torch.tensor(2.0),
+            "state_3": torch.tensor(3.0),
+        }
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+        )
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([mock_metric]),
+        )
+
+        metric_states = create_metric_states_dict(
+            metric_prefix="test_prefix",
+            computation_name="MockRecMetricComputation",
+            metric_states={
+                **initial_states,
+                "ignored_key": torch.tensor(15.0),
+            },
+        )
+
+        cloned_metric = cpu_comms_module.rec_metrics.rec_metrics[0]
+        cloned_computation = cloned_metric._metrics_computations[0]
+
+        cpu_comms_module._load_metric_states(
+            "test_prefix", cloned_computation, metric_states
+        )
+
+        self.assertTrue(cloned_computation._update_called)
+        self.assertIsNone(cloned_computation._computed)
+        assert_tensor_dict_equals(
+            cloned_metric.get_computation_states(),
+            initial_states,
+        )
+
+    def test_snapshot_generation(self) -> None:
+        """Test that original metrics and comms module loaded metrics produce the same snapshot."""
+
+        original_states = {
+            "state_1": torch.tensor(7.5),
+            "state_2": torch.tensor(12.0),
+            "state_3": torch.tensor(49.0),
+        }
+
+        original_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=original_states,
+        )
+
+        rec_metrics = RecMetricList([original_metric])
+        original_snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=rec_metrics,
+        )
+        cpu_comms_module.load_local_metric_state_snapshot(original_snapshot)
+        loaded_snapshot = MetricStateSnapshot.from_metrics(cpu_comms_module.rec_metrics)
+
+        assert_tensor_dict_equals(
+            original_snapshot.metric_states,
+            loaded_snapshot.metric_states,
+        )
+
+    def test_load_metric_states_partial_load(self) -> None:
+        """Test loading metric states when some keys are missing from the snapshot."""
+
+        initial_states = {
+            "state_1": torch.tensor(1.0),
+            "state_2": torch.tensor(2.0),
+            "state_3": torch.tensor(3.0),
+        }
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=initial_states,
+        )
+
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([mock_metric]),
+        )
+
+        # Metric states only contains one of the initial keys
+        metric_states = create_metric_states_dict(
+            metric_prefix="test_prefix",
+            computation_name="MockRecMetricComputation",
+            metric_states={"state_1": torch.tensor(5.0)},
+        )
+
+        cloned_metric = cpu_comms_module.rec_metrics.rec_metrics[0]
+        cloned_computation = cloned_metric._metrics_computations[0]
+
+        cpu_comms_module._load_metric_states(
+            "test_prefix", cloned_computation, metric_states
+        )
+
+        torch.testing.assert_close(
+            cloned_metric.get_computation_states()["state_1"], torch.tensor(5.0)
+        )
+        self.assertFalse(
+            torch.allclose(
+                cloned_metric.get_computation_states()["state_2"], torch.tensor(2.0)
+            )
+        )
+        self.assertFalse(
+            torch.allclose(
+                cloned_metric.get_computation_states()["state_2"], torch.tensor(3.0)
+            )
+        )
+
+    def test_load_multiple_metrics_unfused(self) -> None:
+        """Test handling multiple metrics and tasks together."""
+
+        ne_tasks = gen_test_tasks(["task1", "task2", "task3"])
+        auc_tasks = gen_test_tasks(["task4", "task5", "task6"])
+
+        ne_states = create_tensor_states(["state_1", "state_2", "state_3"], n_tasks=1)
+        mock_nes = [
+            MockRecMetric(
+                world_size=self.world_size,
+                my_rank=self.my_rank,
+                batch_size=self.batch_size,
+                tasks=[task],
+                initial_states=ne_states,
+            )
+            for task in ne_tasks
+        ]
+
+        auc_states = {
+            "state_1": [torch.tensor([[1.0, 2.0]])],
+            "state_2": [torch.tensor([[0.0, 1.0]])],
+            "state_3": [torch.tensor([[4.0, 1.0]])],
+        }
+        mock_aucs = [
+            MockRecMetric(
+                world_size=self.world_size,
+                my_rank=self.my_rank,
+                batch_size=self.batch_size,
+                tasks=[task],
+                reduction_fn=_state_reduction,
+                initial_states=auc_states,
+                is_tensor_list=True,
+            )
+            for task in auc_tasks
+        ]
+
+        rec_metrics_list: List[RecMetric] = [*mock_nes, *mock_aucs]
+        rec_metrics = RecMetricList(rec_metrics_list)
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=ne_tasks + auc_tasks,
+            rec_metrics=rec_metrics,
+        )
+
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+        cpu_comms_module.load_local_metric_state_snapshot(snapshot)
+
+        ne_states_dict = {}
+        for task in ne_tasks:
+            ne_states_dict.update(
+                create_metric_states_dict(
+                    metric_prefix=task.name,
+                    computation_name="MockRecMetricComputation",
+                    metric_states=ne_states,
+                )
+            )
+
+        auc_states_dict = {}
+        for task in auc_tasks:
+            auc_states_dict.update(
+                create_metric_states_dict(
+                    metric_prefix=task.name,
+                    computation_name="MockRecMetricComputation",
+                    metric_states=auc_states,
+                )
+            )
+
+        expected_metric_states = {**ne_states_dict, **auc_states_dict}
+        self.assertEqual(len(cpu_comms_module.rec_metrics.rec_metrics), 6)
+        actual_metric_states_dict = {}
+        for task, metric in zip(
+            cpu_comms_module.rec_tasks, cpu_comms_module.rec_metrics.rec_metrics
+        ):
+            metric = cast(MockRecMetric, metric)
+            actual_metric_states_dict.update(
+                create_metric_states_dict(
+                    metric_prefix=task.name,
+                    computation_name="MockRecMetricComputation",
+                    metric_states=metric.get_computation_states(),
+                )
+            )
+        assert_tensor_dict_equals(
+            actual_metric_states_dict,
+            expected_metric_states,
+        )
+
+    def test_load_multiple_metrics_fused(self) -> None:
+        """Test handling multiple metrics and tasks together."""
+
+        ne_tasks = gen_test_tasks(["task1", "task2", "task3"])
+
+        ne_states = create_tensor_states(["state_1", "state_2", "state_3"], n_tasks=3)
+        mock_ne = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=ne_tasks,
+            initial_states=ne_states,
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+        )
+
+        rec_metrics = RecMetricList([mock_ne])
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=ne_tasks,
+            rec_metrics=rec_metrics,
+        )
+
+        snapshot = MetricStateSnapshot.from_metrics(rec_metrics)
+        cpu_comms_module.load_local_metric_state_snapshot(snapshot)
+
+        self.assertEqual(len(cpu_comms_module.rec_metrics.rec_metrics), 1)
+        metric = cpu_comms_module.rec_metrics.rec_metrics[0]
+        metric = cast(MockRecMetric, metric)
+        assert_tensor_dict_equals(
+            metric.get_computation_states(),
+            ne_states,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import concurrent.futures
+import os
+import queue
+import threading
+import time
+import unittest
+from typing import Callable, cast, Dict
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
+from torchrec.metrics.cpu_offloaded_metric_module import (
+    CPUOffloadedRecMetricModule,
+    MetricUpdateJob,
+)
+from torchrec.metrics.metric_module import MetricValue, RecMetricModule
+from torchrec.metrics.rec_metric import RecMetricException, RecMetricList
+from torchrec.metrics.test_utils import gen_test_tasks
+from torchrec.metrics.test_utils.mock_metrics import (
+    assert_tensor_dict_equals,
+    create_tensor_states,
+    MockRecMetric,
+)
+from torchrec.metrics.throughput import ThroughputMetric
+from torchrec.test_utils import get_free_port, seed_and_log, skip_if_asan_class
+
+
+def wait_until_true(
+    condition: Callable[[], bool], timeout: float = 15.0, interval: float = 0.1
+) -> None:
+    """Wait until a condition is true or timeout is reached."""
+    start_time = time.time()
+    while not condition():
+        time.sleep(interval)
+        if time.time() - start_time > timeout:
+            raise TimeoutError("Timeout reached while waiting for condition")
+
+
+class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.world_size = 1
+        self.batch_size = 1
+        self.my_rank = 0
+        self.tasks = gen_test_tasks(["task1"])
+        self.initial_states = create_tensor_states(["cross_entropy_sum"])
+
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["LOCAL_WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = str("localhost")
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+
+        self.mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states=self.initial_states,
+        )
+        self.rec_metrics = RecMetricList([self.mock_metric])
+
+        dist.init_process_group("gloo")
+        self.cpu_module: CPUOffloadedRecMetricModule = CPUOffloadedRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+            throughput_metric=ThroughputMetric(
+                world_size=self.world_size,
+                batch_size=self.batch_size,
+                window_seconds=1,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        dist.destroy_process_group()
+        if hasattr(self, "cpu_module"):
+            try:
+                self.cpu_module.shutdown()
+            except Exception:
+                pass
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_transfer_to_cpu(self) -> None:
+        """Test non-blocking tensor output transfer from GPU to CPU."""
+
+        output = {
+            "task1-prediction": torch.tensor([1.0, 2.0, 3.0]).to("cuda:0"),
+            "task1-label": torch.tensor([0.0, 1.0, 0.0]).to("cuda:0"),
+            "task1-weight": torch.tensor([5.0, 1.0, 0.0]).to("cuda:0"),
+        }
+
+        cpu_output, transfer_event = self.cpu_module._transfer_to_cpu(output)
+        wait_until_true(transfer_event.query)
+
+        self.assertEqual(len(cpu_output), 3)
+        for key, tensor in cpu_output.items():
+            self.assertEqual(tensor.device.type, "cpu")
+            torch.testing.assert_close(tensor, output[key].cpu())
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_update_rec_metrics(self) -> None:
+        """
+        Test updating the mock metric with a single batch of data. This goes through
+        the update queue, to the update thread which calls update() on rec_metrics.
+        """
+        model_out = {
+            "task1-prediction": torch.tensor([0.5, 0.7]),
+            "task1-label": torch.tensor([0.0, 1.0]),
+            "task1-weight": torch.tensor([1.0, 1.0]),
+        }
+
+        self.cpu_module.update(model_out)
+
+        wait_until_true(self.mock_metric.update_called)
+        self.assertTrue(self.mock_metric.predictions_update_calls is not None)
+        torch.testing.assert_close(
+            model_out["task1-prediction"],
+            # pyre-ignore[6]
+            self.mock_metric.predictions_update_calls[0]["task1"],
+        )
+        self.assertTrue(self.mock_metric.labels_update_calls is not None)
+        torch.testing.assert_close(
+            model_out["task1-label"],
+            # pyre-ignore[6]
+            self.mock_metric.labels_update_calls[0]["task1"],
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_update_rec_metrics_queue_full(self) -> None:
+        cpu_module = CPUOffloadedRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+            update_queue_size=1,  # Small queue size
+        )
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.5]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        block_event: threading.Event = threading.Event()
+
+        def controlled_process_job(_: MetricUpdateJob) -> None:
+            # Simulate "busy" update thread
+            block_event.wait()
+
+        with patch.object(
+            cpu_module, "_process_metric_update_job", side_effect=controlled_process_job
+        ):
+            # Fill the queue beyond capacity
+            # First item is polled and blocked. Second item will stay in queue.
+            cpu_module._update_rec_metrics(model_out)
+            cpu_module._update_rec_metrics(model_out)
+
+            self.assertRaisesRegex(
+                RecMetricException,
+                "update metric queue is full",
+                cpu_module._update_rec_metrics,
+                model_out,
+            )
+            block_event.set()
+
+    def test_sync_compute_raises_exception(self) -> None:
+        self.assertRaisesRegex(
+            RecMetricException,
+            "compute\\(\\) is not supported in CPUOffloadedRecMetricModule.",
+            self.cpu_module.compute,
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_async_compute_synchronization_marker(self) -> None:
+        """
+        Test that async_compute() appends a synchronization marker to the compute queue
+        after processing all pending metric update jobs.
+
+        Note that the comms module's metrics are actually the ones that are computed.
+        """
+        future: concurrent.futures.Future[Dict[str, MetricValue]] = (
+            concurrent.futures.Future()
+        )
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+
+        for _ in range(10):
+            self.cpu_module.update(model_out)
+
+        self.cpu_module.async_compute(future)
+
+        comms_mock_metric = cast(
+            MockRecMetric, self.cpu_module.comms_module.rec_metrics.rec_metrics[0]
+        )
+        wait_until_true(comms_mock_metric.compute_called)
+
+        self.assertEqual(self.cpu_module.update_queue_size_logger.count, 11)
+        self.assertEqual(self.cpu_module.compute_queue_size_logger.count, 1)
+        self.assertEqual(self.mock_metric.update_called_count, 10)
+
+    def test_async_compute_after_shutdown(self) -> None:
+        self.cpu_module.shutdown()
+
+        future: concurrent.futures.Future[Dict[str, MetricValue]] = (
+            concurrent.futures.Future()
+        )
+        self.cpu_module.async_compute(future)
+
+        self.assertRaisesRegex(
+            RecMetricException, "metric processor thread is shut down.", future.result
+        )
+
+    def test_update_after_shutdown(self) -> None:
+        self.cpu_module.shutdown()
+
+        # Should raise exception
+        self.assertRaisesRegex(
+            RecMetricException,
+            "metric processor thread is shut down.",
+            self.cpu_module.update,
+            {"predictions": torch.tensor([0.5])},
+        )
+
+    def test_graceful_shutdown(self) -> None:
+        self.assertTrue(self.cpu_module.update_thread.is_alive())
+        self.assertTrue(self.cpu_module.compute_thread.is_alive())
+
+        self.cpu_module.shutdown()
+
+        self.assertFalse(self.cpu_module.update_thread.is_alive())
+        self.assertFalse(self.cpu_module.compute_thread.is_alive())
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_wait_until_queue_is_empty(self) -> None:
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+        self.cpu_module.update(model_out)
+        self.cpu_module.async_compute(concurrent.futures.Future())
+
+        self.cpu_module.wait_until_queue_is_empty(self.cpu_module.update_queue)
+        self.cpu_module.wait_until_queue_is_empty(self.cpu_module.compute_queue)
+
+        self.assertTrue(self.cpu_module.update_queue.empty())
+        self.assertTrue(self.cpu_module.compute_queue.empty())
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_state_dict_save_load(self) -> None:
+        """
+        Test state_dict() method. Generated from comms module, loaded into offloaded module
+
+        Offloaded module: update local state tensors | load state_dict
+        Comms module: aggregate global state tensors | save state_dict
+
+        We want the offloaded module to load globally reduced states when starting from a checkpoint.
+        Hence, we save comms module's state dict and load it into offloaded module.
+        """
+
+        offloaded_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states={
+                "state_1": torch.tensor([1.0]),
+                "state_2": torch.tensor([2.0]),
+                "state_3": torch.tensor([3.0]),
+            },
+        )
+        offloaded_module = CPUOffloadedRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([offloaded_metric]),
+        )
+
+        # Update comms module with new state tensors. Offloaded module is untouched.
+        comms_metric = cast(
+            MockRecMetric, offloaded_module.comms_module.rec_metrics.rec_metrics[0]
+        )
+        comms_metric.set_computation_states(
+            {
+                "state_1": torch.tensor([4.0]),
+                "state_2": torch.tensor([5.0]),
+                "state_3": torch.tensor([6.0]),
+            }
+        )
+        state_dict = offloaded_module.state_dict()
+        assert_tensor_dict_equals(
+            actual_states=state_dict,
+            expected_states={
+                "rec_metrics.rec_metrics.0._metrics_computations.0.state_1": torch.tensor(
+                    [4.0]
+                ),
+                "rec_metrics.rec_metrics.0._metrics_computations.0.state_2": torch.tensor(
+                    [5.0]
+                ),
+                "rec_metrics.rec_metrics.0._metrics_computations.0.state_3": torch.tensor(
+                    [6.0]
+                ),
+            },
+        )
+
+        # Load comms state dict into offloaded module. Confirm that offloaded module
+        # now also contains the updated state tensors from comms module.
+        offloaded_module.load_state_dict(state_dict)
+
+        assert_tensor_dict_equals(
+            actual_states=offloaded_metric.get_computation_states(),
+            expected_states={
+                "state_1": torch.tensor([4.0]),
+                "state_2": torch.tensor([5.0]),
+                "state_3": torch.tensor([6.0]),
+            },
+        )
+        offloaded_module.shutdown()
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_sync(self) -> None:
+        """Test sync() method waits for queues to empty and syncs metric states."""
+        offloaded_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states={
+                "state_1": torch.tensor([0.5]),
+                "state_2": torch.tensor([0.7]),
+                "state_3": torch.tensor([1.0]),
+            },
+        )
+        offloaded_module = CPUOffloadedRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([offloaded_metric]),
+        )
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5]),
+            "task1-label": torch.tensor([0.7]),
+            "task1-weight": torch.tensor([1.0]),
+        }
+        offloaded_module.update(model_out)
+        offloaded_module.sync()
+
+        self.assertTrue(offloaded_module.update_queue.empty())
+        self.assertTrue(offloaded_module.compute_queue.empty())
+        synced_state = offloaded_module.rec_metrics.rec_metrics[
+            0
+        ].get_computation_states()
+        assert_tensor_dict_equals(
+            actual_states=synced_state,
+            expected_states={
+                "state_1": torch.tensor([0.5]),
+                "state_2": torch.tensor([0.7]),
+                "state_3": torch.tensor([1.0]),
+            },
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_flush_remaining_work(self) -> None:
+        """Test _flush_remaining_work() processes all items in queue during shutdown."""
+        test_queue = queue.Queue()
+        metric_update_job = MetricUpdateJob(
+            model_out={
+                "task1-prediction": torch.tensor([0.5]),
+                "task1-label": torch.tensor([0.7]),
+                "task1-weight": torch.tensor([1.0]),
+            },
+            transfer_completed_event=torch.cuda.Event(),
+            kwargs={},
+        )
+
+        test_queue.put(metric_update_job)
+        test_queue.put(metric_update_job)
+
+        items_processed = self.cpu_module._flush_remaining_work(test_queue)
+
+        self.assertEqual(items_processed, 2)
+        self.assertTrue(test_queue.empty())
+
+
+@skip_if_asan_class
+class CPUOffloadedMetricModuleDistributedTest(MultiProcessTestBase):
+    """
+    Distributed tests comparing CPUOffloadedRecMetricModule with standard RecMetricModule.
+    Compare both the state_dict for checkpointing path, and the computed metrics for
+    metric_module.update()/compute() path.
+    """
+
+    @seed_and_log
+    def setUp(self) -> None:
+        super().setUp()
+
+        if torch.cuda.device_count() < 2:
+            self.skipTest("This test requires at least 2 GPUs")
+
+    def test_cpu_offloaded_vs_standard_metric_module_results(self) -> None:
+        """Test that CPUOffloadedRecMetricModule produces identical results to standard RecMetricModule."""
+        world_size = 2
+        batch_size = 8
+        num_batches = 5
+
+        self._run_multi_process_test(
+            callable=_compare_metric_results_worker,
+            world_size=world_size,
+            batch_size=batch_size,
+            num_batches=num_batches,
+            compare_sync=False,
+        )
+
+    def test_cpu_offloaded_vs_standard_sync_workflow(self) -> None:
+        """Test that CPUOffloadedRecMetricModule sync workflow produces identical state dicts."""
+        world_size = 2
+        batch_size = 2
+        num_batches = 2
+
+        self._run_multi_process_test(
+            callable=_compare_metric_results_worker,
+            world_size=world_size,
+            batch_size=batch_size,
+            num_batches=num_batches,
+            compare_sync=True,
+        )
+
+    def test_cpu_offloaded_scalability_with_multiple_batches(self) -> None:
+        world_size = 2
+        batch_size = 16
+        num_batches = 20
+
+        self._run_multi_process_test(
+            callable=_compare_metric_results_worker,
+            world_size=world_size,
+            batch_size=batch_size,
+            num_batches=num_batches,
+            compare_sync=False,
+        )
+
+
+def _compare_metric_results_worker(
+    rank: int,
+    world_size: int,
+    batch_size: int,
+    num_batches: int,
+    compare_sync: bool,
+) -> None:
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    device = f"cuda:{rank}"
+    torch.cuda.set_device(device)
+
+    tasks = gen_test_tasks(["task1", "task2"])
+
+    initial_states = {
+        "state_1": torch.tensor([1.0]),
+        "state_2": torch.tensor([2.0]),
+        "state_3": torch.tensor([3.0]),
+    }
+
+    standard_metric = MockRecMetric(
+        world_size=world_size,
+        my_rank=rank,
+        batch_size=batch_size,
+        tasks=tasks,
+        initial_states=initial_states.copy(),
+    )
+
+    offloaded_metric = MockRecMetric(
+        world_size=world_size,
+        my_rank=rank,
+        batch_size=batch_size,
+        tasks=tasks,
+        initial_states=initial_states.copy(),
+    )
+
+    standard_module = RecMetricModule(
+        batch_size=batch_size,
+        world_size=world_size,
+        rec_tasks=tasks,
+        rec_metrics=RecMetricList([standard_metric]),
+    ).to(device)
+
+    # Create CPUOffloadedRecMetricModule (automatically stays on CPU)
+    cpu_offloaded_module = CPUOffloadedRecMetricModule(
+        batch_size=batch_size,
+        world_size=world_size,
+        rec_tasks=tasks,
+        rec_metrics=RecMetricList([offloaded_metric]),
+    ).to(device)
+
+    # Generate same training data for both modules
+    torch.manual_seed(42 + rank)  # Ensure deterministic but rank-specific data
+
+    model_outputs = []
+    for _ in range(num_batches):
+        model_out = {
+            "task1-prediction": torch.rand(batch_size).to(device),
+            "task1-label": torch.randint(0, 2, (batch_size,)).float().to(device),
+            "task1-weight": torch.ones(batch_size).to(device),
+            "task2-prediction": torch.rand(batch_size).to(device),
+            "task2-label": torch.randint(0, 2, (batch_size,)).float().to(device),
+            "task2-weight": torch.ones(batch_size).to(device),
+        }
+        model_outputs.append(model_out)
+
+    for model_out in model_outputs:
+        standard_module.update(model_out)
+        cpu_offloaded_module.update(model_out)
+
+    # Checkpointing
+    if compare_sync:
+        # Sync both modules
+        standard_module.sync()
+        cpu_offloaded_module.sync()
+
+        standard_state_dict = standard_module.state_dict()
+        offloaded_state_dict = cpu_offloaded_module.state_dict()
+
+        assert_tensor_dict_equals(
+            actual_states=offloaded_state_dict,
+            expected_states=standard_state_dict,
+        )
+
+    standard_results = standard_module.compute()
+
+    future: concurrent.futures.Future[Dict[str, MetricValue]] = (
+        concurrent.futures.Future()
+    )
+    cpu_offloaded_module.async_compute(future)
+
+    # Wait for async compute to finish. Compare the input to each update()
+    offloaded_results = future.result(timeout=10.0)
+    for (
+        offloaded_predictions,
+        offloaded_labels,
+        offloaded_weights,
+        standard_predictions,
+        standard_labels,
+        standard_weights,
+    ) in zip(
+        offloaded_metric.predictions_update_calls,
+        offloaded_metric.labels_update_calls,
+        offloaded_metric.weights_update_calls,
+        standard_metric.predictions_update_calls,
+        standard_metric.labels_update_calls,
+        standard_metric.weights_update_calls,
+    ):
+        assert_tensor_dict_equals(
+            actual_states=offloaded_predictions,
+            expected_states=standard_predictions,
+        )
+        assert_tensor_dict_equals(
+            actual_states=offloaded_labels,
+            expected_states=standard_labels,
+        )
+        assert_tensor_dict_equals(
+            actual_states=offloaded_weights,
+            expected_states=standard_weights,
+        )
+
+    # Compare the computed metric results from both modules
+    assert_tensor_dict_equals(
+        actual_states=offloaded_results,
+        expected_states=standard_results,
+    )
+
+    cpu_offloaded_module.shutdown()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff adds the basic building blocks for a zero overhead RecMetrics implementation. Follow up patches will contain integration with users of torchrec.

One of the main pain points of using RecMetricModule is that metric updates and computes are done synchronously. In training jobs, there has been cases where metric updates take +20% of a training iteration. Metric computations, although less frequent, can takes over a couple of seconds.

CPUOffloadedRecMetricModule aims to perform all metric updates/computes asynchronously, completely removing them from the critical path.

This patch adds:
- CPUOffloadedRecMetricModule: RecMetricModule that offloads metric update() and compute() to CPU using background threads and dual queues.

Differential Revision: D83773529


