### PR TITLE
Reland D87662877: Generate 1 acc graph for esr mb5 by removing fx wrapper for kjt

### DIFF
--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -343,7 +343,6 @@ def _construct_jagged_tensors_tw(
     return ret
 
 
-@torch.fx.wrap
 def _fx_marker_construct_jagged_tensor(
     values: torch.Tensor,
     lengths: torch.Tensor,


### PR DESCRIPTION
Summary: D87662877 was reverted in D87747630 due to incompatibility between publish package and lowering package. E.g., In test it uses prod lowering package which does not include this diff change.

Differential Revision: D87848633


