### PR TITLE
Add option to use gather to select indices in EC

### DIFF
--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -408,6 +408,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
         tables: List[EmbeddingConfig],
         device: Optional[torch.device] = None,
         need_indices: bool = False,
+        use_gather_select: bool = False,
     ) -> None:
         super().__init__()
         torch._C._log_api_usage_once(f"torchrec.modules.{self.__class__.__name__}")
@@ -415,6 +416,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
         self._embedding_configs = tables
         self._embedding_dim: int = -1
         self._need_indices: bool = need_indices
+        self._use_gather_select: bool = use_gather_select
         self._device: torch.device = (
             device if device is not None else torch.device("cpu")
         )
@@ -541,3 +543,10 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
             param = self.embeddings[f"{table_config.name}"].weight
             # pyre-ignore
             table_config.init_fn(param)
+
+    def use_gather_select(self) -> bool:
+        """
+        Returns:
+            bool: Whether the EmbeddingCollection uses torch.gather to select embeddings.
+        """
+        return self._use_gather_select


### PR DESCRIPTION
Summary:
Due to atomic add in torch.index_select, the backward performance sometimes is bad comparing with gather. In this diff, it provides users with control over the indexing process and select the suitable operator based on specific cases. 


Perf comparison on pure operators(forward+backward)

2D Embedding, No Repetition
Config: shape=(1000000, 256), dim=0, indices=100000, unique=95300 (95.3%)
Method                    Time (s)     Speedup    Status
torch.gather              0.9439       1.00      x 🏆
torch.index_select        1.0509       0.90      x 

2D Embedding, Low Repetition
Config: shape=(1000000, 256), dim=0, indices=100000, unique=48732 (48.7%)
Method                    Time (s)     Speedup    Status
torch.gather              0.9076       1.00      x 🏆
torch.index_select        1.0415       0.87      x 

2D Embedding, High Repetition
Config: shape=(1000000, 256), dim=0, indices=250000, unique=9957 (4.0%)
Method                    Time (s)     Speedup    Status
torch.gather              1.2385       1.00      x 🏆
torch.index_select        1.6225       0.76      x 

Small Vocab, Low Repetition
Config: shape=(1000, 256), dim=0, indices=2000, unique=635 (31.8%)
Method                    Time (s)     Speedup    Status
torch.gather              0.1502       1.00      x 🏆
torch.index_select        0.1763       0.85      x 

Small Vocab, Very High Repetition
Config: shape=(1000, 256), dim=0, indices=100000, unique=625 (0.6%)
Method                    Time (s)     Speedup    Status
torch.gather              0.2626       1.00      x 🏆
torch.index_select        0.4126       0.64      x 

Large Vocab, No Repetition
Config: shape=(10000000, 256), dim=0, indices=10000, unique=9996 (100.0%)
Method                    Time (s)     Speedup    Status
torch.gather              5.8014       1.00      x 🏆
torch.index_select        5.8184       1.00      x 

Large Vocab, Low Repetition
Config: shape=(10000000, 256), dim=0, indices=10000, unique=5000 (50.0%)
Method                    Time (s)     Speedup    Status
torch.gather              5.7912       1.00      x 🏆
torch.index_select        5.8137       1.00      x 

Large Vocab, High Repetition
Config: shape=(10000000, 256), dim=0, indices=10000, unique=400 (4.0%)
Method                    Time (s)     Speedup    Status
torch.gather              5.7784       1.00      x 🏆
torch.index_select        5.8100       0.99      x 




Differential Revision: D85309309


