### PR TITLE
Fix flaky test

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -163,6 +163,8 @@ class ModelParallelTestShared(MultiProcessTestBase):
         offsets_dtype: torch.dtype = torch.int64,
         lengths_dtype: torch.dtype = torch.int64,
         sharding_strategy: Optional[ShardingStrategy] = None,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
     ) -> None:
         self._build_tables_and_groups(data_type=data_type)
         # directly run the test with single process
@@ -194,6 +196,8 @@ class ModelParallelTestShared(MultiProcessTestBase):
                 offsets_dtype=offsets_dtype,
                 lengths_dtype=lengths_dtype,
                 sharding_strategy=sharding_strategy,
+                atol=atol,
+                rtol=rtol,
             )
         else:
             self._run_multi_process_test(
@@ -223,6 +227,8 @@ class ModelParallelTestShared(MultiProcessTestBase):
                 offsets_dtype=offsets_dtype,
                 lengths_dtype=lengths_dtype,
                 sharding_strategy=sharding_strategy,
+                atol=atol,
+                rtol=rtol,
             )
 
     def _test_dynamic_sharding(

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -792,6 +792,8 @@ def sharding_single_rank_test_single_process(
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
     sharding_strategy: Optional[ShardingStrategy] = None,
+    atol: Optional[float] = None,
+    rtol: Optional[float] = None,
 ) -> None:
     batch_size = random.randint(0, batch_size) if allow_zero_batch_size else batch_size
     # Generate model & inputs.
@@ -1036,7 +1038,9 @@ def sharding_single_rank_test_single_process(
                 rtol=1e-4,  # relaxed rtol due to FP16 in weights
             )
         else:
-            torch.testing.assert_close(global_pred, torch.cat(all_local_pred))
+            torch.testing.assert_close(
+                global_pred, torch.cat(all_local_pred), atol=atol, rtol=rtol
+            )
 
 
 def sharding_single_rank_test(
@@ -1073,6 +1077,8 @@ def sharding_single_rank_test(
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
     sharding_strategy: Optional[ShardingStrategy] = None,
+    atol: Optional[float] = None,
+    rtol: Optional[float] = None,
 ) -> None:
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         assert ctx.pg is not None
@@ -1109,6 +1115,8 @@ def sharding_single_rank_test(
             lengths_dtype=lengths_dtype,
             random_seed=random_seed,
             sharding_strategy=sharding_strategy,
+            atol=atol,
+            rtol=rtol,
         )
 
 

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -325,6 +325,8 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             model_class=TestTowerSparseNN,
             qcomms_config=qcomms_config,
             apply_optimizer_in_backward_config=apply_optimizer_in_backward_config,
+            atol=1e-4,
+            rtol=1e-4,
         )
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
There was a falsifying eample before which worked after this change. TWCW (which is not currently used in prod) has a slightly higher difference in results than the default atol/rtol used by other TorchRec tests.

In this diff I added the ability to set atol/rtol for each test to override with original defaults.

Differential Revision: D89766172


