### PR TITLE
Clean up KJT validator killswitch

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1539,11 +1539,8 @@ class ShardedEmbeddingBagCollection(
         ctx.inverse_indices = features.inverse_indices_or_none()
 
         if self._has_uninitialized_input_dist:
-            if torch._utils_internal.justknobs_check(
-                "pytorch/torchrec:enable_kjt_validation"
-            ):
-                logger.info("Validating input features...")
-                validate_keyed_jagged_tensor(features, self._embedding_bag_configs)
+            logger.info("Validating input features...")
+            validate_keyed_jagged_tensor(features, self._embedding_bag_configs)
 
             self._create_input_dist(features.keys())
             self._has_uninitialized_input_dist = False


### PR DESCRIPTION
Summary: The killswitch `pytorch/torchrec:enable_kjt_validation` has been switched ON for a couple of months and it is working normally, so it should be safe to clean it up.

Reviewed By: TroyGarden

Differential Revision: D89088119


