### PR TITLE
Cleaner MetricModule interface

### DIFF
--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -104,9 +104,6 @@ class CPUCommsRecMetricModule(RecMetricModule):
         Uses aggregated states.
         """
 
-        # All update() calls were done prior. Clear previous computed state.
-        # Otherwise, we get warnings that compute() was called before
-        # update() which is not the case.
         computation = cast(RecMetricComputation, computation)
         set_update_called(computation)
         computation._computed = None
@@ -155,8 +152,9 @@ class CPUCommsRecMetricModule(RecMetricModule):
 
 def set_update_called(computation: RecMetricComputation) -> None:
     """
-    Set _update_called to True for RecMetricComputation.
-    This is a workaround for torchmetrics 1.0.3+.
+    All update() calls were done prior. Clear previous computed state.
+    Otherwise, we get warnings that compute() was called before
+    update() which is not the case.
     """
     try:
         computation._update_called = True

--- a/torchrec/metrics/metric_job_types.py
+++ b/torchrec/metrics/metric_job_types.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import concurrent
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch
 from torchrec.metrics.metric_module import MetricValue
@@ -26,7 +26,7 @@ class MetricUpdateJob:
     def __init__(
         self,
         model_out: Dict[str, torch.Tensor],
-        transfer_completed_event: torch.cuda.Event,
+        transfer_completed_event: Optional[torch.cuda.Event],
         kwargs: Dict[str, Any],
     ) -> None:
         """
