### PR TITLE
clean up KillSwitch in D88218200

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -385,12 +385,7 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
         return copy_dmp
 
     def _init_dmp(self, module: nn.Module) -> nn.Module:
-        if torch._utils_internal.justknobs_check(
-            "pytorch/torchrec:enable_module_id_cache_for_dmp_shard_modules"
-        ):
-            module_id_cache: Dict[int, ShardedModule] = {}
-        else:
-            module_id_cache = None
+        module_id_cache: Dict[int, ShardedModule] = {}
         return self._shard_modules_impl(module, module_id_cache=module_id_cache)
 
     def _init_delta_tracker(


### PR DESCRIPTION
Summary:
# REF
https://fb.workplace.com/groups/429376538334034/permalink/1343336826937996/

* follow the TorchRec KillSwitch Guideline, clean up the `justknobs_check` after 1 week
* mark the justnob as `Archive`: [enable_module_id_cache_for_dmp_shard_modules](https://www.internalfb.com/intern/justknobs/?name=pytorch%2Ftorchrec#enable_module_id_cache_for_dmp_shard_modules)

Differential Revision: D88218235


