### PR TITLE
uneven shard sizes support to Fully Sharded 2D collectives and unit tests

### DIFF
--- a/torchrec/distributed/sharding/cw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/cw_sequence_sharding.py
@@ -68,6 +68,7 @@ class CwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/cw_sharding.py
+++ b/torchrec/distributed/sharding/cw_sharding.py
@@ -287,6 +287,7 @@ class CwPooledEmbeddingSharding(
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/dp_sequence_sharding.py
+++ b/torchrec/distributed/sharding/dp_sequence_sharding.py
@@ -80,6 +80,7 @@ class DpSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._env.process_group,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/dp_sharding.py
+++ b/torchrec/distributed/sharding/dp_sharding.py
@@ -213,6 +213,7 @@ class DpPooledEmbeddingSharding(
             # For data parallel we need to turn always gradient scaling in for weights
             # because get_gradient_scaling from comm_ops only affects model_parallel tables, not DP
             scale_weight_gradients=False,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/grid_sharding.py
+++ b/torchrec/distributed/sharding/grid_sharding.py
@@ -508,6 +508,7 @@ class GridPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.TABLE_ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -157,6 +157,7 @@ class RwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -678,6 +678,7 @@ class RwPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/tw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/tw_sequence_sharding.py
@@ -141,6 +141,7 @@ class TwSequenceEmbeddingSharding(
             grouped_configs=self._grouped_embedding_configs,
             pg=self._pg,
             device=device if device is not None else self._device,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/tw_sharding.py
+++ b/torchrec/distributed/sharding/tw_sharding.py
@@ -435,6 +435,7 @@ class TwPooledEmbeddingSharding(
             pg=self._pg,
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -676,6 +676,7 @@ class TwRwPooledEmbeddingSharding(
             device=device if device is not None else self._device,
             feature_processor=feature_processor,
             sharding_type=ShardingType.TABLE_ROW_WISE,
+            env=self._env,
         )
 
     def create_output_dist(

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -26,7 +26,7 @@ from torchrec.distributed.test_utils.test_sharding import (
     SharderType,
     sharding_single_rank_test,
 )
-from torchrec.distributed.types import ModuleSharder, ShardingType
+from torchrec.distributed.types import ModuleSharder, ShardingStrategy, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
 from torchrec.test_utils import seed_and_log, skip_if_asan_class
 from torchrec.types import DataType
@@ -161,6 +161,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
         indices_dtype: torch.dtype = torch.int64,
         offsets_dtype: torch.dtype = torch.int64,
         lengths_dtype: torch.dtype = torch.int64,
+        sharding_strategy: Optional[ShardingStrategy] = None,
     ) -> None:
         self._build_tables_and_groups(data_type=data_type)
         # directly run the test with single process
@@ -191,6 +192,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
                 indices_dtype=indices_dtype,
                 offsets_dtype=offsets_dtype,
                 lengths_dtype=lengths_dtype,
+                sharding_strategy=sharding_strategy,
             )
         else:
             self._run_multi_process_test(
@@ -219,6 +221,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
                 indices_dtype=indices_dtype,
                 offsets_dtype=offsets_dtype,
                 lengths_dtype=lengths_dtype,
+                sharding_strategy=sharding_strategy,
             )
 
     def _test_dynamic_sharding(

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -62,6 +62,7 @@ from torchrec.distributed.types import (
     ShardedTensor,
     ShardingEnv,
     ShardingPlan,
+    ShardingStrategy,
     ShardingType,
 )
 from torchrec.modules.embedding_configs import (
@@ -790,6 +791,7 @@ def sharding_single_rank_test_single_process(
     offsets_dtype: torch.dtype = torch.int64,
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
+    sharding_strategy: Optional[ShardingStrategy] = None,
 ) -> None:
     batch_size = random.randint(0, batch_size) if allow_zero_batch_size else batch_size
     # Generate model & inputs.
@@ -956,6 +958,7 @@ def sharding_single_rank_test_single_process(
             use_inter_host_allreduce=use_inter_host_allreduce,
             custom_all_reduce=all_reduce_func,
             submodule_configs=submodule_configs,
+            sharding_strategy=sharding_strategy,
         )
     else:
         local_model = DistributedModelParallel(
@@ -1069,6 +1072,7 @@ def sharding_single_rank_test(
     offsets_dtype: torch.dtype = torch.int64,
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
+    sharding_strategy: Optional[ShardingStrategy] = None,
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         assert ctx.pg is not None
@@ -1104,6 +1108,7 @@ def sharding_single_rank_test(
             offsets_dtype=offsets_dtype,
             lengths_dtype=lengths_dtype,
             random_seed=random_seed,
+            sharding_strategy=sharding_strategy,
         )
 
 


### PR DESCRIPTION
Summary:
Adding support for uneven sharding splits across data parallel dimension. In sharding types like row wise and table row wise, uneven sharding cases exist which will cause current collectives in fully sharded 2D to fail. We add padding to ensure the collectives see equal shapes.

The collectives shape handling happens as such:
```
            total_size = self._emb_module.weights_dev.numel()

            shard_size = (total_size + num_groups - 1) // num_groups  # ceil division
            padded_total_size = shard_size * num_groups
            padding_size = padded_total_size - total_size

            if padding_size > 0:
                input_tensor = torch.nn.functional.pad(
                    self._emb_module.weights_dev.contiguous(),
                    (0, padding_size),
                    value=0.0,
                )
            else:
                input_tensor = self._emb_module.weights_dev.contiguous()
```

Padding occurs on the right most shard (the same happens with TorchRec uneven sharding as the last shard is the uneven one

The all_gather also accounts for this:
```
num_groups = self._env.num_sharding_groups()
        shard_size = self._shard_buf.numel()
        padded_total_size = shard_size * num_groups

        self._unsharded_param.untyped_storage().resize_(
            padded_total_size * self._element_size
        )

self._emb_module.weights_dev = self._unsharded_param[
            : self._original_shape.numel()
        ]
```


This diff also adds all required unit tests for all sharding types for fully sharded 2D (sequence and pooled embeddings)

Reviewed By: liangbeixu, kausv

Differential Revision: D87406987