@@ -37,7 +37,9 @@ class MetricUpdateJob:
         """
 
         self.model_out: Dict[str, torch.Tensor] = model_out
-        self.transfer_completed_event: torch.cuda.Event = transfer_completed_event
+        self.transfer_completed_event: Optional[torch.cuda.Event] = (
+            transfer_completed_event
+        )
         self.kwargs: Dict[str, Any] = kwargs
 
 

--- a/torchrec/metrics/metrics_output_util.py
+++ b/torchrec/metrics/metrics_output_util.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Utility functions for handling MetricsOutput (Union[MetricsResult, MetricsFuture]) from
+- RecMetricModule.compute()
+- CPUOffloadedRecMetricModule.async_compute()
+"""
+
+import concurrent
+import logging
+from typing import Callable, TypeVar
+
+from torchrec.metrics.metric_module import (
+    PublishableMetrics,
+    PublishableMetricsFuture,
+    PublishableMetricsOutput,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def update_metrics_output(
+    metrics_output: PublishableMetricsOutput,
+    metrics_update: PublishableMetrics,
+) -> PublishableMetricsOutput:
+    """
+    Updates metrics_output with specified dict.
+
+    Args:
+        metrics_output: Either metrics dict (sync) or Future (async)
+        metrics_update: Dict to update metrics_output with
+
+    Returns:
+        Updated metrics_output
+    """
+
+    if isinstance(metrics_output, concurrent.futures.Future):
+
+        def _update_callback(future: PublishableMetricsFuture) -> None:
+            future.result().update(metrics_update)
+
+        metrics_output.add_done_callback(_update_callback)
+    else:
+        metrics_output.update(metrics_update)
+    return metrics_output
+
+
+def get_metrics_async(
+    metrics_output: PublishableMetricsOutput,
+    callback: Callable[[PublishableMetrics], T],
+    *,
+    on_error: Callable[[Exception], None] | None = None,
+) -> T | None:
+    """
+    Register a callback to execute when metrics are ready.
+
+    Preserves CPUOffloadedRecMetricModule's async benefits by executing callbacks when Future resolves,
+    without blocking the critical training path.
+
+    Args:
+        metrics_output: Either metrics dict (sync from RecMetricModule) or Future (async from CPUOffloadedRecMetricModule)
+        callback: Function to execute with resolved metrics
+        on_error: Optional error handler for exceptions
+
+    Returns:
+        Result of callback if metrics are immediately available (Dict[str, MetricValue]),
+        None if async (Future) - callback will be invoked later
+
+    Example:
+        >>> metrics_output = self.metrics.compute()
+        >>> metrics_result = get_metrics_async(metrics_output, lambda m: publish_metrics(m)) # publish when metrics are ready
+    """
+
+    # Asynchronous path
+    if isinstance(metrics_output, concurrent.futures.Future):
+
+        def on_complete(future: PublishableMetricsFuture) -> None:
+            try:
+                result = future.result()
+                callback(result)
+            except Exception as e:
+                if on_error:
+                    on_error(e)
+                else:
+                    logger.exception("Error in metrics callback")
+                    raise
+
+        metrics_output.add_done_callback(on_complete)
+        return None
+    else:
+        # Synchronous path
+        return callback(metrics_output)
+
+
+def get_metrics_sync(
+    metrics_output: PublishableMetricsOutput,
+) -> PublishableMetrics:
+    """
+    Synchronously resolve PublishableMetricsOutput to PublishableMetrics.
+
+    Use this when you need the actual metrics dict immediately (e.g., to modify it).
+    For async handling, use get_metrics_async() instead.
+
+    Args:
+        metrics_output: Either metrics dict (sync) or Future (async)
+
+    Returns:
+        Resolved metrics dict
+
+    Raises:
+        Exception: Any exception from Future computation
+
+    Example:
+        >>> metrics_output = self.metrics.compute()
+        >>> metrics_result = get_metrics_sync(metrics_output) # wait until metrics are ready
+        >>> publish_metrics(metrics_result)
+    """
+    if isinstance(metrics_output, concurrent.futures.Future):
+        return metrics_output.result()
+    else:
+        return metrics_output

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -7,7 +7,6 @@
 
 # pyre-strict
 
-import concurrent
 import copy
 import dataclasses
 import logging
@@ -27,7 +26,7 @@ from torchrec.distributed.test_utils.multi_process import (
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metric_module import (
     generate_metric_module,
-    MetricValue,
+    MetricsResult,
     RecMetricModule,
     StateMetric,
     StateMetricEnum,
@@ -55,7 +54,7 @@ class MockOptimizer(StateMetric):
     def __init__(self) -> None:
         self.get_metrics_call = 0
 
-    def get_metrics(self) -> Dict[str, MetricValue]:
+    def get_metrics(self) -> MetricsResult:
         self.get_metrics_call += 1
         return {"learning_rate": torch.tensor(1.0)}
 
@@ -849,7 +848,7 @@ class MetricModuleTest(unittest.TestCase):
             RecMetricException,
             "async_compute is not supported in RecMetricModule",
         ):
-            metric_module.async_compute(concurrent.futures.Future())
+            metric_module.async_compute()
 
     def test_load_state_dict_with_trained_batches_key(self) -> None:
         metric_module = generate_metric_module(

--- a/torchrec/metrics/tests/test_metrics_output_util.py
+++ b/torchrec/metrics/tests/test_metrics_output_util.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for metrics_output_util - utilities for handling PublishableMetricsOutput (dict or Future).
+
+These tests focus on our utility functions' behavior, not on testing Python's
+concurrent.futures module which is already well-tested.
+"""
+
+import unittest
+from concurrent.futures import Future
+from typing import Callable
+
+import torch
+from torchrec.metrics.metric_module import PublishableMetrics, PublishableMetricsFuture
+from torchrec.metrics.metrics_output_util import (
+    get_metrics_async,
+    get_metrics_sync,
+    update_metrics_output,
+)
+
+
+class GetMetricsAsyncTest(unittest.TestCase):
+    """Tests that get_metrics_async correctly dispatches between sync/async paths."""
+
+    def setUp(self) -> None:
+        self.metrics: PublishableMetrics = {"loss": torch.tensor(0.5)}
+        self.received_metrics: PublishableMetrics | None = None
+        self.received_error: Exception | None = None
+
+    def _callback(self, metrics: PublishableMetrics) -> None:
+        self.received_metrics = metrics
+
+    def _error_handler(self, error: Exception) -> None:
+        self.received_error = error
+
+    def test_synchronous_dict_path(self) -> None:
+        result = get_metrics_async(self.metrics, self._callback)
+
+        self.assertIsNone(result)
+        self.assertIs(self.received_metrics, self.metrics)
+
+    def test_synchronous_dict_returns_callback_value(self) -> None:
+        result = get_metrics_async(self.metrics, lambda metrics: "success")
+        self.assertEqual(result, "success")
+
+    def test_asynchronous_future_path(self) -> None:
+        future: PublishableMetricsFuture = Future()
+
+        get_metrics_async(future, self._callback)
+        self.assertIsNone(self.received_metrics)
+
+        future.set_result(self.metrics)
+        self.assertEqual(self.received_metrics, self.metrics)
+
+    def test_error_handler_receives_callback_exceptions(self) -> None:
+        """Error handler receives exceptions raised by callbacks."""
+        future: PublishableMetricsFuture = Future()
+
+        def failing_callback(metrics: PublishableMetrics) -> None:
+            raise ValueError("callback failed")
+
+        get_metrics_async(future, failing_callback, on_error=self._error_handler)
+        future.set_result(self.metrics)
+
+        self.assertIsInstance(self.received_error, ValueError)
+
+    def test_error_handler_receives_future_exceptions(self) -> None:
+        """Error handler receives exceptions from Future resolution."""
+        future: PublishableMetricsFuture = Future()
+
+        get_metrics_async(future, self._callback, on_error=self._error_handler)
+        future.set_exception(RuntimeError("computation failed"))
+
+        self.assertIsInstance(self.received_error, RuntimeError)
+
+
+class GetMetricsSyncTest(unittest.TestCase):
+    """Tests that get_metrics_sync correctly handles both dict and Future inputs."""
+
+    def setUp(self) -> None:
+        self.metrics: PublishableMetrics = {"loss": torch.tensor(0.5)}
+
+    def test_dict_returns_immediately(self) -> None:
+        result = get_metrics_sync(self.metrics)
+        self.assertEqual(result, self.metrics)
+
+    def test_future_blocks_until_resolved(self) -> None:
+        future: PublishableMetricsFuture = Future()
+        future.set_result(self.metrics)
+
+        result = get_metrics_sync(future)
+        self.assertEqual(result, self.metrics)
+
+    def test_future_exception_propagates(self) -> None:
+        """Exceptions from Future are propagated to caller."""
+        future: PublishableMetricsFuture = Future()
+        future.set_exception(RuntimeError("failed"))
+
+        with self.assertRaises(RuntimeError):
+            get_metrics_sync(future)
+
+
+class MultipleCallbacksTest(unittest.TestCase):
+    """Tests that multiple callbacks can be attached and all execute correctly."""
+
+    def setUp(self) -> None:
+        self.sample_data: PublishableMetrics = {
+            "metric_a": torch.tensor(1.0),
+            "metric_b": torch.tensor(2.0),
+        }
+        self.callback_executions: dict[str, bool] = {
+            "callback_1": False,
+            "callback_2": False,
+            "callback_3": False,
+        }
+        self.extracted_value: float | None = None
+
+    def _make_tracking_callback(
+        self, name: str
+    ) -> Callable[[PublishableMetrics], None]:
+        """Factory for callbacks that track execution."""
+
+        def callback(metrics: PublishableMetrics) -> None:
+            self.callback_executions[name] = True
+
+        return callback
+
+    def _value_extraction_callback(self, metrics: PublishableMetrics) -> None:
+        """Callback that extracts a value from metrics."""
+        metric = metrics.get("metric_a")
+        if isinstance(metric, torch.Tensor):
+            self.extracted_value = metric.item()
+
+    def test_multiple_callbacks_on_future(self) -> None:
+        """Multiple callbacks attached to same Future all execute when resolved."""
+        future: Future[PublishableMetrics] = Future()
+
+        # Attach multiple callbacks to the same Future
+        get_metrics_async(future, self._make_tracking_callback("callback_1"))
+        get_metrics_async(future, self._make_tracking_callback("callback_2"))
+        get_metrics_async(future, self._make_tracking_callback("callback_3"))
+        get_metrics_async(future, self._value_extraction_callback)
+
+        # Verify no callbacks executed yet
+        self.assertEqual(
+            self.callback_executions,
+            {"callback_1": False, "callback_2": False, "callback_3": False},
+        )
+        self.assertIsNone(self.extracted_value)
+
+        # Resolve the Future
+        future.set_result(self.sample_data)
+
+        # Verify all callbacks executed
+        self.assertEqual(
+            self.callback_executions,
+            {"callback_1": True, "callback_2": True, "callback_3": True},
+        )
+        self.assertIsNotNone(self.extracted_value)
+        self.assertAlmostEqual(self.extracted_value, 1.0, places=5)
+
+    def test_multiple_callbacks_on_dict(self) -> None:
+        """Multiple callbacks with dict input all execute immediately."""
+        get_metrics_async(self.sample_data, self._make_tracking_callback("callback_1"))
+        get_metrics_async(self.sample_data, self._make_tracking_callback("callback_2"))
+        get_metrics_async(self.sample_data, self._value_extraction_callback)
+
+        # Verify all callbacks executed immediately
+        self.assertEqual(
+            self.callback_executions,
+            {"callback_1": True, "callback_2": True, "callback_3": False},
+        )
+        self.assertIsNotNone(self.extracted_value)
+        self.assertAlmostEqual(self.extracted_value, 1.0, places=5)
+
+
+class UpdateMetricsOutputTest(unittest.TestCase):
+    """Tests for update_metrics_output chaining behavior."""
+
+    def test_update_dict_sync(self) -> None:
+        metrics: PublishableMetrics = {"loss": torch.tensor(0.5)}
+
+        result = update_metrics_output(metrics, {"exception": "error"})
+
+        self.assertIs(result, metrics)
+        self.assertIn("exception", metrics)
+        self.assertEqual(metrics["exception"], "error")
+
+    def test_update_future(self) -> None:
+        future: PublishableMetricsFuture = Future()
+        metrics: PublishableMetrics = {"loss": torch.tensor(0.5)}
+
+        result = update_metrics_output(future, {"exception": "error"})
+
+        self.assertIs(result, future)
+        future.set_result(metrics)
+
+        self.assertIn("exception", metrics)
+        self.assertDictEqual(
+            metrics,
+            {
+                "loss": torch.tensor(0.5),
+                "exception": "error",
+            },
+        )
+
+    def test_update_future_then_read(self) -> None:
+        future: PublishableMetricsFuture = Future()
+        metrics: PublishableMetrics = {"loss": torch.tensor(0.5)}
+        captured_metrics: PublishableMetrics | None = None
+
+        # Chain: update first, then read
+        update_metrics_output(future, {"exception": "error"})
+
+        def capture_callback(m: PublishableMetrics) -> None:
+            nonlocal captured_metrics
+            captured_metrics = m
+
+        get_metrics_async(future, capture_callback)
+        future.set_result(metrics)
+
+        self.assertDictEqual(
+            captured_metrics, {"loss": torch.tensor(0.5), "exception": "error"}
+        )


### PR DESCRIPTION
Summary:
Utilities for CPUOffloadedRecMetricModule and RecMetricModule.

Also raise exceptions in the main thread if any of the background threads. Added unit tests.

Simplify the core metric types:
- MetricsResult = Dict[str, MetricValue]: sync metrics computation
- MetricsFuture = concurrent.futures.Future[MetricsResult]: for async computation
- MetricsOutput = Union[MetricsResult, MetricsFuture]: Either a MetricsResult, or a MetricsFuture

Introduce a metrics_output_util to handle the logic between futures and dicts. Users can schedule callbacks via
`on_metrics_ready()`

Differential Revision: D87110900


