### PR TITLE
Sync tensordict

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -1469,7 +1469,7 @@ class ShardedEmbeddingCollection(
     ) -> Awaitable[Awaitable[KJTList]]:
         need_permute: bool = True
         if isinstance(features, TensorDict):
-            feature_keys = list(features.keys())  # pyre-ignore[6]
+            feature_keys = list(features.keys())
             if self._features_order:
                 feature_keys = [feature_keys[i] for i in self._features_order]
                 need_permute = False

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1513,7 +1513,7 @@ class ShardedEmbeddingBagCollection(
         in advance
         """
         if isinstance(features, TensorDict):
-            feature_keys = list(features.keys())  # pyre-ignore[6]
+            feature_keys = list(features.keys())
             if len(self._features_order) > 0:
                 feature_keys = [feature_keys[i] for i in self._features_order]
                 self._has_features_permute = False  # feature_keys are in order

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -298,7 +298,7 @@ class ModelInput(Pipelineable):
                     idlist_features, global_idlist_indices, global_idlist_lengths
                 )
             }
-            global_idlist_input = TensorDict(source=dict_of_nt)
+            global_idlist_input = TensorDict(source=dict_of_nt)  # pyre-ignore[6]
 
             assert (
                 len(idscore_features) == 0
@@ -409,7 +409,7 @@ class ModelInput(Pipelineable):
                         local_idlist_lengths,
                     )
                 }
-                local_idlist_input = TensorDict(source=dict_of_nt)
+                local_idlist_input = TensorDict(source=dict_of_nt)  # pyre-ignore[6]
                 assert (
                     len(idscore_features) == 0
                 ), "TensorDict does not support weighted features"


### PR DESCRIPTION
Summary:
Imported commits from public tensordict repo using
```
python3 pytorch/import.py --project_name tensordict --no_submit
```

Manual Change:
* adding a new dependency: pyvers
  * imported a new dependency pyvers in the stack
* some import failures due to checked in code missing new lines
  * hypothesis: code formatter removed the new lines
  * manually added the new lines back and re-ran the script
* added pyi files to library source to fix linter errors
* disabled tests that use ray because we can't initialize a ray cluster on sandcastle hosts

Differential Revision: D85157386
