### PR TITLE
Enable NCCL Debug info on tests

### DIFF
--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -117,6 +117,7 @@ class MultiProcessTestBase(unittest.TestCase):
         os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
+        os.environ["NCCL_DEBUG"] = "INFO"
 
         torch.use_deterministic_algorithms(True)
         if torch.cuda.is_available():


### PR DESCRIPTION
Summary: Hoping to get sandcastle debug results for all tests with this change to debug flaky test failures

Differential Revision: D87943452


