### PR TITLE
cache weight/optimizer tensor mappings for efficient sync()

### DIFF
--- a/torchrec/distributed/tests/test_dmp_collection.py
+++ b/torchrec/distributed/tests/test_dmp_collection.py
@@ -163,6 +163,8 @@ class TestDMPCollectionContext(unittest.TestCase):
         self.assertIsNone(context.device_mesh)
         self.assertIsNone(context.sharding_pg)
         self.assertIsNone(context.replica_pg)
+        self.assertEqual(context.weights_by_dtype, {})
+        self.assertEqual(context.optimizer_tensors_by_dtype, {})
 
     def test_modules_to_sync_can_be_passed_to_constructor(self) -> None:
         mock_plan = MagicMock(spec=ShardingPlan)
@@ -250,6 +252,8 @@ class TestDMPCollectionContext(unittest.TestCase):
         self.assertNotIn("sharding_pg=", repr_str)
         self.assertNotIn("replica_pg=", repr_str)
         self.assertNotIn("modules_to_sync=", repr_str)
+        self.assertNotIn("weights_by_dtype=", repr_str)
+        self.assertNotIn("optimizer_tensors_by_dtype=", repr_str)
         self.assertNotIn("sharded_module=", repr_str)
 
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -1009,6 +1009,8 @@ class DMPCollectionContext(DMPCollectionConfig):
     replica_pg: "dist.ProcessGroup"
     modules_to_sync: List[Tuple[nn.Module, nn.Module]]
     sharded_module: Optional[nn.Module]
+    weights_by_dtype: Dict["torch.dtype", List["torch.Tensor"]]
+    optimizer_tensors_by_dtype: Dict["torch.dtype", List["torch.Tensor"]]
 
     def __init__(
         self,
@@ -1023,6 +1025,10 @@ class DMPCollectionContext(DMPCollectionConfig):
         device_mesh: Optional["DeviceMesh"] = None,
         sharding_pg: Optional["dist.ProcessGroup"] = None,
         replica_pg: Optional["dist.ProcessGroup"] = None,
+        weights_by_dtype: Optional[Dict["torch.dtype", List["torch.Tensor"]]] = None,
+        optimizer_tensors_by_dtype: Optional[
+            Dict["torch.dtype", List["torch.Tensor"]]
+        ] = None,
     ) -> None:
         super().__init__(
             module=module,
@@ -1039,6 +1045,12 @@ class DMPCollectionContext(DMPCollectionConfig):
         self.device_mesh: Optional["DeviceMesh"] = device_mesh
         self.sharding_pg: Optional["dist.ProcessGroup"] = sharding_pg
         self.replica_pg: Optional["dist.ProcessGroup"] = replica_pg
+        self.weights_by_dtype: Dict["torch.dtype", List["torch.Tensor"]] = (
+            weights_by_dtype if weights_by_dtype is not None else {}
+        )
+        self.optimizer_tensors_by_dtype: Dict["torch.dtype", List["torch.Tensor"]] = (
+            optimizer_tensors_by_dtype if optimizer_tensors_by_dtype is not None else {}
+        )
 
 
 class ShardingEnv2D(ShardingEnv):


### PR DESCRIPTION
Summary:
Every call to `sync()` was rebuilding dictionaries that map dtypes to tensor lists
by iterating through all embedding kernels and their weights.Not needed since mappings don't change between sync() calls.

This diff optimizes sync() by:
1. Adding `weights_by_dtype` and `optimizer_tensors_by_dtype` fields
   to `DMPCollectionContext` to store pre-computed tensor mappings
2. Adding `_cache_sync_tensors()` method that populates these caches once after
   `_group_sharded_modules()` completes
3. Modifying `_sync()` to use the cached mappings instead of rebuilding them

This reduces the per-sync() overhead, particularly for models with many embedding
tables or frequent sync operations. Practically, speaking this does not matter for most models but it does make our code cleaner to understand and removes unneeded inefficiencies.

Added unit testing to bulletproof implementation from erroneous changes

Differential Revision: D88993014


