### PR TITLE
add feature range validation for ebc

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1543,7 +1543,7 @@ class ShardedEmbeddingBagCollection(
                 "pytorch/torchrec:enable_kjt_validation"
             ):
                 logger.info("Validating input features...")
-                validate_keyed_jagged_tensor(features)
+                validate_keyed_jagged_tensor(features, self._embedding_bag_configs)
 
             self._create_input_dist(features.keys())
             self._has_uninitialized_input_dist = False

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2825,11 +2825,15 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             logger.warning(
                 "Trying to non-strict torch.export KJT to_dict, which is extremely slow and not recommended!"
             )
+        length_per_key = self.length_per_key()
+        if isinstance(length_per_key, torch.Tensor):
+            # length_per_key should be a list of ints, but in some (incorrect) cases it is a tensor
+            length_per_key = length_per_key.tolist()
         _jt_dict = _maybe_compute_kjt_to_jt_dict(
             stride=self.stride(),
             stride_per_key=self.stride_per_key(),
             keys=self.keys(),
-            length_per_key=self.length_per_key(),
+            length_per_key=length_per_key,
             lengths=self.lengths(),
             values=self.values(),
             variable_stride_per_key=self.variable_stride_per_key(),


### PR DESCRIPTION
Summary:
Enable validation of KeyedJaggedTensor feature values against EmbeddingBagConfig ranges to catch out-of-range embedding lookups early. Modified all validation functions to return boolean values, allowing callers to programmatically distinguish between hard failures (structural errors that raise ValueError) and soft failures (out-of-range values that return False with warnings).

This supports two use cases:
1. Production monitoring - detect invalid embedding IDs without crashing
2. Data quality checks - identify features with values outside [0, num_embeddings)

All validation functions now return bool for consistency, maintaining full backward compatibility since existing code can continue to ignore return values.

Differential Revision: D88013492


