### PR TITLE
Use logger instead of print for benchmark results

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -197,6 +197,43 @@ class BenchmarkResult:
             content += f"{c: <{length}}|"
         return head + "\n" + split + "\n" + content + "\n"
 
+    def prettify(self) -> str:
+        """Return a human-readable formatted string for console output."""
+        lines = [
+            "",
+            "=" * 60,
+            f"  Benchmark: {self.short_name}",
+            "=" * 60,
+            "",
+            "  Runtime:",
+            f"    GPU (P90):              {self.runtime_percentile(90, device='gpu'):.2f} ms",
+            f"    CPU (P90):              {self.runtime_percentile(90, device='cpu'):.2f} ms",
+        ]
+
+        if len(self.gpu_mem_stats) > 0:
+            lines.extend(
+                [
+                    "",
+                    "  GPU Memory:",
+                    f"    Peak Allocated (P90):   {self.max_mem_alloc_percentile(90)/1000:.2f} GB",
+                    f"    Peak Reserved (P90):    {self.max_mem_reserved_percentile(90)/1000:.2f} GB",
+                    f"    Used (P90):             {self.device_mem_used(90)/1000:.2f} GB",
+                    f"    Malloc Retries:         P50={self.mem_retries(50):.0f}  P90={self.mem_retries(90):.0f}  P100={self.mem_retries(100):.0f}",
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "  CPU Memory:",
+                f"    Peak RSS (P90):         {self.cpu_mem_percentile(90)/1000:.2f} GB",
+                "",
+                "=" * 60,
+            ]
+        )
+
+        return "\n".join(lines)
+
     def runtime_percentile(
         self,
         percentile: int = 50,

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -211,7 +211,8 @@ def runner(
         )
 
         if rank == 0:
-            print(result)
+            print(result.prettify())
+            print("\nMarkdown format:\n", result)
 
         return result
 

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -20,8 +20,11 @@ To support a new model in pipeline benchmark:
     See benchmark_pipeline_utils.py for step-by-step instructions.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import List, Optional
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
@@ -211,8 +214,9 @@ def runner(
         )
 
         if rank == 0:
-            print(result.prettify())
-            print("\nMarkdown format:\n", result)
+            logger.setLevel(logging.INFO)
+            logger.info(result.prettify())
+            logger.info("\nMarkdown format:\n%s", result)
 
         return result
 


### PR DESCRIPTION
Summary: Replace print() with logger.info() for benchmark result output to follow logging best practices and enable better control over output verbosity. The logger level is set locally to INFO since the global default is WARNING.

Reviewed By: ge0405

Differential Revision: D89969780


