### PR TITLE
update python version in Generate documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         include:
          - os: linux.24_04.4x
-           python-version: 3.9
-           python-tag: "py39"
+           python-version: 3.12
+           python-tag: "py312"
     steps:
     - name: Check ldd --version
       run: ldd --version


### PR DESCRIPTION
Summary:
# context
* torchrec github workflow starts to fail: [job](https://github.com/meta-pytorch/torchrec/actions/runs/18788899544/job/53619374395)
<img width="3662" height="1576" alt="image" src="https://github.com/user-attachments/assets/27edce0c-e19e-4e2a-9dfd-da75e9e6aa65" />


* error message
```
Run conda run -n build_binary pip install torch --index-url https://download.pytorch.org/whl/nightly/cpu
  conda run -n build_binary pip install torch --index-url https://download.pytorch.org/whl/nightly/cpu
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}

ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
ERROR: No matching distribution found for torch
ERROR conda.cli.main_run:execute(127): `conda run pip install torch --index-url https://download.pytorch.org/whl/nightly/cpu` failed. (See above for error)
Looking in indexes: https://download.pytorch.org/whl/nightly/cpu
```
* this is because PyTorch no longer support python 3.9 and this workflow still uses python 3.9
* update python version to 3.12 (the default version for ubuntu 20.04)
* workflow job succeeded: [job](https://github.com/meta-pytorch/torchrec/actions/runs/18790963779)
<img width="1410" height="857" alt="image" src="https://github.com/user-attachments/assets/9db36748-ea80-4055-9347-3e180ac9bf35" />

Differential Revision: D85462203


