### PR TITLE
Remove psutil dependency

### DIFF
--- a/.github/scripts/install_libs.sh
+++ b/.github/scripts/install_libs.sh
@@ -28,4 +28,4 @@ elif [ "$CHANNEL" = "test" ]; then
 fi
 
 
-${CONDA_RUN} pip install importlib-metadata click PyYAML psutil
+${CONDA_RUN} pip install importlib-metadata click PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ tqdm
 usort
 parameterized
 PyYAML
-psutil
 
 # for tests
 # https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3


### PR DESCRIPTION
Summary: As title, psutil is added in D86171150 to torchrec before because it is used in fbgemm-gpu. But right now psutil is removed in D87183818. So remove the unused dependency.

Differential Revision: D87458831


