### PR TITLE
disable flasky test in github workflow

### DIFF
--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -395,7 +395,9 @@ class DedupIndicesWeightAccumulationTest(unittest.TestCase):
         not torch.cuda.is_available(),
         "Not enough GPUs, this test requires at least one GPU",
     )
-    def test_dedup_indices_weight_accumulation(self) -> None:
+    def test_dedup_indices_weight_accumulation_disabled_in_oss_compatibility(
+        self,
+    ) -> None:
         """
         Test the _dedup_indices method to ensure weight accumulation works correctly
         with the new scatter_add_along_first_dim implementation.


### PR DESCRIPTION
Summary: Disabled a flaky test in the TorchRec sequence model parallel test suite to prevent intermittent failures in the GitHub workflow CI pipeline. The test was causing unreliable builds and needed to be disabled until the underlying issue can be properly investigated and resolved.

Differential Revision: D86021612


