### PR TITLE
Validate sharding plan correctness: Shard to rank assignment

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -799,6 +799,7 @@ class PlannerErrorType(Enum):
     OTHER = "other"
     PLANNER_INPUT_CONTEXT_MISMATCH = "planner_input_context_mismatch"
     PLAN_LOADING_FAILED = "plan_loading_failed"
+    INVALID_RANK_ASSIGNMENT = "invalid_rank_assignment"
 
 
 class PlannerError(Exception):


### PR DESCRIPTION
Summary:
- validate correct rank assignment
    - checks for None ranks
    - checks for ranks in correct rank range
    - check consistency in Manifold planner sharding plan rank assignment

Differential Revision: D85878244


