### PR TITLE
fix CPU test timeout issue

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -32,7 +32,7 @@ on:
           - test
 
 jobs:
-  build_test:
+  unittest_ci_gpu:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -32,7 +32,7 @@ on:
           - test
 
 jobs:
-  build_test:
+  unittest_ci_cpu:
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
       contents: read
     with:
       runner: ${{ matrix.os }}
-      timeout: 15
+      timeout: 20
       script: |
         ldd --version
         conda create -y --name build_binary python=${{ matrix.python.version }}


### PR DESCRIPTION
Summary:
# context
* torchrec github cpu unit tests runtime is about 14m 50s
<img width="1734" height="846" alt="image" src="https://github.com/user-attachments/assets/fd2fd8a3-ba95-494a-a2d5-fa5ca18ae8f0" />
* some jobs are cancelled due to timeout (15m 10s)
<img width="1762" height="804" alt="image" src="https://github.com/user-attachments/assets/2fc85481-af00-4480-9f98-0f47f913cad9" />
* increase the time limit to 20m
<img width="1217" height="800" alt="image" src="https://github.com/user-attachments/assets/8d0a6a29-e5f4-4c51-ac6d-2b28a7ef5c00" />

Differential Revision: D88338771


