### PR TITLE
Fix perserving strides, inverse_indices in ManagedCollisionCollection

### DIFF
--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -417,6 +417,10 @@ class ManagedCollisionCollection(nn.Module):
             values=values,
             lengths=lengths,
             weights=features.weights_or_none(),
+            stride=features.stride(),
+            stride_per_key=features.stride_per_key(),
+            stride_per_key_per_rank=features._stride_per_key_per_rank,
+            inverse_indices=features.inverse_indices_or_none(),
         )
 
     def evict(self) -> Dict[str, Optional[torch.Tensor]]:


### PR DESCRIPTION
Summary:
The forward method of `ManagedCollisionCollection` goes through each table, and maps the original indices of the input KJT into the new indices using a hash-function. This produces a Dict[str, JaggedTensor], which is then converted into a KeyedJaggedTensor.

MCC should only change the values attribute of the KJT, while perserving all other attributes.

This conversion did not perserve key attributes of KJT such as `inverse_indices`, and `stride`. that are essential to work with VBE.

Reviewed By: kausv

Differential Revision: D84944895


