### PR TITLE
Remove no-op operation in sharded tensor pool

### DIFF
--- a/torchrec/distributed/tensor_pool.py
+++ b/torchrec/distributed/tensor_pool.py
@@ -305,7 +305,6 @@ class LocalShardPool(torch.nn.Module):
     @torch.jit.export
     def set_device(self, device_str: str) -> None:
         self.current_device = torch.device(device_str)
-        self._shard.to(self.current_device)
 
     def forward(self, rank_ids: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
Summary: During implementation for item usharding added a no-op operation by mistake. Since item usharding already updates the device map to correctly move all the parameters of corresponding LocalShardPool to cpu / cuda (depending upon where the shard is located), setting device for shard here is not required. Removing this line to avoid confusion

Differential Revision: D87244659


