### PR TITLE
add base pipeline light

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -247,7 +247,9 @@ def run_pipeline(
         short_name=benchmark_res_per_rank[0].short_name,
         gpu_elapsed_time=benchmark_res_per_rank[0].gpu_elapsed_time,
         cpu_elapsed_time=benchmark_res_per_rank[0].cpu_elapsed_time,
-        gpu_mem_stats=[GPUMemoryStats(rank, 0, 0, 0) for rank in range(world_size)],
+        gpu_mem_stats=[
+            GPUMemoryStats(rank, 0, 0, 0, 0, 0) for rank in range(world_size)
+        ],
         cpu_mem_stats=[CPUMemoryStats(rank, 0) for rank in range(world_size)],
         rank=0,
     )

--- a/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
+++ b/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
@@ -1,0 +1,39 @@
+# this is a very basic sparse data dist config
+# runs on 2 ranks, showing traces with reasonable workloads
+RunOptions:
+  world_size: 2
+  num_batches: 10
+  num_benchmarks: 1
+  num_profiles: 1
+  sharding_type: table_wise
+  profile_dir: "."
+  name: "base_pipeline_light"
+  # export_stacks: True # enable this to export stack traces
+  loglevel: "info"
+PipelineConfig:
+  pipeline: "base"
+ModelInputConfig:
+  feature_pooling_avg: 10
+EmbeddingTablesConfig:
+  num_unweighted_features: 20
+  num_weighted_features: 20
+  embedding_feature_dim: 256
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 512
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+      - name: large_table
+        embedding_dim: 2048
+        num_embeddings: 1_000_000
+        feature_names: ["additional_0_1"]
+    - []
+    - - name: skipped_table
+        embedding_dim: 128
+        num_embeddings: 100_000
+        feature_names: ["additional_2_1"]
+PlannerConfig:
+  additional_constraints:
+    large_table:
+      sharding_types: [column_wise]


### PR DESCRIPTION
Summary:
# context
* create a light weighted base-pipeline example
* modify the `GPUMemoryStats` to include `free` and `total` CUDA memory info.
* trace
<img width="2510" height="1208" alt="image" src="https://github.com/user-attachments/assets/34565165-0d45-49b3-9602-fb89080bd2d3" />
* snapshot
<img width="3414" height="1392" alt="image" src="https://github.com/user-attachments/assets/a19a9d06-f1cc-43ca-858d-f0fae5c89249" />

|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|-------------------------------------|--|--|--|--|--|--|--|
|base_pipeline_light                |2067.63 ms       |1916.18 ms       |11.84 GB                |17.32 GB                   |18.32 GB          |0.0 / 0.0 / 0.0              |4.10 GB           |
|sparse_data_dist_light             |1870.40 ms       |1809.62 ms       |12.47 GB                |18.24 GB                   |19.24 GB          |0.0 / 0.0 / 0.0              |4.11 GB           |
|sparse_data_dist_base              |8377.98 ms       |8118.92 ms       |35.94 GB                   |57.06 GB                      |58.11 GB             |0.0 / 0.0 / 0.0              |29.68 GB          |

