### PR TITLE
Fix MPZCH model publish

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -305,7 +305,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
 
         self._max_probe = max_probe
         self._buckets = total_num_buckets
-        self.register_buffer("_hash_zch_bucket", torch.tensor([total_num_buckets]))
+        self.register_buffer("_hash_zch_bucket", torch.tensor([[total_num_buckets]]))
         # Do not need to store in buffer since this is created and consumed
         # at each step https://fburl.com/code/axzimmbx
         self._evicted_indices = []


### PR DESCRIPTION
Summary: Remove _hash_zch_bucket in the inference module for model publish

Differential Revision: D84944806


