### PR TITLE
Update DeltaCheckpointing and DeltaPublish with generic model tracker

### DIFF
--- a/torchrec/distributed/model_tracker/model_delta_tracker.py
+++ b/torchrec/distributed/model_tracker/model_delta_tracker.py
@@ -132,7 +132,6 @@ class ModelDeltaTracker(ABC):
         """
         pass
 
-    @abstractmethod
     def step(self) -> None:
         """
         Advance the batch index for all consumers.

--- a/torchrec/distributed/model_tracker/model_delta_tracker.py
+++ b/torchrec/distributed/model_tracker/model_delta_tracker.py
@@ -94,7 +94,7 @@ class ModelDeltaTracker(ABC):
             kjt (KeyedJaggedTensor): The KeyedJaggedTensor containing IDs to record.
             states (torch.Tensor): The embeddings or states corresponding to the IDs in the kjt.
         """
-        pass
+        ...
 
     @abstractmethod
     def get_unique_ids(self, consumer: Optional[str] = None) -> Dict[str, torch.Tensor]:
@@ -104,7 +104,7 @@ class ModelDeltaTracker(ABC):
         Args:
             consumer (str, optional): The consumer to retrieve unique IDs for.
         """
-        pass
+        ...
 
     @abstractmethod
     def get_unique(
@@ -120,7 +120,7 @@ class ModelDeltaTracker(ABC):
         Args:
             consumer (str, optional): The consumer to retrieve delta values for.
         """
-        pass
+        ...
 
     @abstractmethod
     def clear(self, consumer: Optional[str] = None) -> None:
@@ -130,7 +130,7 @@ class ModelDeltaTracker(ABC):
         Args:
             consumer (str, optional): The consumer to clear IDs/States for.
         """
-        pass
+        ...
 
     def step(self) -> None:
         """

--- a/torchrec/distributed/model_tracker/trackers/raw_id_tracker.py
+++ b/torchrec/distributed/model_tracker/trackers/raw_id_tracker.py
@@ -23,7 +23,7 @@ from torchrec.distributed.mc_embeddingbag import (
     ShardedManagedCollisionEmbeddingBagCollection,
 )
 from torchrec.distributed.mc_modules import ShardedManagedCollisionCollection
-from torchrec.distributed.model_tracker.delta_store import DeltaStoreTrec
+from torchrec.distributed.model_tracker.delta_store import RawIdTrackerStore
 
 from torchrec.distributed.model_tracker.model_delta_tracker import ModelDeltaTracker
 from torchrec.distributed.model_tracker.types import IndexedLookup, UniqueRows
@@ -71,7 +71,7 @@ class RawIdTracker(ModelDeltaTracker):
             c: -1 for c in (self._consumers or [self.DEFAULT_CONSUMER])
         }
 
-        self.store: DeltaStoreTrec = DeltaStoreTrec()
+        self.store: RawIdTrackerStore = RawIdTrackerStore()
 
         # Mapping feature name to corresponding FQNs. This is used for retrieving
         # the FQN associated with a given feature name in record_lookup().
@@ -212,7 +212,6 @@ class RawIdTracker(ModelDeltaTracker):
                 batch_idx=self.curr_batch_idx,
                 fqn=table_fqn,
                 ids=torch.cat(ids_list),
-                states=None,
                 raw_ids=torch.cat(per_table_raw_ids[table_fqn]),
             )
 

--- a/torchrec/distributed/model_tracker/types.py
+++ b/torchrec/distributed/model_tracker/types.py
@@ -23,8 +23,18 @@ class IndexedLookup:
     batch_idx: int
     ids: torch.Tensor
     states: Optional[torch.Tensor]
-    raw_ids: Optional[torch.Tensor] = None
     compact: bool = False
+
+
+@dataclass
+class RawIndexedLookup:
+    r"""
+    Data class for storing per batch lookedup ids and embeddings or optimizer states.
+    """
+
+    batch_idx: int
+    ids: torch.Tensor
+    raw_ids: Optional[torch.Tensor] = None
 
 
 @dataclass


### PR DESCRIPTION
Summary:
internal
Updating DeltaCP and DeltaPublish to with ModelDeltaTracker to allow these functionalities to use either of DeltaTracker implementation

General Context: We are in the process of transition to a unified DeltaTracker and this is 9/n diffs representing  changes towards the transition.

Differential Revision:
D80615817

Privacy Context Container: L1158701