* memory debugger
```
#####################################################################################################################################################################################################################################################################################################
#                                                                                                                                                                    --- Planner Statistics ---                                                                                                                                                                     #
#                                                                                                                                             --- Evaluated 1 proposal(s), found 1 possible plan(s), ran for 0.11s ---                                                                                                                                              #
# ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #
#      Rank      HBM (GB)     DDR (GB)                     Perf (ms)     Input (MB)     Output (MB)         Shards                                                                                                                                                                                                                                                  #
#    ------    ----------   ----------                   -----------   ------------   -------------       --------                                                                                                                                                                                                                                                  #
#         0    5.85 (22%)     0.0 (0%)   0.27 (0.05,0.04,0.1,0.04,0)           0.23            25.0   CW: 8 TW: 21                                                                                                                                                                                                                                                  #
#         1   5.754 (21%)     0.0 (0%)   0.26 (0.05,0.04,0.1,0.04,0)           0.22            24.0   CW: 8 TW: 20                                                                                                                                                                                                                                                  #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Perf: Total perf (Forward compute, Forward comms, Backward compute, Backward comms, Prefetch compute)                                                                                                                                                                                                                                                             #
# Input: MB/iteration, Output: MB/iteration, Shards: number of tables                                                                                                                                                                                                                                                                                               #
# HBM: estimated peak memory usage for shards, dense tensors, and features (KJT)                                                                                                                                                                                                                                                                                    #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Parameter Info:                                                                                                                                                                                                                                                                                                                                                   #
#                                      FQN     Sharding     Compute Kernel                           Perf (ms)     Storage (HBM, DDR)     Cache Load Factor     Sum Pooling Factor     Sum Num Poolings     Num Indices     Output     Weighted                         Sharder     Features     Emb Dim (CW Dim)     Hash Size                             Ranks   #
#                                    -----   ----------   ----------------                         -----------   --------------------   -------------------   --------------------   ------------------   -------------   --------   ----------                       ---------   ----------   ------------------   -----------                           -------   #
#     sparse.weighted_ebc.weighted_table_0           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_1           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_2           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_3           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_4           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_5           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_6           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_7           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#     sparse.weighted_ebc.weighted_table_8           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#     sparse.weighted_ebc.weighted_table_9           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_10           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_11           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_12           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_13           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_14           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_15           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_16           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_17           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#    sparse.weighted_ebc.weighted_table_18           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#    sparse.weighted_ebc.weighted_table_19           TW              fused   0.012 (0.002,0.002,0.007,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled     weighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_0           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_1           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_2           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_3           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_4           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_5           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_6           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_7           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                       sparse.ebc.table_8           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                       sparse.ebc.table_9           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_10           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_11           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_12           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_13           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_14           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_15           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_16           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_17           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                      sparse.ebc.table_18           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 0   #
#                      sparse.ebc.table_19           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  256        100000                                 1   #
#                    sparse.ebc.FP16_table           TW              fused    0.01 (0.002,0.002,0.004,0.002,0)     (0.096 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1                  512        100000                                 0   #
#                   sparse.ebc.large_table           CW              fused       0.079 (0.02,0.01,0.04,0.01,0)     (7.637 GB, 0.0 GB)                  None                    1.0                  1.0             1.0     pooled   unweighted   EmbeddingBagCollectionSharder            1           2048 (128)       1000000   0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1   #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Batch Size: 512                                                                                                                                                                                                                                                                                                                                                   #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Compute Kernels Count:                                                                                                                                                                                                                                                                                                                                            #
#    fused: 42                                                                                                                                                                                                                                                                                                                                                      #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Compute Kernels Storage:                                                                                                                                                                                                                                                                                                                                          #
#    fused: HBM: 11.588 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                             #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Total Perf Imbalance Statistics                                                                                                                                                                                                                                                                                                                                   #
# Total Variation: 0.009                                                                                                                                                                                                                                                                                                                                            #
# Total Distance: 0.019                                                                                                                                                                                                                                                                                                                                             #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                             #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                              #
#                                                                                                                                                                                                                                                                                                                                                                   #
# HBM Imbalance Statistics                                                                                                                                                                                                                                                                                                                                          #
# Total Variation: 0.004                                                                                                                                                                                                                                                                                                                                            #
# Total Distance: 0.008                                                                                                                                                                                                                                                                                                                                             #
# Chi Divergence: 0.000                                                                                                                                                                                                                                                                                                                                             #
# KL Divergence: 0.000                                                                                                                                                                                                                                                                                                                                              #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Imbalance stats range 0-1, higher means more imbalanced                                                                                                                                                                                                                                                                                                           #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Maximum of Total Perf: 0.27 ms on rank 0                                                                                                                                                                                                                                                                                                                          #
# Mean Total Perf: 0.265 ms                                                                                                                                                                                                                                                                                                                                         #
# Max Total Perf is 1.85% greater than the mean                                                                                                                                                                                                                                                                                                                     #
# Maximum of Forward Compute: 0.055 ms on rank 0                                                                                                                                                                                                                                                                                                                    #
# Maximum of Forward Comms: 0.041 ms on rank 0                                                                                                                                                                                                                                                                                                                      #
# Maximum of Backward Compute: 0.134 ms on rank 0                                                                                                                                                                                                                                                                                                                   #
# Maximum of Backward Comms: 0.041 ms on rank 0                                                                                                                                                                                                                                                                                                                     #
# Maximum of Prefetch Compute: 0.0 ms on ranks 0-1                                                                                                                                                                                                                                                                                                                  #
# Sum of Maxima: 0.27 ms                                                                                                                                                                                                                                                                                                                                            #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Estimated Sharding Distribution                                                                                                                                                                                                                                                                                                                                    #
# Sparse only Max HBM: 5.842 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
# Sparse only Min HBM: 5.746 GB on rank [1]                                                                                                                                                                                                                                                                                                                         #
# Max HBM: 5.85 GB on rank [0]                                                                                                                                                                                                                                                                                                                                      #
# Min HBM: 5.754 GB on rank [1]                                                                                                                                                                                                                                                                                                                                     #
# Mean HBM: 5.802 GB on rank []                                                                                                                                                                                                                                                                                                                                     #
# Low Median HBM: 5.754 GB on rank [1]                                                                                                                                                                                                                                                                                                                              #
# High Median HBM: 5.85 GB on rank [0]                                                                                                                                                                                                                                                                                                                              #
# Critical Path (comms): 0.081                                                                                                                                                                                                                                                                                                                                      #
# Critical Path (compute): 0.188                                                                                                                                                                                                                                                                                                                                    #
# Critical Path (comms + compute): 0.27                                                                                                                                                                                                                                                                                                                             #
# Max HBM is 0.83% greater than the mean                                                                                                                                                                                                                                                                                                                            #
#                                                                                                                                                                                                                                                                                                                                                                   #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Top HBM Memory Usage Estimation: 5.85 GB                                                                                                                                                                                                                                                                                                                          #
# Top Tier #2 Estimated Peak HBM Pressure: 5.754 GB on rank 0                                                                                                                                                                                                                                                                                                       #
# Top Tier #1 Estimated Peak HBM Pressure: 5.85 GB on rank 0                                                                                                                                                                                                                                                                                                        #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Reserved Memory:                                                                                                                                                                                                                                                                                                                                                  #
#    HBM: 4.8 GB                                                                                                                                                                                                                                                                                                                                                    #
#    Percent of Total HBM: 15%                                                                                                                                                                                                                                                                                                                                      #
# Planning Memory:                                                                                                                                                                                                                                                                                                                                                  #
#    HBM: 27.2 GB, DDR: 128.0 GB                                                                                                                                                                                                                                                                                                                                    #
#    Percent of Total HBM: 85%                                                                                                                                                                                                                                                                                                                                      #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Dense Storage (per rank):                                                                                                                                                                                                                                                                                                                                         #
#    HBM: 0.005 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                                     #
#                                                                                                                                                                                                                                                                                                                                                                   #
# KJT Storage (per rank):                                                                                                                                                                                                                                                                                                                                           #
#    HBM: 0.003 GB, DDR: 0.0 GB                                                                                                                                                                                                                                                                                                                                     #
#                                                                                                                                                                                                                                                                                                                                                                   #
# Top 5 Tables Causing Max Perf:                                                                                                                                                                                                                                                                                                                                    #
#    weighted_table_0                                                                                                                                                                                                                                                                                                                                               #
#    weighted_table_2                                                                                                                                                                                                                                                                                                                                               #
#    weighted_table_4                                                                                                                                                                                                                                                                                                                                               #
#    weighted_table_6                                                                                                                                                                                                                                                                                                                                               #
#    weighted_table_8                                                                                                                                                                                                                                                                                                                                               #
# Top 5 Tables Causing Max HBM:                                                                                                                                                                                                                                                                                                                                     #
#    large_table: 0.477 GB on ranks [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]                                                                                                                                                                                                                                                                                #
#    weighted_table_0: 0.096 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
#    weighted_table_2: 0.096 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
#    weighted_table_4: 0.096 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
#    weighted_table_6: 0.096 GB on rank [0]                                                                                                                                                                                                                                                                                                                         #
#####################################################################################################################################################################################################################################################################################################################################################################

# 1. a debugger with cuda.mem_get_info introduces ~436 MB GPU memory overhead
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              91W / 330W |    436MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   40C    P0              90W / 330W |    436MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA PG509-210               On  | 00000000:48:00.0 Off |                    0 |
| N/A   36C    P0              87W / 330W |    436MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=     0mb, reserved=     0mb, free= 80613mb, total= 81050mb, used=   437mb main::283
GPUMemoryStats: Rank 1: retries=0, allocated=     0mb, reserved=     0mb, free= 80613mb, total= 81050mb, used=   437mb main::283
GPUMemoryStats: Rank 2: retries=0, allocated=     0mb, reserved=     0mb, free= 80613mb, total= 81050mb, used=   437mb main::283
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
|    1   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
|    2   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
+---------------------------------------------------------------------------------------+

# 2. a debugger in a subprocess introduces another ~436 MB GPU memory overhead
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |    869MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   41C    P0              91W / 330W |    869MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=     0mb, reserved=     0mb, free= 80181mb, total= 81050mb, used=   869mb runner::133
GPUMemoryStats: Rank 1: retries=0, allocated=     0mb, reserved=     0mb, free= 80181mb, total= 81050mb, used=   869mb runner::133
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
|    0   N/A  N/A   1942334      C   ...form-runtime#python#py_version_3_10      426MiB |
|    1   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
|    1   N/A  N/A   1942336      C   ...form-runtime#python#py_version_3_10      426MiB |
|    2   N/A  N/A   1861604      C   ...form-runtime#python#py_version_3_10      426MiB |
+---------------------------------------------------------------------------------------+



# 2. (restarted)
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   37C    P0              90W / 330W |    436MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   40C    P0              90W / 330W |    436MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=     0mb, reserved=     0mb, free= 80613mb, total= 81050mb, used=   437mb runner::133
GPUMemoryStats: Rank 1: retries=0, allocated=     0mb, reserved=     0mb, free= 80613mb, total= 81050mb, used=   437mb runner::133
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10      426MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10      426MiB |
+---------------------------------------------------------------------------------------+



# 3. a debugger has HBM overhead?
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |    790MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   41C    P0              91W / 330W |    790MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=     0mb, reserved=     2mb, free= 80259mb, total= 81050mb, used=   791mb model_config::285
GPUMemoryStats: Rank 1: retries=0, allocated=     0mb, reserved=     2mb, free= 80259mb, total= 81050mb, used=   791mb model_config::285
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10      778MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10      778MiB |
+---------------------------------------------------------------------------------------+



# 4. init embedding tables on devices
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              91W / 330W |   6752MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |   6654MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=  5959mb, reserved=  5964mb, free= 74297mb, total= 81050mb, used=  6753mb model_config::295
GPUMemoryStats: Rank 1: retries=0, allocated=  5861mb, reserved=  5866mb, free= 74395mb, total= 81050mb, used=  6655mb model_config::295
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10     6740MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10     6642MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.allocated', 5959), ('active_bytes.all.current', 5959), ('active_bytes.all.peak', 5959), ('active_bytes.large_pool.allocated', 5957), ('active_bytes.large_pool.current', 5957), ('active_bytes.large_pool.peak', 5957), ('allocated_bytes.all.allocated', 5959), ('allocated_bytes.all.current', 5959), ('allocated_bytes.all.peak', 5959), ('allocated_bytes.large_pool.allocated', 5957), ('allocated_bytes.large_pool.current', 5957), ('allocated_bytes.large_pool.peak', 5957), ('requested_bytes.all.allocated', 5959), ('requested_bytes.all.current', 5958), ('requested_bytes.all.peak', 5958), ('requested_bytes.large_pool.allocated', 5957), ('requested_bytes.large_pool.current', 5957), ('requested_bytes.large_pool.peak', 5957), ('reserved_bytes.all.allocated', 5964), ('reserved_bytes.all.current', 5964), ('reserved_bytes.all.peak', 5964), ('reserved_bytes.large_pool.allocated', 5962), ('reserved_bytes.large_pool.current', 5962), ('reserved_bytes.large_pool.peak', 5962)]
[('active_bytes.all.allocated', 5861), ('active_bytes.all.current', 5861), ('active_bytes.all.peak', 5861), ('active_bytes.large_pool.allocated', 5859), ('active_bytes.large_pool.current', 5859), ('active_bytes.large_pool.peak', 5859), ('allocated_bytes.all.allocated', 5861), ('allocated_bytes.all.current', 5861), ('allocated_bytes.all.peak', 5861), ('allocated_bytes.large_pool.allocated', 5859), ('allocated_bytes.large_pool.current', 5859), ('allocated_bytes.large_pool.peak', 5859), ('requested_bytes.all.allocated', 5861), ('requested_bytes.all.current', 5860), ('requested_bytes.all.peak', 5860), ('requested_bytes.large_pool.allocated', 5859), ('requested_bytes.large_pool.current', 5859), ('requested_bytes.large_pool.peak', 5859), ('reserved_bytes.all.allocated', 5866), ('reserved_bytes.all.current', 5866), ('reserved_bytes.all.peak', 5866), ('reserved_bytes.large_pool.allocated', 5864), ('reserved_bytes.large_pool.current', 5864), ('reserved_bytes.large_pool.peak', 5864)]



# 5. pipeline read to train (nothing changed)
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |   6752MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |   6654MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=  5959mb, reserved=  5964mb, free= 74297mb, total= 81050mb, used=  6753mb runner::205
GPUMemoryStats: Rank 1: retries=0, allocated=  5861mb, reserved=  5866mb, free= 74395mb, total= 81050mb, used=  6655mb runner::205
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10     6740MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10     6642MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.allocated', 5959), ('active_bytes.all.current', 5959), ('active_bytes.all.peak', 5959), ('active_bytes.large_pool.allocated', 5957), ('active_bytes.large_pool.current', 5957), ('active_bytes.large_pool.peak', 5957), ('allocated_bytes.all.allocated', 5959), ('allocated_bytes.all.current', 5959), ('allocated_bytes.all.peak', 5959), ('allocated_bytes.large_pool.allocated', 5957), ('allocated_bytes.large_pool.current', 5957), ('allocated_bytes.large_pool.peak', 5957), ('requested_bytes.all.allocated', 5959), ('requested_bytes.all.current', 5958), ('requested_bytes.all.peak', 5958), ('requested_bytes.large_pool.allocated', 5957), ('requested_bytes.large_pool.current', 5957), ('requested_bytes.large_pool.peak', 5957), ('reserved_bytes.all.allocated', 5964), ('reserved_bytes.all.current', 5964), ('reserved_bytes.all.peak', 5964), ('reserved_bytes.large_pool.allocated', 5962), ('reserved_bytes.large_pool.current', 5962), ('reserved_bytes.large_pool.peak', 5962)]
[('active_bytes.all.allocated', 5861), ('active_bytes.all.current', 5861), ('active_bytes.all.peak', 5861), ('active_bytes.large_pool.allocated', 5859), ('active_bytes.large_pool.current', 5859), ('active_bytes.large_pool.peak', 5859), ('allocated_bytes.all.allocated', 5861), ('allocated_bytes.all.current', 5861), ('allocated_bytes.all.peak', 5861), ('allocated_bytes.large_pool.allocated', 5859), ('allocated_bytes.large_pool.current', 5859), ('allocated_bytes.large_pool.peak', 5859), ('requested_bytes.all.allocated', 5861), ('requested_bytes.all.current', 5860), ('requested_bytes.all.peak', 5860), ('requested_bytes.large_pool.allocated', 5859), ('requested_bytes.large_pool.current', 5859), ('requested_bytes.large_pool.peak', 5859), ('reserved_bytes.all.allocated', 5866), ('reserved_bytes.all.current', 5866), ('reserved_bytes.all.peak', 5866), ('reserved_bytes.large_pool.allocated', 5864), ('reserved_bytes.large_pool.current', 5864), ('reserved_bytes.large_pool.peak', 5864)]



# 6. start benchmark (nothing changed)
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              91W / 330W |   6752MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |   6654MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=  5959mb, reserved=  5964mb, free= 74297mb, total= 81050mb, used=  6753mb benchmark_core::712
GPUMemoryStats: Rank 1: retries=0, allocated=  5861mb, reserved=  5866mb, free= 74395mb, total= 81050mb, used=  6655mb benchmark_core::712
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10     6740MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10     6642MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.allocated', 5959), ('active_bytes.all.current', 5959), ('active_bytes.all.peak', 5959), ('active_bytes.large_pool.allocated', 5957), ('active_bytes.large_pool.current', 5957), ('active_bytes.large_pool.peak', 5957), ('allocated_bytes.all.allocated', 5959), ('allocated_bytes.all.current', 5959), ('allocated_bytes.all.peak', 5959), ('allocated_bytes.large_pool.allocated', 5957), ('allocated_bytes.large_pool.current', 5957), ('allocated_bytes.large_pool.peak', 5957), ('requested_bytes.all.allocated', 5959), ('requested_bytes.all.current', 5958), ('requested_bytes.all.peak', 5958), ('requested_bytes.large_pool.allocated', 5957), ('requested_bytes.large_pool.current', 5957), ('requested_bytes.large_pool.peak', 5957), ('reserved_bytes.all.allocated', 5964), ('reserved_bytes.all.current', 5964), ('reserved_bytes.all.peak', 5964), ('reserved_bytes.large_pool.allocated', 5962), ('reserved_bytes.large_pool.current', 5962), ('reserved_bytes.large_pool.peak', 5962)]
[('active_bytes.all.allocated', 5861), ('active_bytes.all.current', 5861), ('active_bytes.all.peak', 5861), ('active_bytes.large_pool.allocated', 5859), ('active_bytes.large_pool.current', 5859), ('active_bytes.large_pool.peak', 5859), ('allocated_bytes.all.allocated', 5861), ('allocated_bytes.all.current', 5861), ('allocated_bytes.all.peak', 5861), ('allocated_bytes.large_pool.allocated', 5859), ('allocated_bytes.large_pool.current', 5859), ('allocated_bytes.large_pool.peak', 5859), ('requested_bytes.all.allocated', 5861), ('requested_bytes.all.current', 5860), ('requested_bytes.all.peak', 5860), ('requested_bytes.large_pool.allocated', 5859), ('requested_bytes.large_pool.current', 5859), ('requested_bytes.large_pool.peak', 5859), ('reserved_bytes.all.allocated', 5866), ('reserved_bytes.all.current', 5866), ('reserved_bytes.all.peak', 5866), ('reserved_bytes.large_pool.allocated', 5864), ('reserved_bytes.large_pool.current', 5864), ('reserved_bytes.large_pool.peak', 5864)]



# 7. _reset_memory_stats (some stats are cleared)
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              91W / 330W |   6752MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |   6654MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated=  5959mb, reserved=  5964mb, free= 74297mb, total= 81050mb, used=  6753mb benchmark_core::715
GPUMemoryStats: Rank 1: retries=0, allocated=  5861mb, reserved=  5866mb, free= 74395mb, total= 81050mb, used=  6655mb benchmark_core::715
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10     6740MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10     6642MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.current', 5959), ('active_bytes.all.peak', 5959), ('active_bytes.large_pool.current', 5957), ('active_bytes.large_pool.peak', 5957), ('allocated_bytes.all.current', 5959), ('allocated_bytes.all.peak', 5959), ('allocated_bytes.large_pool.current', 5957), ('allocated_bytes.large_pool.peak', 5957), ('requested_bytes.all.current', 5958), ('requested_bytes.all.peak', 5958), ('requested_bytes.large_pool.current', 5957), ('requested_bytes.large_pool.peak', 5957), ('reserved_bytes.all.current', 5964), ('reserved_bytes.all.peak', 5964), ('reserved_bytes.large_pool.current', 5962), ('reserved_bytes.large_pool.peak', 5962)]
[('active_bytes.all.current', 5861), ('active_bytes.all.peak', 5861), ('active_bytes.large_pool.current', 5859), ('active_bytes.large_pool.peak', 5859), ('allocated_bytes.all.current', 5861), ('allocated_bytes.all.peak', 5861), ('allocated_bytes.large_pool.current', 5859), ('allocated_bytes.large_pool.peak', 5859), ('requested_bytes.all.current', 5860), ('requested_bytes.all.peak', 5860), ('requested_bytes.large_pool.current', 5859), ('requested_bytes.large_pool.peak', 5859), ('reserved_bytes.all.current', 5866), ('reserved_bytes.all.peak', 5866), ('reserved_bytes.large_pool.current', 5864), ('reserved_bytes.large_pool.peak', 5864)]



# 8. benchmark runs
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |  18268MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |  18146MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated= 11842mb, reserved= 17272mb, free= 62781mb, total= 81050mb, used= 18269mb benchmark_core::796
GPUMemoryStats: Rank 1: retries=0, allocated= 11739mb, reserved= 17150mb, free= 62903mb, total= 81050mb, used= 18147mb benchmark_core::796
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10    18256MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10    18134MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.allocated', 276351), ('active_bytes.all.current', 6312), ('active_bytes.all.freed', 275997), ('active_bytes.all.peak', 11842), ('active_bytes.large_pool.allocated', 276294), ('active_bytes.large_pool.current', 6309), ('active_bytes.large_pool.freed', 275942), ('active_bytes.large_pool.peak', 11838), ('allocated_bytes.all.allocated', 276351), ('allocated_bytes.all.current', 6176), ('allocated_bytes.all.freed', 276134), ('allocated_bytes.all.peak', 11842), ('allocated_bytes.large_pool.allocated', 276294), ('allocated_bytes.large_pool.current', 6173), ('allocated_bytes.large_pool.freed', 276078), ('allocated_bytes.large_pool.peak', 11838), ('inactive_split_bytes.all.allocated', 64432), ('inactive_split_bytes.all.current', 791), ('inactive_split_bytes.all.freed', 63646), ('inactive_split_bytes.all.peak', 1526), ('inactive_split_bytes.large_pool.allocated', 64345), ('inactive_split_bytes.large_pool.current', 788), ('inactive_split_bytes.large_pool.freed', 63562), ('inactive_split_bytes.large_pool.peak', 1522), ('requested_bytes.all.allocated', 276239), ('requested_bytes.all.current', 6311), ('requested_bytes.all.freed', 275886), ('requested_bytes.all.peak', 11839), ('requested_bytes.large_pool.allocated', 276182), ('requested_bytes.large_pool.current', 6308), ('requested_bytes.large_pool.freed', 275831), ('requested_bytes.large_pool.peak', 11835), ('reserved_bytes.all.allocated', 11308), ('reserved_bytes.all.current', 17272), ('reserved_bytes.all.peak', 17272), ('reserved_bytes.large_pool.allocated', 11300), ('reserved_bytes.large_pool.current', 17262), ('reserved_bytes.large_pool.peak', 17262)]
[('active_bytes.all.allocated', 256671), ('active_bytes.all.current', 6209), ('active_bytes.all.freed', 256323), ('active_bytes.all.peak', 11739), ('active_bytes.large_pool.allocated', 256619), ('active_bytes.large_pool.current', 6206), ('active_bytes.large_pool.freed', 256272), ('active_bytes.large_pool.peak', 11736), ('allocated_bytes.all.allocated', 256671), ('allocated_bytes.all.current', 6073), ('allocated_bytes.all.freed', 256459), ('allocated_bytes.all.peak', 11739), ('allocated_bytes.large_pool.allocated', 256619), ('allocated_bytes.large_pool.current', 6070), ('allocated_bytes.large_pool.freed', 256408), ('allocated_bytes.large_pool.peak', 11736), ('inactive_split_bytes.all.allocated', 88041), ('inactive_split_bytes.all.current', 312), ('inactive_split_bytes.all.freed', 87734), ('inactive_split_bytes.all.peak', 2585), ('inactive_split_bytes.large_pool.allocated', 87968), ('inactive_split_bytes.large_pool.current', 309), ('inactive_split_bytes.large_pool.freed', 87664), ('inactive_split_bytes.large_pool.peak', 2580), ('requested_bytes.all.allocated', 256548), ('requested_bytes.all.current', 6208), ('requested_bytes.all.freed', 256201), ('requested_bytes.all.peak', 11737), ('requested_bytes.large_pool.allocated', 256496), ('requested_bytes.large_pool.current', 6205), ('requested_bytes.large_pool.freed', 256150), ('requested_bytes.large_pool.peak', 11733), ('reserved_bytes.all.allocated', 11284), ('reserved_bytes.all.current', 17150), ('reserved_bytes.all.peak', 17150), ('reserved_bytes.large_pool.allocated', 11278), ('reserved_bytes.large_pool.current', 17142), ('reserved_bytes.large_pool.peak', 17142)]



# 9. clear cache on rank 0
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |   7898MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   41C    P0              91W / 330W |  18146MiB / 81920MiB |    100%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated= 11842mb, reserved= 17272mb, free= 73151mb, total= 81050mb, used=  7899mb benchmark_core::821
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10     7886MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10    18134MiB |
+---------------------------------------------------------------------------------------+



# 9. snapshot runs
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA PG509-210               On  | 00000000:11:00.0 Off |                    0 |
| N/A   39C    P0              92W / 330W |  18174MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA PG509-210               On  | 00000000:12:00.0 Off |                    0 |
| N/A   42C    P0              91W / 330W |  18146MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
GPUMemoryStats: Rank 0: retries=0, allocated= 11842mb, reserved= 17272mb, free= 62875mb, total= 81050mb, used= 18175mb benchmark_core::853
GPUMemoryStats: Rank 1: retries=0, allocated= 11739mb, reserved= 17150mb, free= 62903mb, total= 81050mb, used= 18147mb benchmark_core::853
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2205190      C   ...form-runtime#python#py_version_3_10    18162MiB |
|    1   N/A  N/A   2205189      C   ...form-runtime#python#py_version_3_10    18134MiB |
+---------------------------------------------------------------------------------------+
[('active_bytes.all.allocated', 552632), ('active_bytes.all.current', 6313), ('active_bytes.all.freed', 552277), ('active_bytes.all.peak', 11842), ('active_bytes.large_pool.allocated', 552520), ('active_bytes.large_pool.current', 6310), ('active_bytes.large_pool.freed', 552167), ('active_bytes.large_pool.peak', 11838), ('active_bytes.small_pool.allocated', 112), ('active_bytes.small_pool.freed', 110), ('allocated_bytes.all.allocated', 552632), ('allocated_bytes.all.current', 6177), ('allocated_bytes.all.freed', 552414), ('allocated_bytes.all.peak', 11842), ('allocated_bytes.large_pool.allocated', 552520), ('allocated_bytes.large_pool.current', 6174), ('allocated_bytes.large_pool.freed', 552303), ('allocated_bytes.large_pool.peak', 11838), ('allocated_bytes.small_pool.allocated', 112), ('allocated_bytes.small_pool.freed', 110), ('inactive_split_bytes.all.allocated', 130050), ('inactive_split_bytes.all.current', 1248), ('inactive_split_bytes.all.freed', 128807), ('inactive_split_bytes.all.peak', 1565), ('inactive_split_bytes.large_pool.allocated', 129879), ('inactive_split_bytes.large_pool.current', 1245), ('inactive_split_bytes.large_pool.freed', 128639), ('inactive_split_bytes.large_pool.peak', 1562), ('inactive_split_bytes.small_pool.allocated', 170), ('inactive_split_bytes.small_pool.freed', 168), ('requested_bytes.all.allocated', 552413), ('requested_bytes.all.current', 6311), ('requested_bytes.all.freed', 552060), ('requested_bytes.all.peak', 11839), ('requested_bytes.large_pool.allocated', 552301), ('requested_bytes.large_pool.current', 6308), ('requested_bytes.large_pool.freed', 551950), ('requested_bytes.large_pool.peak', 11835), ('requested_bytes.small_pool.allocated', 111), ('requested_bytes.small_pool.freed', 109), ('reserved_bytes.all.allocated', 21584), ('reserved_bytes.all.current', 17178), ('reserved_bytes.all.freed', 10370), ('reserved_bytes.all.peak', 17272), ('reserved_bytes.large_pool.allocated', 21570), ('reserved_bytes.large_pool.current', 17168), ('reserved_bytes.large_pool.freed', 10364), ('reserved_bytes.large_pool.peak', 17262)]
[('active_bytes.all.allocated', 513276), ('active_bytes.all.current', 6210), ('active_bytes.all.freed', 512926), ('active_bytes.all.peak', 11739), ('active_bytes.large_pool.allocated', 513174), ('active_bytes.large_pool.current', 6207), ('active_bytes.large_pool.freed', 512825), ('active_bytes.large_pool.peak', 11736), ('active_bytes.small_pool.allocated', 101), ('active_bytes.small_pool.freed', 100), ('allocated_bytes.all.allocated', 513276), ('allocated_bytes.all.current', 6074), ('allocated_bytes.all.freed', 513063), ('allocated_bytes.all.peak', 11739), ('allocated_bytes.large_pool.allocated', 513174), ('allocated_bytes.large_pool.current', 6071), ('allocated_bytes.large_pool.freed', 512962), ('allocated_bytes.large_pool.peak', 11736), ('allocated_bytes.small_pool.allocated', 101), ('allocated_bytes.small_pool.freed', 100), ('inactive_split_bytes.all.allocated', 179686), ('inactive_split_bytes.all.current', 371), ('inactive_split_bytes.all.freed', 179320), ('inactive_split_bytes.all.peak', 2585), ('inactive_split_bytes.large_pool.allocated', 179544), ('inactive_split_bytes.large_pool.current', 368), ('inactive_split_bytes.large_pool.freed', 179180), ('inactive_split_bytes.large_pool.peak', 2580), ('inactive_split_bytes.small_pool.allocated', 142), ('inactive_split_bytes.small_pool.freed', 139), ('requested_bytes.all.allocated', 513030), ('requested_bytes.all.current', 6208), ('requested_bytes.all.freed', 512683), ('requested_bytes.all.peak', 11737), ('requested_bytes.large_pool.allocated', 512929), ('requested_bytes.large_pool.current', 6205), ('requested_bytes.large_pool.freed', 512583), ('requested_bytes.large_pool.peak', 11733), ('requested_bytes.small_pool.allocated', 101), ('requested_bytes.small_pool.freed', 100), ('reserved_bytes.all.allocated', 11284), ('reserved_bytes.all.current', 17150), ('reserved_bytes.all.peak', 17150), ('reserved_bytes.large_pool.allocated', 11278), ('reserved_bytes.large_pool.current', 17142), ('reserved_bytes.large_pool.peak', 17142)]
```

Differential Revision: D87951519
