### PR TITLE
Prevent duplicate test execution from base test classes

### DIFF
--- a/.github/scripts/tests_to_skip.txt
+++ b/.github/scripts/tests_to_skip.txt
@@ -1,1 +1,0 @@
-_disabled_in_oss_compatibility

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -116,26 +116,30 @@ jobs:
           python -c "import numpy"
         echo "numpy succeeded"
         conda install -n build_binary -y pytest
-        # Read the list of tests to skip from a file, ignoring empty lines and comments
-        skip_expression=$(awk '!/^($|#)/ {printf " and not %s", $0}' ./.github/scripts/tests_to_skip.txt)
-        # Check if skip_expression is effectively empty
-        if [ -z "$skip_expression" ]; then
-          skip_expression=""
-        else
-          skip_expression=${skip_expression:5}  # Remove the leading " and "
-        fi
         conda run -n build_binary \
-          python -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors \
-          --ignore=torchrec/distributed/tests/test_comm.py --ignore=torchrec/distributed/tests/test_infer_shardings.py \
-          --ignore=torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py --ignore=torchrec/distributed/tests/test_pt2_multiprocess.py \
-          --ignore=torchrec/distributed/tests/test_pt2.py --ignore=torchrec/distributed/tests/test_quant_model_parallel.py \
-          --ignore=torchrec/distributed/tests/test_quant_pruning.py --ignore=torchrec/distributed/tests/test_quant_sequence_model_parallel.py \
-          --ignore-glob='torchrec/metrics/*' --ignore-glob='torchrec/distributed/tests/test_model_parallel_gloo*' \
-          --ignore-glob='torchrec/inference/inference_legacy/tests*' --ignore-glob='*test_model_parallel_nccl*' \
-          --ignore=torchrec/distributed/tests/test_cache_prefetch.py --ignore=torchrec/distributed/tests/test_fp_embeddingbag_single_rank.py \
-          --ignore=torchrec/distributed/tests/test_infer_utils.py --ignore=torchrec/distributed/tests/test_fx_jit.py --ignore-glob=**/test_utils/ \
-          --ignore-glob='*test_train_pipeline*' --ignore=torchrec/distributed/tests/test_model_parallel_hierarchical.py \
-          -k "$skip_expression"
+          python -m pytest torchrec -v -s \
+          -W ignore::pytest.PytestCollectionWarning \
+          --continue-on-collection-errors \
+          --ignore=torchrec/distributed/tests/test_comm.py \
+          --ignore=torchrec/distributed/tests/test_infer_shardings.py \
+          --ignore=torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py \
+          --ignore=torchrec/distributed/tests/test_pt2_multiprocess.py \
+          --ignore=torchrec/distributed/tests/test_pt2.py \
+          --ignore=torchrec/distributed/tests/test_quant_model_parallel.py \
+          --ignore=torchrec/distributed/tests/test_quant_pruning.py \
+          --ignore=torchrec/distributed/tests/test_quant_sequence_model_parallel.py \
+          --ignore=torchrec/distributed/tests/test_cache_prefetch.py \
+          --ignore=torchrec/distributed/tests/test_fp_embeddingbag_single_rank.py \
+          --ignore=torchrec/distributed/tests/test_infer_utils.py \
+          --ignore=torchrec/distributed/tests/test_fx_jit.py \
+          --ignore=torchrec/distributed/tests/test_model_parallel_hierarchical.py \
+          --ignore-glob=**/test_utils/ \
+          --ignore-glob='torchrec/metrics/' \
+          --ignore-glob='*test_train_pipeline*' \
+          --ignore-glob='torchrec/distributed/tests/test_model_parallel_gloo*' \
+          --ignore-glob='torchrec/inference/inference_legacy/tests*' \
+          --ignore-glob='*test_model_parallel_nccl*' \
+          -k "not _disabled_in_oss_compatibility"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -104,18 +104,10 @@ jobs:
           python -c "import numpy"
         echo "numpy succeeded"
         conda install -n build_binary -y pytest
