### PR TITLE
add tracker_fn to MCC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ tqdm
 usort
 parameterized
 PyYAML
+psutil
 
 # for tests
 # https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -781,7 +781,8 @@ def modify_input_for_feature_processor(
 
         if is_collection:
             if hasattr(feature_processors, "pre_process_pipeline_input"):
-                feature_processors.pre_process_pipeline_input(features)  # pyre-ignore[29]
+                # pyre-ignore[29]
+                feature_processors.pre_process_pipeline_input(features)
             else:
                 logging.info(
                     f"[Feature Processor Pipeline] Skipping pre_process_pipeline_input for feature processor {feature_processors=}"

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -357,9 +357,11 @@ class ManagedCollisionCollection(nn.Module):
             len(features) for features in self._table_to_features.values()
         ]
 
-        table_to_config = {config.name: config for config in embedding_configs}
+        self._table_name_to_config: Dict[str, BaseEmbeddingConfig] = {
+            config.name: config for config in embedding_configs
+        }
 
-        for name, config in table_to_config.items():
+        for name, config in self._table_name_to_config.items():
             if name not in managed_collision_modules:
                 raise ValueError(
                     f"Table {name} is not present in managed_collision_modules"


### PR DESCRIPTION
Summary:
Adding post lookup tracker function within MMC module to allow tracking of hash_zch_identities with delta tracker. 

internal 
This is needed to support MPZCH modules for Raw embedding streaming. 
Mode details : https://docs.google.com/document/d/1KEHwiXKLgXwRIdDFBYopjX3OiP3mRLM24Qkbiiu-TgE/edit?tab=t.0#bookmark=id.lhhgee2cs6ld

Differential Revision: D84920121


