### PR TITLE
[mem optimization] add inplace_copy_batch_to_gpu in TrainPipeline

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -183,6 +183,7 @@ def runner(
             model: nn.Module,
             pipeline: TrainPipeline,
         ) -> None:
+            pipeline.reset()
             dataloader = iter(bench_inputs)
             while True:
                 try:

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -2,8 +2,9 @@
 # runs on 2 ranks, showing traces with reasonable workloads
 RunOptions:
   world_size: 2
-  num_batches: 5
-  num_benchmarks: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
   sharding_type: table_wise
   profile_dir: "."
   name: "sparse_data_dist_base"
@@ -11,10 +12,10 @@ RunOptions:
 PipelineConfig:
   pipeline: "sparse"
 ModelInputConfig:
-  feature_pooling_avg: 10
+  feature_pooling_avg: 30
 EmbeddingTablesConfig:
-  num_unweighted_features: 100
-  num_weighted_features: 100
+  num_unweighted_features: 90
+  num_weighted_features: 80
   embedding_feature_dim: 256
   additional_tables:
     - - name: FP16_table

--- a/torchrec/distributed/test_utils/pipeline_config.py
+++ b/torchrec/distributed/test_utils/pipeline_config.py
@@ -48,6 +48,7 @@ class PipelineConfig:
 
     pipeline: str = "base"
     emb_lookup_stream: str = "data_dist"
+    inplace_copy_batch_to_gpu: bool = False
     apply_jit: bool = False
 
     def generate_pipeline(
@@ -111,14 +112,24 @@ class PipelineConfig:
                 device=device,
                 emb_lookup_stream=self.emb_lookup_stream,
                 apply_jit=self.apply_jit,
+                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
             )
         elif self.pipeline == "base":
             assert self.apply_jit is False, "JIT is not supported for base pipeline"
 
-            return TrainPipelineBase(model=model, optimizer=opt, device=device)
+            return TrainPipelineBase(
+                model=model,
+                optimizer=opt,
+                device=device,
+                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
+            )
         else:
             Pipeline = _pipeline_cls[self.pipeline]
             # pyre-ignore[28]
             return Pipeline(
-                model=model, optimizer=opt, device=device, apply_jit=self.apply_jit
+                model=model,
+                optimizer=opt,
+                device=device,
+                apply_jit=self.apply_jit,
+                inplace_copy_batch_to_gpu=self.inplace_copy_batch_to_gpu,
             )

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -36,6 +36,7 @@ class EmbeddingTablesConfig:
     num_unweighted_features: int = 100
     num_weighted_features: int = 100
     embedding_feature_dim: int = 128
+    base_row_size: int = 100_000
     table_data_type: DataType = DataType.FP32
     additional_tables: List[List[Dict[str, Any]]] = field(default_factory=list)
 
@@ -71,7 +72,7 @@ class EmbeddingTablesConfig:
         """
         unweighted_tables = [
             EmbeddingBagConfig(
-                num_embeddings=max(i + 1, 100) * 2000,
+                num_embeddings=max(i + 1, 100) * self.base_row_size // 100,
                 embedding_dim=self.embedding_feature_dim,
                 name="table_" + str(i),
                 feature_names=["feature_" + str(i)],
@@ -81,7 +82,7 @@ class EmbeddingTablesConfig:
         ]
         weighted_tables = [
             EmbeddingBagConfig(
-                num_embeddings=max(i + 1, 100) * 2000,
+                num_embeddings=max(i + 1, 100) * self.base_row_size // 100,
                 embedding_dim=self.embedding_feature_dim,
                 name="weighted_table_" + str(i),
                 feature_names=["weighted_feature_" + str(i)],

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -68,11 +68,33 @@ from torchrec.streamable import Multistreamable, Pipelineable
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _to_device(batch: In, device: torch.device, non_blocking: bool) -> In:
+def _to_device(
+    batch: In,
+    device: torch.device,
+    non_blocking: bool,
+    data_copy_stream: Optional[torch.Stream] = None,
+) -> In:
     assert isinstance(
         batch, (torch.Tensor, Pipelineable)
     ), f"{type(batch)} must implement Pipelineable interface"
-    return cast(In, batch.to(device=device, non_blocking=non_blocking))
+    if data_copy_stream is not None:
+        return cast(
+            In,
+            # pyre-ignore[28]
+            batch.to(
+                device=device,
+                non_blocking=non_blocking,
+                data_copy_stream=data_copy_stream,
+            ),
+        )
+    else:
+        return cast(
+            In,
+            batch.to(
+                device=device,
+                non_blocking=non_blocking,
+            ),
+        )
 
 
 def _wait_for_batch(batch: In, stream: Optional[torch.Stream]) -> None:


### PR DESCRIPTION
Summary:
This diff implements support for pre-allocation in-place copy for host-to-device data transfer in TorchRec train pipelines, addressing CUDA memory overhead issues identified in production RecSys models.

https://fb.workplace.com/groups/429376538334034/permalink/1497469664858044/

## Context

As described in the [RFC on Workplace](https://fb.workplace.com/groups/429376538334034/permalink/1497469664858044/), we identified an extra CUDA memory overhead of 3-6 GB per rank on top of the active memory snapshot in most RecSys model training pipelines. This overhead stems from PyTorch's caching allocator behavior when using side CUDA streams for non-blocking host-to-device transfers - the allocator associates transferred tensor memory with the side stream, preventing memory reuse in the main stream and causing up to 13GB extra memory footprint per rank in production models.
<img width="3174" height="1954" alt="image" src="https://github.com/user-attachments/assets/92c1de28-3ad3-4f86-b554-b20b1c980167" />


The solution proposed in [D86068070](https://www.internalfb.com/diff/D86068070) enables pre-allocating memory on the main stream and using in-place copy to reduce this overhead. In local train pipeline benchmarks with 1-GB ModelInput (2 KJTs + float features), this approach reduced memory footprint by ~6 GB per rank. This optimization enables many memory-constrained use cases across platforms including APS, Pyper, and MVAI.

## Key Changes:

1. **Added `inplace_copy_batch_to_gpu` parameter**: New boolean flag throughout the train pipeline infrastructure that enables switching between standard batch copying (direct allocation on side stream) and in-place copying (pre-allocation on main stream).

2. **New `inplace_copy_batch_to_gpu()` method**: Implemented in `TrainPipeline` class to handle the new data transfer pattern with proper stream synchronization, using `_to_device()` with the optional `data_copy_stream` parameter.

3. **Extended `Pipelineable.to()` interface**: Added optional `data_copy_stream` parameter to the abstract method, allowing implementations to specify which stream should execute the data copy operation (see https://github.com/meta-pytorch/torchrec/pull/3510).

4. **Updated benchmark configuration** (`sparse_data_dist_base.yml`):
   - Increased `num_batches` from 5 to 10
   - Changed `feature_pooling_avg` from 10 to 30 
   - Reduced `num_benchmarks` from 2 to 1
   - Added `num_profiles: 1` for profiling

5. **Enhanced table configuration**: Added `base_row_size` parameter (default: 100,000) to `EmbeddingTablesConfig` for more flexible embedding table sizing.

These changes enable performance and memory comparison between standard and in-place copy strategies, with proper benchmarking infrastructure to measure and trace the differences.

Differential Revision: D86208714


