### PR TITLE
skip CPU tests for test_fully_sharded_sequence_tw

### DIFF
--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -1559,6 +1559,10 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
             sharding_strategy=ShardingStrategy.FULLY_SHARDED,
         )
 
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 7,
+        "Not enough GPUs, this test requires at least eight GPUs",
+    )
     @given(
         sharding_type=st.just(ShardingType.TABLE_WISE.value),
         kernel_type=st.sampled_from(


### PR DESCRIPTION
Summary:
# context
* 2D sharding tests need GPUs
* add the skip statement for CPU workflow
{F1983921852}

Differential Revision: D88303278


