### PR TITLE
Add more exception handling and support for class constructors

### DIFF
--- a/torchrec/distributed/torchrec_logger.py
+++ b/torchrec/distributed/torchrec_logger.py
@@ -42,12 +42,16 @@ def _get_logging_handler(
 
 
 def _get_msg_dict(func_name: str, **kwargs: Any) -> dict[str, Any]:
-    msg_dict = {
-        "func_name": f"{func_name}",
-    }
-    if dist.is_initialized():
-        group = kwargs.get("group") or kwargs.get("process_group")
-        msg_dict["group"] = f"{group}"
-        msg_dict["world_size"] = f"{dist.get_world_size(group)}"
-        msg_dict["rank"] = f"{dist.get_rank(group)}"
-    return msg_dict
+    try:
+        msg_dict = {
+            "func_name": f"{func_name}",
+        }
+        if dist.is_initialized():
+            group = kwargs.get("group") or kwargs.get("process_group")
+            msg_dict["group"] = f"{group}"
+            msg_dict["world_size"] = f"{dist.get_world_size(group)}"
+            msg_dict["rank"] = f"{dist.get_rank(group)}"
+        return msg_dict
+    except Exception as error:
+        logging.error(f"Torchrec Logger: Error in _get_msg_dict: {error}")
+        return {"_get_msg_dict_error": str(error)}


### PR DESCRIPTION
Summary:
This diff adds a few features to the static logger

1) Better exception handling to make sure any failures are silent and don't affect the actual training job.
2) Support for handling class constructors. This includes changing the function name to include the name of the class for constructors and moving the collection of inputs to after the function call succeeds.
3) Moved the static logger enablement stricts to a configerator file instead of using justknobs metadata. The justknobs will only be used as a kill switch now

Reviewed By: kausv, saumishr

Differential Revision: D76294357