-        # Read the list of tests to skip from a file, ignoring empty lines and comments
-        skip_expression=$(awk '!/^($|#)/ {printf " and not %s", $0}' ./.github/scripts/tests_to_skip.txt)
-        # Check if skip_expression is effectively empty
-        if [ -z "$skip_expression" ]; then
-          skip_expression=""
-        else
-          skip_expression=${skip_expression:5}  # Remove the leading " and "
-        fi
         conda run -n build_binary \
           python -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors \
-          --ignore-glob=**/test_utils/ -k "$skip_expression"
-
+        --ignore-glob=**/test_utils/ \
+        -k "not _disabled_in_oss_compatibility"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -307,11 +307,19 @@ class ModelParallelTestShared(MultiProcessTestBase):
 
 @skip_if_asan_class
 class ModelParallelBase(ModelParallelTestShared):
-    def setUp(self, backend: str = "nccl") -> None:
-        super().setUp(backend=backend)
+    # tests will skip if no backend specified
+    backend = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if cls.backend not in ("nccl", "gloo"):
+            raise unittest.SkipTest(f"No valid backend specified: {cls.backend}")
+
+    def setUp(self) -> None:
+        super().setUp(backend=self.backend)
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        torch.cuda.device_count() < 2,
         "Not enough GPUs, this test requires at least two GPUs",
     )
     # pyre-fixme[56]
@@ -667,7 +675,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        torch.cuda.device_count() < 2,
         "Not enough GPUs, this test requires at least two GPUs",
     )
     # pyre-fixme[56]
@@ -749,7 +757,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        torch.cuda.device_count() < 2,
         "Not enough GPUs, this test requires at least two GPUs",
     )
     # pyre-fixme[56]
@@ -807,7 +815,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        torch.cuda.device_count() < 2,
         "Not enough GPUs, this test requires at least two GPUs",
     )
     # pyre-fixme[56]
@@ -845,7 +853,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 3,
+        torch.cuda.device_count() < 4,
         "Not enough GPUs, this test requires at least four GPUs",
     )
     # pyre-fixme[56]
@@ -936,7 +944,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 7,
+        torch.cuda.device_count() < 8,
         "Not enough GPUs, this test requires at least eight GPUs",
     )
     # pyre-fixme[56]
@@ -1027,7 +1035,7 @@ class ModelParallelBase(ModelParallelTestShared):
         )
 
     @unittest.skipIf(
-        torch.cuda.device_count() <= 1,
+        torch.cuda.device_count() < 2,
         "Not enough GPUs, this test requires at least two GPUs",
     )
     # pyre-fixme[56]

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -190,7 +190,15 @@ class InferenceModelParallelTestBase(unittest.TestCase):
 
 
 class ModelParallelSparseOnlyBase(unittest.TestCase):
-    def setUp(self, backend: str = "nccl") -> None:
+    # tests will be skipped if no backend is specified
+    backend: str = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if cls.backend not in ("nccl", "gloo"):
+            raise unittest.SkipTest(f"No valid backend specified: {cls.backend}")
+
+    def setUp(self) -> None:
         os.environ["RANK"] = "0"
         os.environ["WORLD_SIZE"] = "1"
         os.environ["LOCAL_WORLD_SIZE"] = "1"
@@ -198,7 +206,6 @@ class ModelParallelSparseOnlyBase(unittest.TestCase):
         os.environ["MASTER_PORT"] = str(get_free_port())
         os.environ["NCCL_SOCKET_IFNAME"] = "lo"
 
-        self.backend = backend
         if torch.cuda.is_available():
             self.device = torch.device("cuda:0")
             torch.cuda.set_device(self.device)
@@ -522,6 +529,17 @@ class ModelParallelSingleRankBase(unittest.TestCase):
 
 
 class ModelParallelStateDictBase(ModelParallelSingleRankBase):
+    # tests will be skipped if no backend is specified
+    backend: str = ""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if cls.backend not in ("nccl", "gloo"):
+            raise unittest.SkipTest(f"No valid backend specified: {cls.backend}")
+
+    def setUp(self) -> None:
+        super().setUp(backend=self.backend)
+
     def _create_tables(self) -> None:
         num_features = 4
         num_weighted_features = 2

