### PR TITLE
update supported python version in setup.py

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -20,10 +20,6 @@ jobs:
       matrix:
         include:
           - os: linux.2xlarge
-            python-version: 3.9
-            python-tag: "py39"
-            cuda-tag: "cu126"
-          - os: linux.2xlarge
             python-version: '3.10'
             python-tag: "py310"
             cuda-tag: "cu126"
@@ -115,7 +111,6 @@ jobs:
         os:
           - linux.g5.12xlarge.nvidia.gpu
         python-version:
-          - 3.9
           - "3.10"
           - "3.11"
           - "3.12"

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def main(argv: List[str]) -> None:
             "sharding",
             "distributed training",
         ],
-        python_requires=">=3.9",
+        python_requires=">=3.10",
         install_requires=install_requires,
         packages=packages,
         zip_safe=False,


### PR DESCRIPTION
Summary:
# context
* python 3.9 is out of support: https://devguide.python.org/versions/
<img width="1634" height="688" alt="image" src="https://github.com/user-attachments/assets/15664fa1-841b-4bea-a82b-33ba810a7bdb" />

* remove python 3.9 from setup.py and release workflow

Differential Revision: D88654131


