### PR TITLE
add EC module in train pipeline benchmark

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_seq.yml
@@ -1,0 +1,51 @@
+# Mixed EBC + EC (EmbeddingCollection) benchmark config
+# Demonstrates benchmarking with both EmbeddingBagConfig and EmbeddingConfig tables
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "sparse_data_dist_seq"
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 100
+  feature_pooling_avg: 30
+ModelSelectionConfig:
+  model_name: "mixed_embedding"
+  model_config:
+    num_float_features: 100
+EmbeddingTablesConfig:
+  num_unweighted_features: 70
+  num_weighted_features: 70
+  embedding_feature_dim: 256
+  additional_tables:
+    # First list: unweighted tables (EBC + EC mixed)
+    - - name: ebc_table_0
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["ebc_feature_0"]
+      - name: ebc_table_1
+        embedding_dim: 256
+        num_embeddings: 200_000
+        feature_names: ["ebc_feature_1"]
+      # EC tables - use config_class to specify EmbeddingConfig
+      - name: ec_table_0
+        embedding_dim: 1024
+        num_embeddings: 1_000_000
+        feature_names: ["ec_feature_0"]
+        config_class: EmbeddingConfig
+      - name: ec_table_1
+        embedding_dim: 1024
+        num_embeddings: 2_000_000
+        feature_names: ["ec_feature_1"]
+        config_class: EmbeddingConfig
+    # Second list: weighted tables (empty for this config)
+    - []
+PlannerConfig:
+  pooling_factors: [30.0]
+  hardware:  # A100
+    hbm_cap: 85899345920  # 80GB