--- a/torchrec/distributed/tests/test_model_parallel_gloo.py
+++ b/torchrec/distributed/tests/test_model_parallel_gloo.py
@@ -17,15 +17,12 @@ from torchrec.distributed.test_utils.test_model_parallel_base import (
 
 
 class ModelParallelTestGloo(ModelParallelBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"
 
 
 class ModelParallelStateDictTestGloo(ModelParallelStateDictBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"
 
 
 class ModelParallelSparseOnlyTestGloo(ModelParallelSparseOnlyBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"

--- a/torchrec/distributed/tests/test_model_parallel_gloo_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_gloo_gpu.py
@@ -13,5 +13,4 @@ from torchrec.distributed.test_utils.test_model_parallel import ModelParallelBas
 
 
 class ModelParallelTestGloo(ModelParallelBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"

--- a/torchrec/distributed/tests/test_model_parallel_gloo_gpu_single_rank.py
+++ b/torchrec/distributed/tests/test_model_parallel_gloo_gpu_single_rank.py
@@ -16,10 +16,8 @@ from torchrec.distributed.test_utils.test_model_parallel_base import (
 
 
 class ModelParallelStateDictTestGloo(ModelParallelStateDictBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"
 
 
 class ModelParallelSparseOnlyTestGloo(ModelParallelSparseOnlyBase):
-    def setUp(self, backend: str = "gloo") -> None:
-        super().setUp(backend=backend)
+    backend = "gloo"

--- a/torchrec/distributed/tests/test_model_parallel_nccl.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl.py
@@ -11,4 +11,4 @@ from torchrec.distributed.test_utils.test_model_parallel import ModelParallelBas
 
 
 class ModelParallelTestNccl(ModelParallelBase):
-    pass
+    backend = "nccl"

--- a/torchrec/distributed/tests/test_model_parallel_nccl_single_rank.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl_single_rank.py
@@ -26,7 +26,7 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 
 class ModelParallelStateDictTestNccl(ModelParallelStateDictBase):
-    pass
+    backend = "nccl"
 
 
 class SparseArch(nn.Module):
@@ -67,6 +67,8 @@ class TwoSparseArchModel(nn.Module):
 
 
 class ModelParallelSparseOnlyTestNccl(ModelParallelSparseOnlyBase):
+    backend = "nccl"
+
     def test_shared_sparse_module_in_multiple_parents(self) -> None:
         """
         Test that the module ID cache correctly handles the same sparse module


### PR DESCRIPTION
Summary:
## Context
Refactored TorchRec distributed test infrastructure to prevent duplicate test execution from base test classes. Base classes containing test methods were being discovered and executed by test runners, causing redundant test runs with skipped tests due to unspecified backends.

## Problem
Test base classes (`ModelParallelSparseOnlyBase`, `ModelParallelSingleRankBase`, `ModelParallelStateDictBase`, `ModelParallelBase`, and `InferenceModelParallelTestBase`) contained test methods and had empty backend configuration (`backend = ""`). Test runners would execute these base classes directly, resulting in:
- Duplicate test executions (once on base class, once on concrete implementations)
- Redundant skipped tests with "No valid backend specified" messages
- Wasted CI resources and increased test execution time

## Solution
Restructured test hierarchy to separate base classes (helper methods only) from test implementation classes:

**Base Classes** (`test_model_parallel_base.py`):
- `InferenceModelParallelTestBase` - setUp/tearDown only, no test methods
- `ModelParallelSparseOnlyBase` - Helper methods only, no test methods
- `ModelParallelSingleRankBase` - Helper methods only, no test methods
- `ModelParallelStateDictBase` - Contains tests but skips if no backend specified

**Test Implementation** (`test_model_parallel.py`):
- `ModelParallelTestShared` - Shared test implementation logic
- `ModelParallelBase` - Contains test methods with backend validation

**Concrete Test Classes** (`tests/` directory):
- `test_model_parallel_gloo.py` - Gloo backend tests
- `test_model_parallel_gloo_gpu.py` - Gloo GPU tests
- `test_model_parallel_gloo_gpu_single_rank.py` - Single-rank Gloo GPU tests
- `test_model_parallel_nccl.py` - NCCL backend tests
- `test_model_parallel_nccl_single_rank.py` - Single-rank NCCL tests

Each concrete class inherits from base and sets `backend` attribute (e.g., `backend = "nccl"`).

Reviewed By: TroyGarden

Differential Revision: D89607271


