### PR TITLE
Add MP-ZCH to benchmark for TestSparseNN

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -1,0 +1,64 @@
+# This is a very basic MP-ZCH benchmark configuration
+#   MP-ZCH parameters have comments next to them below.
+#   Note that MP-ZCH must be enabled for all tables in the model,
+#      and MP-ZCH only works with row-wise sharding.
+RunOptions:
+  world_size: 2
+  num_batches: 20
+  num_benchmarks: 5
+  num_profiles: 1
+  sharding_type: row_wise        # MP-ZCH only works with row-wise sharding
+  profile_dir: "."
+  name: "sparse_data_dist_mpzch"
+  num_float_features: 1000
+PipelineConfig:
+  pipeline: "sparse"
+ModelInputConfig:
+  num_float_features: 1000
+  feature_pooling_avg: 30
+  use_variable_batch: False
+ModelSelectionConfig:
+  model_name: "test_sparse_nn"   # MP-ZCH only works with test_sparse_nn
+  model_config:
+    num_float_features: 1000
+    submodule_kwargs:
+      dense_arch_out_size: 1024
+      over_arch_out_size: 4096
+      over_arch_hidden_layers: 10
+      dense_arch_hidden_sizes: [128, 128, 128]
+EmbeddingTablesConfig:
+  num_unweighted_features: 90
+  num_weighted_features: 80
+  embedding_feature_dim: 256
+  mc_config:
+    mc_type: "mp-zch"           # Either "mp-zch" or "sort-zch"
+    total_num_buckets: 10       # zch_size must be a multiple of total_num_buckets,
+                                #     and total_num_buckets must be a multiple of world size
+    max_probe: 128              # Controls amount of time kernel searches for lookup or insertion
+    input_hash_size: 0          # Maximum input hash size.
+    disable_fallback: False     # If ID lookup fails, then the IDS are removed entirely from output.
+    eviction_policy_name:       # Eviction policy names: "SINGLE_TTL_EVICTION", "PER_FEATURE_TTL_EVICTION",
+                                #   "LRU_EVICTION"
+      "SINGLE_TTL_EVICTION"
+    eviction_config:            # Eviction policy parameters
+      single_ttl: 1
+  additional_tables:
+    - - name: FP16_table
+        embedding_dim: 256
+        num_embeddings: 100_000
+        feature_names: ["additional_0_0"]
+        data_type: FP16
+        mc_config:
+          mc_type: "mp-zch"
+          total_num_buckets: 10
+          max_probe: 128
+          input_hash_size: 0
+          eviction_policy_name: "SINGLE_TTL_EVICTION"
+          eviction_config:
+            single_ttl: 1
+          disable_fallback: False
+PlannerConfig:
+  # MP-ZCH only works with row-wise sharding
+  additional_constraints:
+    FP16_table:
+      sharding_types: [row_wise]

--- a/torchrec/distributed/test_utils/model_config.py
+++ b/torchrec/distributed/test_utils/model_config.py
@@ -30,6 +30,7 @@ from torchrec.distributed import DistributedModelParallel
 from torchrec.distributed.planner import EmbeddingShardingPlanner
 from torchrec.distributed.planner.planners import HeteroEmbeddingShardingPlanner
 from torchrec.distributed.sharding_plan import get_default_sharders
+from torchrec.distributed.test_utils.table_config import ManagedCollisionConfig
 from torchrec.distributed.test_utils.test_model import (
     TestOverArchLarge,
     TestSparseNN,
@@ -87,7 +88,7 @@ class TestSparseNNConfig(BaseModelConfig):
     max_feature_lengths: Optional[Dict[str, int]] = None
     over_arch_clazz: Type[nn.Module] = TestOverArchLarge
     postproc_module: Optional[nn.Module] = None
-    zch: bool = False
+    mc_configs: Optional[Dict[str, ManagedCollisionConfig]] = None
     submodule_kwargs: Optional[Dict[str, Any]] = None
 
     def generate_model(
@@ -108,7 +109,7 @@ class TestSparseNNConfig(BaseModelConfig):
             over_arch_clazz=self.over_arch_clazz,
             postproc_module=self.postproc_module,
             embedding_groups=self.embedding_groups,
-            zch=self.zch,
+            zch_kwargs=kwargs["mc_configs"] if kwargs["mc_configs"] else None,
             submodule_kwargs=self.submodule_kwargs,
         )
 

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_base.py
@@ -98,13 +98,23 @@ class TrainPipelineSparseDistTestBase(unittest.TestCase):
         postproc_module: Optional[nn.Module] = None,
         zch: bool = False,
     ) -> nn.Module:
+        # Create ZCH kwargs arguments if provided
+        zch_kwargs = None
+        if zch:
+            zch_kwargs = {
+                table.name: {
+                    "mc_type": "sort-zch",
+                    "input_hash_size": 4000,
+                }
+                for table in self.tables
+            }
         unsharded_model = model_type(
             tables=self.tables,
             weighted_tables=self.weighted_tables,
             dense_device=self.device,
             sparse_device=torch.device("meta"),
             postproc_module=postproc_module,
-            zch=zch,
+            zch_kwargs=zch_kwargs,
         )
         if enable_fsdp:
             unsharded_model.over.dhn_arch.linear0 = FSDP(


### PR DESCRIPTION
Summary:
Context
--------
- MP-ZCH is added to torchrec/benchmark
- Detailed control of MP-ZCH was missing from TestSparseNN class
    - Replaced `zch=True` to `zch_kwargs` dictionary that maps table to MP-ZCH configs.

Changes
----------
- Added ManagedCollisionConfig config class to `table_config`
    - Add MC-ZCH configs to `runner`, `ModelConfig.generate_models`.
    - Added `TableExtendedConfigs` to store table configs that aren't in EmbeddingBagConfigs. Currently only stores ZCH configs, so may be too soon to do this.
- Modified EmbeddingTablesConfig to allow both globally define MP-ZCH configs and also to tables within additional_tables.
- Change `TestSparseNN` to work with MC config dictionary.
    - Modified `TestEBCSparseArchZCH` to allow finer control of MP-ZCH parameters.

Limitations
-------------
- Either all tables have MP-ZCH enabled or none at all.
    - Because heavy refactoring will be needed for the Model classes in `test_model.py`.
- Only works with "TestSparseNN" model.
- Two attributed: mc_configs, and mc_config_per_table. The latter is for global embedding.


- Here the trace shows # compute:mcc# and start_sparse_dist and compares with MP-ZCH enabled and without:

{F1984388607}

|Test|GPU Runtime (P90)|CPU Runtime (P90)|GPU Peak Mem alloc (P90)|GPU Peak Mem reserved (P90)|GPU Mem used (P90)|Malloc retries (P50/P90/P100)|CPU Peak RSS (P90)|
|---|---|---|---|---|---|---|---|
|sparse_data_dist_mpzch |143352.48 ms |123275.31 ms|58.98 GB                |67.19 GB                   |96.77 GB          |138.0 / 138.0 / 138.0        |59.95 GB          |
|sparse_data_dist_without_mpzch     |122021.96 ms     |100470.20 ms     |53.17 GB                |67.19 GB                   |96.52 GB          |57.0 / 57.0 / 57.0           |60.01 GB          |

Differential Revision: D89904604


