### PR TITLE
st publish mode only load weight

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -477,6 +477,7 @@ def _populate_zero_collision_tbe_params(
             else False
         )
     )
+
     tbe_params["kv_zch_params"] = KVZCHParams(
         bucket_offsets=bucket_offsets,
         bucket_sizes=bucket_sizes,
@@ -484,6 +485,7 @@ def _populate_zero_collision_tbe_params(
         backend_return_whole_row=(backend_type == BackendType.DRAM),
         eviction_policy=eviction_policy,
         embedding_cache_mode=embedding_cache_mode_,
+        load_ckpt_without_opt=eviction_tbe_config.load_ckpt_without_opt,
     )
 
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -664,6 +664,7 @@ class KeyValueParams:
         enable_raw_embedding_streaming: Optional[bool]: enable raw embedding streaming for SSD TBE
         res_store_shards: Optional[int] = None: the number of shards to store the raw embeddings
         kvzch_tbe_config: Optional[KVZCHTBEConfig]: KVZCH config for TBE
+        load_ckpt_without_opt: bool: whether it is st publish
 
         # Parameter Server (PS) Attributes
         ps_hosts (Optional[Tuple[Tuple[str, int]]]): List of PS host ip addresses
@@ -690,6 +691,7 @@ class KeyValueParams:
     )
     res_store_shards: Optional[int] = None  # shards to store the raw embeddings
     kvzch_tbe_config: Optional[KVZCHTBEConfig] = None
+    load_ckpt_without_opt: bool = False  # is st publish
 
     # Parameter Server (PS) Attributes
     ps_hosts: Optional[Tuple[Tuple[str, int], ...]] = None
@@ -719,6 +721,7 @@ class KeyValueParams:
                 self.enable_raw_embedding_streaming,
                 self.res_store_shards,
                 self.kvzch_tbe_config,
+                self.load_ckpt_without_opt,
             )
         )
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/FBGEMM/pull/2122

For silvertorch publish, we don't want to load opt into backend due to limited cpu memory in publish host.
So we need to load the whole row into state dict which loading the checkpoint in st publish, then only save weight into backend, after that backend will only have metaheader + weight.
For the first loading, we need to set dim with metaheader_dim + emb_dim + optimizer_state_dim, otherwise the checkpoint loadding will throw size mismatch error. after the first loading, we only need to get metaheader+weight from backend for state dict, so we can set dim with metaheader_dim + emb

Differential Revision: D85830053


