### PR TITLE
add train pipeline class in logging

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -110,6 +110,8 @@ class TrainPipeline(abc.ABC, Generic[In, Out]):
         # pipeline state such as in foward, in backward etc, used in training recover scenarios
         self._state: PipelineState = PipelineState.IDLE
 
+        logger.info(f"TrainPipeline class: {type(self)}")
+
     def sync_embeddings(
         self,
         model: torch.nn.Module,


### PR DESCRIPTION
Summary:
# context
* add TrainPipeline class logging to help debugging which train pipeline is used in the training job
* this will produce the following log
```
INFO:torchrec.distributed.train_pipeline.train_pipelines:TrainPipeline class: <class 'torchrec.distributed.train_pipeline.train_pipelines.TrainPipelineSparseDist'>
```

Differential Revision: D85577739


