### PR TITLE
Add hash and equality functions to planner types

### DIFF
--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -144,6 +144,18 @@ class DeviceHardware:
     storage: Storage
     perf: Perf
 
+    def __hash__(self) -> int:
+        return hash((self.rank, self.storage, self.perf))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DeviceHardware):
+            return False
+        return (
+            self.rank == other.rank
+            and self.storage == other.storage
+            and self.perf == other.perf
+        )
+
 
 class CustomTopologyData:
     """
@@ -246,6 +258,17 @@ class BasicCommsBandwidths(GeneralizedCommsBandwidth):
             return self.intra_host_bw
         else:
             return self.inter_host_bw
+
+    def __hash__(self) -> int:
+        return hash((self._inter_host_bw, self._intra_host_bw))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BasicCommsBandwidths):
+            return False
+        return (
+            self._inter_host_bw == other._inter_host_bw
+            and self._intra_host_bw == other._intra_host_bw
+        )
 
 
 class Topology:


### PR DESCRIPTION
Summary:
This diff adds explicit `__hash__` and `__eq__` methods to custom objects in the torchrec planner that previously relied on Python's default object identity-based hashing.


1. **DeviceHardware** (fbcode/torchrec/distributed/planner/types.py):
   - Hash based on rank, storage, and perf fields
   - Equality checks all three fields
2. **BasicCommsBandwidths** (fbcode/torchrec/distributed/planner/types.py):
   - Hash based on inter_host_bw and intra_host_bw
   - Equality checks both bandwidth values

Reviewed By: iamzainhuda

Differential Revision: D85731424


