### PR TITLE
Store and retrieve hash_zch_runtime_meta within mc_embbedding submodules

### DIFF
--- a/torchrec/distributed/model_tracker/delta_store.py
+++ b/torchrec/distributed/model_tracker/delta_store.py
@@ -93,6 +93,7 @@ class DeltaStore(ABC):
         ids: torch.Tensor,
         states: Optional[torch.Tensor] = None,
         raw_ids: Optional[torch.Tensor] = None,
+        runtime_meta: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Append a batch of ids and states to the store for a specific table.
@@ -165,6 +166,7 @@ class DeltaStoreTrec(DeltaStore):
         ids: torch.Tensor,
         states: Optional[torch.Tensor] = None,
         raw_ids: Optional[torch.Tensor] = None,
+        runtime_meta: Optional[torch.Tensor] = None,
     ) -> None:
         table_fqn_lookup = self.per_fqn_lookups.get(fqn, [])
         table_fqn_lookup.append(
@@ -284,10 +286,13 @@ class RawIdTrackerStore(DeltaStore):
         ids: torch.Tensor,
         states: Optional[torch.Tensor] = None,
         raw_ids: Optional[torch.Tensor] = None,
+        runtime_meta: Optional[torch.Tensor] = None,
     ) -> None:
         table_fqn_lookup = self.per_fqn_lookups.get(fqn, [])
         table_fqn_lookup.append(
-            RawIndexedLookup(batch_idx=batch_idx, ids=ids, raw_ids=raw_ids)
+            RawIndexedLookup(
+                batch_idx=batch_idx, ids=ids, raw_ids=raw_ids, runtime_meta=runtime_meta
+            )
         )
         self.per_fqn_lookups[fqn] = table_fqn_lookup
 

--- a/torchrec/distributed/model_tracker/types.py
+++ b/torchrec/distributed/model_tracker/types.py
@@ -35,6 +35,7 @@ class RawIndexedLookup:
     batch_idx: int
     ids: torch.Tensor
     raw_ids: Optional[torch.Tensor] = None
+    runtime_meta: Optional[torch.Tensor] = None
 
 
 @dataclass


### PR DESCRIPTION
Summary:
See https://fb.workplace.com/groups/1404957374198553/permalink/1610214197006202/

Similar to D85999577, we store the `hash_zch_runtime_meta` when it is being look up in `mc_modules.py` in `raw_id_tracker` then access it in `batched_embedding_kernel.py` which will then be streamed to the inference side (see the other diffs in this stack D87810125)

Differential Revision: D88623165


