### PR TITLE
correctly set log level for benchmark runs

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -129,7 +129,7 @@ def runner(
         torch.cuda.is_available() and torch.cuda.device_count() >= world_size
     ), "CUDA not available or insufficient GPUs for the requested world_size"
 
-    torch.autograd.set_detect_anomaly(True)
+    run_option.set_log_level()
     with MultiProcessContext(
         rank=rank,
         world_size=world_size,


### PR DESCRIPTION
Summary:
# context
* loglevel is not correctly set in train pipeline benchmark due to the multiprocess setup
* the log level is only set in the main process but not correctly set in the forked/spawn processes
* this diff add the `loglevel` argument into the RunConfig so that in every runner funcion can call `set_logger_level`
* also directly pass the error message on yaml or json parser failure, which previously just warn silently and the warning message is buried in lengthy logs.

Differential Revision: D85829837


