### PR TITLE
Fully Sharded 2D Parallelism

### DIFF
--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -68,6 +68,7 @@ class CwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -287,6 +287,7 @@ class CwPooledEmbeddingSharding(
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/dp_sequence_sharding.py
+++ b/torchrec/distributed/sharding/dp_sequence_sharding.py
@@ -80,6 +80,7 @@ class DpSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._env.process_group,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -213,6 +213,7 @@ class DpPooledEmbeddingSharding(
             # For data parallel we need to turn always gradient scaling in for weights
             # because get_gradient_scaling from comm_ops only affects model_parallel tables, not DP
             scale_weight_gradients=False,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -508,6 +508,7 @@ class GridPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.TABLE_ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -157,6 +157,7 @@ class RwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -678,6 +678,7 @@ class RwPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -141,6 +141,7 @@ class TwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -435,6 +435,7 @@ class TwPooledEmbeddingSharding(
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -676,6 +676,7 @@ class TwRwPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.TABLE_ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(


### PR DESCRIPTION
Summary:
**This diff introduces Fully Sharded 2D Parallelism in TorchRec. It brings forth significant memory (50%+) savings by sharding embedding tables when they are not in use.** 

After the embedding lookup, the embedding table is further sharded across the data parallel dimension until it is needed in the backward pass. This allows model layers after the embedding lookup to have more memory headroom. Enabling further scaling of the dense architecture. **Practically speaking, this saves 50%+ embedding memory per GPU which account for upwards of 10GB of memory saving on large models.** 

The peak memory during this step becomes, ```O(shard + shard/num_replication)```, which then leads to an embedding memory of ```O(shard/num_replication)``` after the lookup step.

The memory free and collective communications are done in a overhead free manner by maximizing computation and communication collectives through asynchronous handling on multiple streams. 

With Fully Sharded 2D, the embedding weight synchronization has to happen every step or trained batches are lost across ranks. We use an asynchronous reduce scatter after the embedding lookup step. We are able to fully overlap this collective with compute to expose no additional overhead.

A new awaitable is introduced, ```ReduceScatterResizeAwaitable``` under the Fully Sharded path that is called with SDD output_dist all to all. This awaitable ```wait()```s on the async reduce scatter and calls the ```resize()``` operation on the embedding memory ensuring no race conditions. 

Users can enable fully sharded 2D through, a new arg `ShardingStrategy`
```
DMPCollection(..., sharding_strategy=ShardingStrategy.FULLY_SHARDED)
```

This is part of our work to create an overhead free 2D parallel which will allow us to use it for every model. 

Remaining work from this diff is to launch an async all gather in the backward pass, making planner aware of such memory savings, and integrate this work with per module 2D

Differential Revision: D82253387


