### PR TITLE
disable pt2 compile for RecMetricComputation::_aggregate_window_state

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -223,6 +223,8 @@ class RecMetricComputation(Metric, abc.ABC):
                 max_buffer_count=MAX_BUFFER_COUNT,
             )
 
+    # disable pt2 compile for this function as it would exceed the recompilation limit
+    @torch.compiler.disable
     def _aggregate_window_state(
         self, state_name: str, state: torch.Tensor, num_samples: int
     ) -> None:


### PR DESCRIPTION
Summary: PT2 compile fails compiling most torchrec metrics because the recompilation of RecMetricComputation::_aggregate_window_state function hits the limit. This diff fix this issue by disabling PT2 compile for this function explicitly.

Differential Revision: D88123850


