### PR TITLE
Use anomaly detection as ctx manager

### DIFF
--- a/torchrec/distributed/tests/test_emb_anomaly.py
+++ b/torchrec/distributed/tests/test_emb_anomaly.py
@@ -227,10 +227,9 @@ def run_debug_model(
         loss = torch.sum(logits)
 
         tc = unittest.TestCase()
-        with tc.assertRaisesRegex(
-            RuntimeError, "NaN/Inf detected in gradient entering"
-        ):
-            loss.backward()
+        with torch.autograd.detect_anomaly():
+            with tc.assertRaisesRegex(RuntimeError, "returned nan values"):
+                loss.backward()
 
 
 def run_embedding_collection(


### PR DESCRIPTION
Summary:
PyTorch's detect_anomaly() context is needed to catch NaN gradients
When using detect_anomaly(), PyTorch raises errors with its own message format ("returned nan values"), not the DebugEmbedding* format ("NaN/Inf detected in gradient entering")

Differential Revision: D89752392


