### PR TITLE
add psutil in requirements.txt

### DIFF
--- a/.github/scripts/install_libs.sh
+++ b/.github/scripts/install_libs.sh
@@ -28,4 +28,4 @@ elif [ "$CHANNEL" = "test" ]; then
 fi
 
 
-${CONDA_RUN} pip install importlib-metadata click PyYAML
+${CONDA_RUN} pip install -r requirements.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,3 +122,7 @@ jobs:
           if-no-files-found: error
           path: docs
           s3-prefix: meta-pytorch/torchrec/${{ github.event.pull_request.number }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -136,3 +136,7 @@ jobs:
           --ignore=torchrec/distributed/tests/test_infer_utils.py --ignore=torchrec/distributed/tests/test_fx_jit.py --ignore-glob=**/test_utils/ \
           --ignore-glob='*test_train_pipeline*' --ignore=torchrec/distributed/tests/test_model_parallel_hierarchical.py \
           -k "$skip_expression"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -115,3 +115,7 @@ jobs:
         conda run -n build_binary \
           python -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors \
           --ignore-glob=**/test_utils/ -k "$skip_expression"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black
 click
 cmake
-fbgemm-gpu
+fbgemm-gpu>=1.4.0
 hypothesis==6.70.1
 importlib-metadata
 iopath
@@ -16,7 +16,5 @@ tqdm
 usort
 parameterized
 PyYAML
-
-# for tests
-# https://github.com/pytorch/pytorch/blob/b96b1e8cff029bb0a73283e6e7f6cc240313f1dc/requirements.txt#L3
-expecttest
+psutil
+expecttest>=0.3.0


### PR DESCRIPTION
Summary:
# context
* a recent change in torch/distributed adds dependency on psutil, which is already in PyTorch's requirements.txt
<img width="3842" height="1392" alt="image" src="https://github.com/user-attachments/assets/d6f97113-dc62-4ba4-9088-2af1891b8164" />
<img width="3638" height="2138" alt="image" src="https://github.com/user-attachments/assets/9f4b1eea-4da0-442a-80c2-72bbaeaf7ffd" />


* add `psutil` in TorchRec's requirements
<img width="4048" height="1402" alt="image" src="https://github.com/user-attachments/assets/f8b3ebc4-6060-49a4-886b-51273a219c0a" />


Differential Revision: D88755938