--- a/torchrec/distributed/test_utils/model_input.py
+++ b/torchrec/distributed/test_utils/model_input.py
@@ -657,8 +657,8 @@ class ModelInput(Pipelineable):
         """
         return (
             float_features.pin_memory(),
-            idlist_features.pin_memory(),
-            idscore_features.pin_memory(),
+            idlist_features.pin_memory() if idlist_features is not None else None,
+            idscore_features.pin_memory() if idscore_features is not None else None,
             label.pin_memory(),
         )
 


### PR DESCRIPTION
## Changes
- `sparse_data_dist_seq.yml` - New benchmark config for EC
- `model_input.py` - Support list of KJTs
- `model_config.py` - Add EC model config
- `table_config.py` - Add EC table config
- `test_model.py` - Simplify forward pass (remove manual feature filtering, FX tracing compatible)
- `run_benchmarks.sh` - Add new benchmark to daily runs

## sharding plan
```
INFO:torchrec.distributed.planner.stats:############################################################################################################################################################################################################################################################################################################
INFO:torchrec.distributed.planner.stats:#                                                                                                                                        --- Planner Statistics ---                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#                                                                                                                 --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.04s ---                                                                                                                 #
INFO:torchrec.distributed.planner.stats:# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
INFO:torchrec.distributed.planner.stats:#      Rank       HBM (GB)     DDR (GB)                  Perf (ms)     Input (MB)     Output (MB)     Shards                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#    ------     ----------   ----------                -----------   ------------   -------------   --------                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#         0   32.311 (48%)     0.0 (0%)   317.757 (95,16,190,16,0)          555.0          9984.0     TW: 37                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#         1   28.401 (42%)     0.0 (0%)   317.757 (95,16,190,16,0)          555.0          9984.0     TW: 37                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                      #
INFO:torchrec.distributed.planner.stats:# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Parameter Info:                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                FQN     Sharding     Compute Kernel                Perf (ms)     Storage (HBM, DDR)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size     Ranks   #
INFO:torchrec.distributed.planner.stats:#              -----   ----------   ----------------              -----------   --------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------   -------   #
INFO:torchrec.distributed.planner.stats:#      ec.ec_table_0           TW              fused   75.216 (17,12,33,12,0)    (11.329 GB, 0.0 GB)                  None                   30.0                  1.0            30.0   sequence   unweighted      EmbeddingCollectionSharder            1                 1024       1000000         1   #
INFO:torchrec.distributed.planner.stats:#      ec.ec_table_1           TW              fused   75.216 (17,12,33,12,0)    (15.144 GB, 0.0 GB)                  None                   30.0                  1.0            30.0   sequence   unweighted      EmbeddingCollectionSharder            1                 1024       2000000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_0           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_1           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_2           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_3           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_4           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_5           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_6           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_7           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_8           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#        ebc.table_9           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_10           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_11           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_12           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_13           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_14           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_15           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_16           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_17           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_18           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_19           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_20           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_21           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_22           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_23           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_24           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_25           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_26           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_27           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_28           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_29           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_30           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_31           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_32           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_33           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_34           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_35           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_36           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_37           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_38           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_39           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_40           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_41           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_42           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_43           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_44           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_45           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_46           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_47           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_48           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_49           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_50           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_51           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_52           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_53           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_54           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_55           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_56           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_57           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_58           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_59           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_60           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_61           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_62           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_63           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_64           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_65           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_66           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_67           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_68           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#       ebc.table_69           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         0   #
INFO:torchrec.distributed.planner.stats:#    ebc.ebc_table_0           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.173 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000         1   #
INFO:torchrec.distributed.planner.stats:#    ebc.ebc_table_1           TW              fused    6.737 (2,0.1,4,0.1,0)     (0.268 GB, 0.0 GB)                  None                   30.0                  1.0            30.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        200000         0   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Batch Size: 32768                                                                                                                                                                                                                                                                                        #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Count:                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#    fused: 74                                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Compute Kernels Storage:                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:#    fused: HBM: 38.99 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.000                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.000                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.000                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:# Total Variation: 0.032                                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Total Distance: 0.064                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# Chi Divergence: 0.004                                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# KL Divergence: 0.003                                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Maximum of Total Perf: 317.757 ms on ranks 0-1                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Mean Total Perf: 317.757 ms                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Max Total Perf is 0% greater than the mean                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Compute: 95.086 ms on ranks 0-1                                                                                                                                                                                                                                                       #
INFO:torchrec.distributed.planner.stats:# Maximum of Forward Comms: 16.25 ms on ranks 0-1                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Compute: 190.172 ms on ranks 0-1                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:# Maximum of Backward Comms: 16.25 ms on ranks 0-1                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Sum of Maxima: 317.757 ms                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Estimated Sharding Distribution                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Sparse only Max HBM: 21.45 GB on rank [0]                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Sparse only Min HBM: 17.54 GB on rank [1]                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:# Max HBM: 32.311 GB on rank [0]                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Min HBM: 28.401 GB on rank [1]                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Mean HBM: 30.356 GB on rank []                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Low Median HBM: 28.401 GB on rank [1]                                                                                                                                                                                                                                                                    #
INFO:torchrec.distributed.planner.stats:# High Median HBM: 32.311 GB on rank [0]                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms): 32.5                                                                                                                                                                                                                                                                              #
INFO:torchrec.distributed.planner.stats:# Critical Path (compute): 285.257                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:# Critical Path (comms + compute): 317.757                                                                                                                                                                                                                                                                 #
INFO:torchrec.distributed.planner.stats:# Max HBM is 6.44% greater than the mean                                                                                                                                                                                                                                                                   #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Top HBM Memory Usage Estimation: 32.311 GB                                                                                                                                                                                                                                                               #
INFO:torchrec.distributed.planner.stats:# Top Tier #2 Estimated Peak HBM Pressure: 28.401 GB on rank 0                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Top Tier #1 Estimated Peak HBM Pressure: 32.311 GB on rank 0                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Reserved Memory:                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#    HBM: 12.0 GB                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 15%                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:# Planning Memory:                                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#    HBM: 68.0 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:#    Percent of Total HBM: 85%                                                                                                                                                                                                                                                                             #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Dense Storage (per rank):                                                                                                                                                                                                                                                                                #
INFO:torchrec.distributed.planner.stats:#    HBM: 0.021 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# KJT Storage (per rank):                                                                                                                                                                                                                                                                                  #
INFO:torchrec.distributed.planner.stats:#    HBM: 10.84 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#                                                                                                                                                                                                                                                                                                          #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                           #
INFO:torchrec.distributed.planner.stats:# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                            #
INFO:torchrec.distributed.planner.stats:#    ec_table_1: 15.144 GB on rank [0]                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    ebc_table_1: 0.268 GB on rank [0]                                                                                                                                                                                                                                                                     #
INFO:torchrec.distributed.planner.stats:#    table_1: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#    table_3: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:#    table_5: 0.173 GB on rank [0]                                                                                                                                                                                                                                                                         #
INFO:torchrec.distributed.planner.stats:############################################################################################################################################################################################################################################################################################################
```

## benchmark
============================================================

  Runtime:
    GPU (P90):              10783.38 ms
    CPU (P90):              7097.21 ms

  GPU Memory:
    Peak Allocated (P90):   49.72 GB
    Peak Reserved (P90):    78.11 GB
    Used (P90):             71.32 GB
    Malloc Retries:         P50=2  P90=2  P100=2

  CPU Memory:
    Peak RSS (P90):         74.02 GB

============================================================

## trace
<img width="5082" height="1380" alt="image" src="https://github.com/user-attachments/assets/8f6c2ce3-6c08-411b-b087-5529e16d5b70" />


Differential Revision: D85009941
