### PR TITLE
Back out "Generate 1 acc graph for esr mb5 by removing fx wrapper for kjt"

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -343,6 +343,7 @@ def _construct_jagged_tensors_tw(
     return ret
 
 
+@torch.fx.wrap
 def _fx_marker_construct_jagged_tensor(
     values: torch.Tensor,
     lengths: torch.Tensor,


### PR DESCRIPTION
Summary:
Original commit changeset: 9caa15cb6146

Original Phabricator Diff: D87662877

The IGR ranking ESR publish job failed with lowering exception
https://www.internalfb.com/mlhub/pipelines/runs/mast/fire-mrs_ml_release_oncall-f833327556?job_attempt=0&version=0&tab=logs&env=PRODUCTION&logarithm=%7B%22filters%22%3A%5B%7B%22name%22%3A%22streamId%22%2C%22values%22%3A%5B%22stderr%22%2C%22stdout%22%5D%2C%22match_type%22%3A%22EXACT_MATCH%22%2C%22modifiers%22%3A%7B%22not_match%22%3Afalse%2C%22case_insensitive%22%3Afalse%7D%2C%22combine_type%22%3A%22OR%22%7D%2C%7B%22name%22%3A%22logMessage%22%2C%22values%22%3A%5B%22exception%22%5D%2C%22match_type%22%3A%22SUBSTRING_MATCH%22%2C%22modifiers%22%3A%7B%22not_match%22%3Afalse%2C%22case_insensitive%22%3Atrue%7D%2C%22combine_type%22%3A%22AND%22%7D%5D%7D
 {F1983753744}

Reviewed By: yingufan, yixin94

Differential Revision: D87747630


