### PR TITLE
OSS build fix due to dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ tqdm
 usort
 parameterized
 PyYAML
+psutil
 
 # for tests
 # https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3


### PR DESCRIPTION
Summary:
internal
psutil was added as a new dependency in FBGEMM in this diff D85604160 and is causing the OSS build to fail.

Fix:
Added psutil in requirements

Differential Revision: D86103237


