### PR TITLE
validate input existance before using it

### DIFF
--- a/torchrec/distributed/test_utils/input_config.py
+++ b/torchrec/distributed/test_utils/input_config.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, MISSING
 from typing import List, Optional
 
 import torch
@@ -31,6 +31,16 @@ class ModelInputConfig:
     long_kjt_lengths: bool = True
     pin_memory: bool = True
     use_variable_batch: bool = False
+
+    def __post_init__(self):
+        assert self.num_batches is not MISSING, "--num_batches must be specified"
+        assert self.batch_size is not MISSING, "--batch_size must be specified"
+        assert (
+            self.num_float_features is not MISSING
+        ), "--num_float_features must be specified"
+        assert (
+            self.feature_pooling_avg is not MISSING
+        ), "--feature_pooling_avg must be specified"
 
     def generate_batches(
         self,


### PR DESCRIPTION
Summary:
When I run
```
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline --     --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
```
it will fail with
```
...
TypeError: unsupported operand type(s) for /: '_MISSING_TYPE' and 'int'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/__run_lpar_main__.py", line 39, in <module>
    __invoke_main()
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/__run_lpar_main__.py", line 36, in __invoke_main
    run_as_main(module, main_function)
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/__par__/meta_only/bootstrap.py", line 111, in run_as_main
    oss_run_as_main(
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/__par__/bootstrap.py", line 70, in run_as_main
    runpy._run_module_as_main(main_module, alter_argv=False)
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform010/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/torchrec/distributed/benchmark/benchmark_train_pipeline.py", line 294, in <module>
    main()
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/torchrec/distributed/benchmark/base.py", line 602, in wrapper
    return func(**kwargs)
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/torchrec/distributed/benchmark/benchmark_train_pipeline.py", line 280, in main
    run_multi_process_func(
  File "/data/repos/fbsource/buck-out/v2/gen/fbcode/86458b9e59f64287/torchrec/distributed/benchmark/__benchmark_train_pipeline__/benchmark_train_pipeline-inplace#link-tree/torchrec/distributed/test_utils/multi_process.py", line 267, in run_multi_process_func
    results = pool.map(_wrapper_func_for_multiprocessing, args_list)
  File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/local/fbcode/platform010/lib/python3.10/multiprocessing/pool.py", line 774, in get
    raise self._value
TypeError: unsupported operand type(s) for /: '_MISSING_TYPE' and 'int'
```

This is because feature pooling avg is not set

This diff gives a clear message if an expected input isn't set

Reviewed By: kausv

Differential Revision: D89748050


