### PR TITLE
convert DMPCollectionConfig and DMPCollectionContext to proper dataclasses

### DIFF
--- a/torchrec/distributed/tests/test_dmp_collection.py
+++ b/torchrec/distributed/tests/test_dmp_collection.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.types import (
+    DMPCollectionConfig,
+    DMPCollectionContext,
+    ShardingPlan,
+    ShardingStrategy,
+)
+
+
+class MockModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(10, 10)
+
+    def forward(self, x: "torch.Tensor") -> "torch.Tensor":
+        return self.linear(x)
+
+
+class TestDMPCollectionConfig(unittest.TestCase):
+
+    def test_construction_with_required_args(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        config = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        self.assertEqual(config.module, MockModule)
+        self.assertEqual(config.plan, mock_plan)
+        self.assertEqual(config.sharding_group_size, 4)
+        self.assertIsNone(config.node_group_size)
+        self.assertFalse(config.use_inter_host_allreduce)
+        self.assertEqual(config.sharding_strategy, ShardingStrategy.DEFAULT)
+
+    def test_construction_with_all_args(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        config = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=8,
+            node_group_size=4,
+            use_inter_host_allreduce=True,
+            sharding_strategy=ShardingStrategy.FULLY_SHARDED,
+        )
+
+        self.assertEqual(config.module, MockModule)
+        self.assertEqual(config.sharding_group_size, 8)
+        self.assertEqual(config.node_group_size, 4)
+        self.assertTrue(config.use_inter_host_allreduce)
+        self.assertEqual(config.sharding_strategy, ShardingStrategy.FULLY_SHARDED)
+
+    def test_repr_excludes_plan(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        config = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        repr_str = repr(config)
+        self.assertIn("MockModule", repr_str)
+        self.assertIn("sharding_group_size=4", repr_str)
+        self.assertNotIn("plan=", repr_str)
+
+    def test_equality(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        config1 = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+        config2 = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        self.assertEqual(config1, config2)
+
+    def test_inequality(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        config1 = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+        config2 = DMPCollectionConfig(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=8,  # Different sharding_group_size
+        )
+
+        self.assertNotEqual(config1, config2)
+
+
+class TestDMPCollectionContext(unittest.TestCase):
+
+    def test_inherits_from_config(self) -> None:
+        self.assertTrue(issubclass(DMPCollectionContext, DMPCollectionConfig))
+
+    def test_construction_with_none_module(self) -> None:
+        """Test that module=None is allowed for default context in DMPCollection."""
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        # This is used in model_parallel.py for default context
+        context = DMPCollectionContext(
+            module=None,  # type: ignore[arg-type]
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        self.assertIsNone(context.module)
+        self.assertEqual(context.sharding_group_size, 4)
+
+    def test_construction_preserves_parent_signature(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+            node_group_size=2,
+            use_inter_host_allreduce=True,
+            sharding_strategy=ShardingStrategy.FULLY_SHARDED,
+        )
+
+        self.assertEqual(context.module, MockModule)
+        self.assertEqual(context.sharding_group_size, 4)
+        self.assertEqual(context.node_group_size, 2)
+        self.assertTrue(context.use_inter_host_allreduce)
+        self.assertEqual(context.sharding_strategy, ShardingStrategy.FULLY_SHARDED)
+
+    def test_runtime_fields_have_defaults(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        self.assertEqual(context.modules_to_sync, [])
+        self.assertIsNone(context.sharded_module)
+        self.assertIsNone(context.device_mesh)
+        self.assertIsNone(context.sharding_pg)
+        self.assertIsNone(context.replica_pg)
+
+    def test_modules_to_sync_can_be_passed_to_constructor(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+        mock_module1 = MagicMock(spec=nn.Module)
+        mock_module2 = MagicMock(spec=nn.Module)
+        modules_to_sync = [(mock_module1, mock_module2)]
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+            modules_to_sync=modules_to_sync,
+        )
+
+        self.assertEqual(context.modules_to_sync, modules_to_sync)
+
+    def test_sharded_module_can_be_passed_to_constructor(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+        mock_sharded = MagicMock(spec=nn.Module)
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+            sharded_module=mock_sharded,
+        )
+
+        self.assertEqual(context.sharded_module, mock_sharded)
+
+    def test_all_runtime_fields_can_be_passed_to_constructor(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+        mock_device_mesh = MagicMock()
+        mock_sharding_pg = MagicMock()
+        mock_replica_pg = MagicMock()
+        mock_sharded = MagicMock(spec=nn.Module)
+        modules_to_sync = [(MagicMock(spec=nn.Module), MagicMock(spec=nn.Module))]
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+            modules_to_sync=modules_to_sync,
+            sharded_module=mock_sharded,
+            device_mesh=mock_device_mesh,
+            sharding_pg=mock_sharding_pg,
+            replica_pg=mock_replica_pg,
+        )
+
+        self.assertEqual(context.modules_to_sync, modules_to_sync)
+        self.assertEqual(context.sharded_module, mock_sharded)
+        self.assertEqual(context.device_mesh, mock_device_mesh)
+        self.assertEqual(context.sharding_pg, mock_sharding_pg)
+        self.assertEqual(context.replica_pg, mock_replica_pg)
+
+    def test_runtime_fields_can_be_set_after_construction(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+        mock_device_mesh = MagicMock()
+        mock_pg = MagicMock()
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        context.device_mesh = mock_device_mesh
+        context.sharding_pg = mock_pg
+        context.replica_pg = mock_pg
+
+        self.assertEqual(context.device_mesh, mock_device_mesh)
+        self.assertEqual(context.sharding_pg, mock_pg)
+        self.assertEqual(context.replica_pg, mock_pg)
+
+    def test_repr_excludes_runtime_fields(self) -> None:
+        mock_plan = MagicMock(spec=ShardingPlan)
+
+        context = DMPCollectionContext(
+            module=MockModule,
+            plan=mock_plan,
+            sharding_group_size=4,
+        )
+
+        repr_str = repr(context)
+        self.assertNotIn("device_mesh=", repr_str)
+        self.assertNotIn("sharding_pg=", repr_str)
+        self.assertNotIn("replica_pg=", repr_str)
+        self.assertNotIn("modules_to_sync=", repr_str)
+        self.assertNotIn("sharded_module=", repr_str)
+
+
+class TestShardingStrategy(unittest.TestCase):
+
+    def test_strategy_values(self) -> None:
+        self.assertEqual(ShardingStrategy.DEFAULT.value, "default")
+        self.assertEqual(ShardingStrategy.PER_MODULE.value, "per_module")
+        self.assertEqual(ShardingStrategy.FULLY_SHARDED.value, "fully_sharded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -932,12 +932,27 @@ class ShardingStrategy(Enum):
 
 
 class DMPCollectionConfig:
+    """
+    Configuration for a submodule in DMPCollection.
+
+    This class holds the sharding configuration for a specific module type
+    when using 2D parallelism with DMPCollection.
+
+    Attributes:
+        module: The module type (class) to apply this configuration to.
+        plan: The sharding plan for this module's subtree.
+        sharding_group_size: Number of ranks in each sharding group.
+        node_group_size: Optional logical group size for TWRW/GRID sharding.
+        use_inter_host_allreduce: Whether to use inter-host allreduce for sync.
+        sharding_strategy: The sharding strategy to use.
+    """
+
     module: Type[nn.Module]
-    plan: "ShardingPlan" = field(repr=False)  # sub-tree-specific sharding plan
+    plan: "ShardingPlan"
     sharding_group_size: int
-    node_group_size: Optional[int] = None
-    use_inter_host_allreduce: bool = False
-    sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT
+    node_group_size: Optional[int]
+    use_inter_host_allreduce: bool
+    sharding_strategy: ShardingStrategy
 
     def __init__(
         self,
@@ -955,25 +970,75 @@ class DMPCollectionConfig:
         self.use_inter_host_allreduce = use_inter_host_allreduce
         self.sharding_strategy = sharding_strategy
 
-    def __post_init__(self) -> None:
-        if isinstance(self.module, ShardedModule):
+        if self.module is not None and isinstance(self.module, ShardedModule):
             raise ValueError(
                 f"ShardedModule should not be passed into DMPCollectionConfig: got {type(self.module)}"
             )
 
+    def __repr__(self) -> str:
+        return (
+            f"DMPCollectionConfig(module={self.module}, "
+            f"sharding_group_size={self.sharding_group_size}, "
+            f"node_group_size={self.node_group_size}, "
+            f"use_inter_host_allreduce={self.use_inter_host_allreduce}, "
+            f"sharding_strategy={self.sharding_strategy})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DMPCollectionConfig):
+            return NotImplemented
+        return (
+            self.module == other.module
+            and self.plan == other.plan
+            and self.sharding_group_size == other.sharding_group_size
+            and self.node_group_size == other.node_group_size
+            and self.use_inter_host_allreduce == other.use_inter_host_allreduce
+            and self.sharding_strategy == other.sharding_strategy
+        )
+
 
 # for internal use in DMPCollection
 class DMPCollectionContext(DMPCollectionConfig):
-    device_mesh: "DeviceMesh" = field(init=False)
-    sharding_pg: "dist.ProcessGroup" = field(init=False)
-    replica_pg: "dist.ProcessGroup" = field(init=False)
-    modules_to_sync: List[Tuple[nn.Module, nn.Module]] = field(
-        init=False, default_factory=list
-    )
-    sharded_module: Optional[nn.Module] = field(init=False, default=None)
-    sharding_strategy: ShardingStrategy = field(
-        init=False, default=ShardingStrategy.DEFAULT
-    )
+    """
+    Internal context for DMPCollection that extends DMPCollectionConfig
+    with runtime state for process groups and modules to sync.
+    """
+
+    device_mesh: "DeviceMesh"
+    sharding_pg: "dist.ProcessGroup"
+    replica_pg: "dist.ProcessGroup"
+    modules_to_sync: List[Tuple[nn.Module, nn.Module]]
+    sharded_module: Optional[nn.Module]
+
+    def __init__(
+        self,
+        module: Type[nn.Module],
+        plan: "ShardingPlan",
+        sharding_group_size: int,
+        node_group_size: Optional[int] = None,
+        use_inter_host_allreduce: bool = False,
+        sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT,
+        modules_to_sync: Optional[List[Tuple[nn.Module, nn.Module]]] = None,
+        sharded_module: Optional[nn.Module] = None,
+        device_mesh: Optional["DeviceMesh"] = None,
+        sharding_pg: Optional["dist.ProcessGroup"] = None,
+        replica_pg: Optional["dist.ProcessGroup"] = None,
+    ) -> None:
+        super().__init__(
+            module=module,
+            plan=plan,
+            sharding_group_size=sharding_group_size,
+            node_group_size=node_group_size,
+            use_inter_host_allreduce=use_inter_host_allreduce,
+            sharding_strategy=sharding_strategy,
+        )
+        self.modules_to_sync: List[Tuple[nn.Module, nn.Module]] = (
+            modules_to_sync if modules_to_sync is not None else []
+        )
+        self.sharded_module: Optional[nn.Module] = sharded_module
+        self.device_mesh: Optional["DeviceMesh"] = device_mesh
+        self.sharding_pg: Optional["dist.ProcessGroup"] = sharding_pg
+        self.replica_pg: Optional["dist.ProcessGroup"] = replica_pg
 
 
 class ShardingEnv2D(ShardingEnv):


### PR DESCRIPTION
Summary:
The `DMPCollectionConfig` and `DMPCollectionContext` classes used `field()` syntax
at class level but were not decorated with `dataclass`. This meant:

1. The `field()` calls were being executed at class definition time but not processed
   by the dataclass machinery, leaving weird `Field` objects as default values
2. The `__post_init__` method in `DMPCollectionConfig` was never being called,
   so the validation for `ShardedModule` was not working
3. The duplicate `sharding_strategy` field in `DMPCollectionContext` with `init=False`
   was overriding the parent's definition incorrectly

Differential Revision: D88991073


