### PR TITLE
Remove hypothesis shrink phase from multi proc tests

### DIFF
--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -13,7 +13,7 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Type
 import torch
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from hypothesis import assume, given, settings, strategies as st, Verbosity
+from hypothesis import assume, given, Phase, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
@@ -103,7 +103,12 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_cw_2D(
         self,
         sharder_type: str,
@@ -195,7 +200,12 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_tw_2D(
         self,
         sharder_type: str,
@@ -288,7 +298,12 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_grid_2D(
         self,
         sharder_type: str,
@@ -400,7 +415,12 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_rw_2D(
         self,
         sharder_type: str,
@@ -492,7 +512,12 @@ class TestEmbeddingBagCollection2DParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_twrw_2D(
         self,
         sharder_type: str,
@@ -625,7 +650,12 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_ec_rw_2D(
         self,
         sharding_type: str,
@@ -688,7 +718,12 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_ec_cw_2D(
         self,
         sharding_type: str,
@@ -755,7 +790,12 @@ class TestEmbeddingCollection2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_ec_tw_2D(
         self,
         sharding_type: str,
@@ -903,7 +943,12 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_dynamic_2D(
         self,
         sharding_type: str,
@@ -984,7 +1029,12 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_dynamic_2D(
         self,
         sharding_type: str,
@@ -1067,7 +1117,12 @@ class TestDynamic2DParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_partially_fully_sharded_dynamic_2D(
         self,
         sharding_type: str,
@@ -1210,7 +1265,12 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_cw(
         self,
         sharder_type: str,
@@ -1302,7 +1362,12 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_rw(
         self,
         sharder_type: str,
@@ -1394,7 +1459,12 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_twrw(
         self,
         sharder_type: str,
@@ -1487,7 +1557,12 @@ class TestFullySharded2DEBCParallel(ModelParallelTestShared):
         use_inter_host_allreduce=st.booleans(),
         custom_all_reduce=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_tw(
         self,
         sharder_type: str,
@@ -1623,7 +1698,12 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_sequence_cw(
         self,
         sharding_type: str,
@@ -1691,7 +1771,12 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_sequence_rw(
         self,
         sharding_type: str,
@@ -1758,7 +1843,12 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=1, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_fully_sharded_sequence_tw(
         self,
         sharding_type: str,

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -10,17 +10,12 @@
 
 import random
 import unittest
-
 from typing import Any, Dict, List, Optional
 
 import hypothesis.strategies as st
-
 import torch
-
-from hypothesis import assume, given, settings, Verbosity
-
+from hypothesis import assume, given, Phase, settings, Verbosity
 from torch import nn, optim
-
 from torchrec import (
     distributed as trec_dist,
     EmbeddingBagCollection,
@@ -33,7 +28,6 @@ from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.sharding.dynamic_sharding import (
     output_sharding_plan_delta_single,
 )
-
 from torchrec.distributed.sharding_plan import (
     column_wise,
     construct_module_sharding_plan,
@@ -41,7 +35,6 @@ from torchrec.distributed.sharding_plan import (
     table_wise,
 )
 from torchrec.distributed.test_utils.model_input import ModelInput
-
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
@@ -53,7 +46,6 @@ from torchrec.distributed.test_utils.test_sharding import (
     generate_rank_placements,
     SharderType,
 )
-
 from torchrec.distributed.types import (
     EmbeddingModuleShardingPlan,
     ParameterSharding,
@@ -61,7 +53,6 @@ from torchrec.distributed.types import (
     ShardingType,
 )
 from torchrec.modules.embedding_configs import data_type_to_dtype, EmbeddingBagConfig
-
 from torchrec.test_utils import skip_if_asan_class
 from torchrec.types import DataType
 
@@ -416,7 +407,12 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
         data_type=st.sampled_from([DataType.FP32, DataType.FP16]),
         world_size=st.sampled_from([2, 4]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=8,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_dynamic_sharding_ebc_tw(
         self,
         num_tables: int,
@@ -461,7 +457,12 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
         world_size=st.sampled_from([3, 4]),
         embedding_dim=st.sampled_from([16]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=8,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_dynamic_sharding_ebc_cw(
         self,
         num_tables: int,
@@ -549,7 +550,12 @@ class MultiRankDMPDynamicShardingTest(ModelParallelTestShared):
         world_size=st.sampled_from([2, 4]),
         skip_passing_resharding_fqn=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=8, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=8,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding(
         self,
         sharder_type: str,

--- a/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/tests/test_keyed_jagged_tensor_pool.py
@@ -8,18 +8,16 @@
 # pyre-strict
 
 import unittest
-
 from typing import cast, Dict, List
 
 import torch
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, Phase, settings, strategies as st
 from torchrec.distributed.keyed_jagged_tensor_pool import (
     KeyedJaggedTensorPoolSharder,
     ShardedInferenceKeyedJaggedTensorPool,
     ShardedKeyedJaggedTensorPool,
 )
 from torchrec.distributed.shard import _shard_modules
-
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
@@ -162,7 +160,11 @@ class TestShardedKeyedJaggedTensorPool(MultiProcessTestBase):
         enable_uvm=st.booleans(),
         values_dtype=st.sampled_from([torch.int32, torch.int64]),
     )
-    @settings(max_examples=4, deadline=None)
+    @settings(
+        max_examples=4,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharded_keyed_jagged_tensor_pool_rw(
         self, enable_uvm: bool, values_dtype: torch.dtype
     ) -> None:

--- a/torchrec/distributed/tests/test_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_model_parallel_hierarchical.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional, Tuple, Type
 
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
-from hypothesis import assume, given, settings, strategies as st, Verbosity
+from hypothesis import assume, given, Phase, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
@@ -81,7 +81,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         variable_batch_size=st.booleans(),
         pooling=st.sampled_from([PoolingType.SUM, PoolingType.MEAN]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=6,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_nccl_twrw(
         self,
         sharder_type: str,
@@ -169,7 +174,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         variable_batch_size=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=6, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=6,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_nccl_twcw(
         self,
         sharder_type: str,
@@ -228,7 +238,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         ),
         variable_batch_per_feature=st.booleans(),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=2,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_empty_rank(
         self, sharding_type: str, variable_batch_per_feature: bool
     ) -> None:
@@ -293,7 +308,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=1,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_embedding_tower_nccl(
         self,
         sharding_type: str,
@@ -303,6 +323,7 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             Dict[str, Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]]
         ],
     ) -> None:
+        print(f"phases: {settings().phases}")
         # Dense kernels do not have overlapped optimizer behavior yet
         assume(
             apply_optimizer_in_backward_config is None
@@ -364,7 +385,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
             ]
         ),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=4,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_embedding_tower_collection_nccl(
         self,
         sharding_type: str,
@@ -414,7 +440,12 @@ class ModelParallelHierarchicalTest(ModelParallelTestShared):
         global_constant_batch=st.booleans(),
         pooling=st.sampled_from([PoolingType.SUM, PoolingType.MEAN]),
     )
-    @settings(verbosity=Verbosity.verbose, max_examples=2, deadline=None)
+    @settings(
+        verbosity=Verbosity.verbose,
+        max_examples=2,
+        deadline=None,
+        phases=[Phase.explicit, Phase.generate, Phase.target],
+    )
     def test_sharding_variable_batch(
         self,
         sharding_type: str,


### PR DESCRIPTION
Summary:
Currently, when distributed tests fail, hypothesis tries to shrink failures to come up with the failure cases.

This results in lot of tests getting scheduled and results in timeout, also hiding the failure cases.

Removed Shrink Phase from distributed test.
Hoping to see the underlying error cases.

Differential Revision: D89787146


