### PR TITLE
remove test failure due to empty KJT corner case

### DIFF
--- a/torchrec/sparse/jagged_tensor_validator.py
+++ b/torchrec/sparse/jagged_tensor_validator.py
@@ -200,6 +200,11 @@ def _validate_feature_range(
         return True
 
     valid = True
+
+    # add a corner case check for empty KJT, which will cause error in to_dict()
+    if kjt.lengths().numel() == 0:
+        return valid
+
     jtd = kjt.to_dict()
     for feature, jt in jtd.items():
         if feature not in feature_to_range_map:


### PR DESCRIPTION
Summary:
# context
* fix test case failure (flaky test) due to a corner case where a KJT is empty and errors out at KJT.to_dict() call
* add a KJT.length check in the KJT validator

Differential Revision: D89394875


