### PR TITLE
Prettify the train pipeline benchmark output

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -197,6 +197,43 @@ class BenchmarkResult:
             content += f"{c: <{length}}|"
         return head + "\n" + split + "\n" + content + "\n"
 
+    def prettify(self) -> str:
+        """Return a human-readable formatted string for console output."""
+        lines = [
+            "",
+            "=" * 60,
+            f"  Benchmark: {self.short_name}",
+            "=" * 60,
+            "",
+            "  Runtime:",
+            f"    GPU (P90):              {self.runtime_percentile(90, device='gpu'):.2f} ms",
+            f"    CPU (P90):              {self.runtime_percentile(90, device='cpu'):.2f} ms",
+        ]
+
+        if len(self.gpu_mem_stats) > 0:
+            lines.extend(
+                [
+                    "",
+                    "  GPU Memory:",
+                    f"    Peak Allocated (P90):   {self.max_mem_alloc_percentile(90)/1000:.2f} GB",
+                    f"    Peak Reserved (P90):    {self.max_mem_reserved_percentile(90)/1000:.2f} GB",
+                    f"    Used (P90):             {self.device_mem_used(90)/1000:.2f} GB",
+                    f"    Malloc Retries:         P50={self.mem_retries(50):.0f}  P90={self.mem_retries(90):.0f}  P100={self.mem_retries(100):.0f}",
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "  CPU Memory:",
+                f"    Peak RSS (P90):         {self.cpu_mem_percentile(90)/1000:.2f} GB",
+                "",
+                "=" * 60,
+            ]
+        )
+
+        return "\n".join(lines)
+
     def runtime_percentile(
         self,
         percentile: int = 50,

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -211,7 +211,8 @@ def runner(
         )
 
         if rank == 0:
-            print(result)
+            print(result.prettify())
+            print("\nMarkdown format:\n", result)
 
         return result
 


### PR DESCRIPTION
Summary:
Improved the `BenchmarkResult.__str__` method to produce a cleaner, multi-line, well-aligned output format instead of a single long markdown table line.

Before (old format):
```
|short name                         |GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|...|
|--|--|--|--|--|--|--|
|sparse_data_dist_base              |12.34 ms         |10.56 ms         |1.23 GB                 |...|
```

After (new format):
```
============================================================
  Benchmark: sparse_data_dist_base
============================================================

  Runtime:
    GPU (P90):              12.34 ms
    CPU (P90):              10.56 ms

  GPU Memory:
    Peak Allocated (P90):   1.23 GB
    Peak Reserved (P90):    2.34 GB
    Used (P90):             3.45 GB
    Malloc Retries:         P50=0  P90=0  P100=0

  CPU Memory:
    Peak RSS (P90):         4.56 GB

============================================================
```

Differential Revision: D89873089


