### PR TITLE
Remove creating string for every key in plan to due perf Tradeoff

### DIFF
--- a/torchrec/distributed/sharding/dynamic_sharding.py
+++ b/torchrec/distributed/sharding/dynamic_sharding.py
@@ -919,9 +919,7 @@ def output_sharding_plans_delta(
     """
     delta_plans: Dict[str, Tuple[float, EmbeddingModuleShardingPlan]] = {}
     for key, plan in old_plan.items():
-        assert (
-            key in new_plan
-        ), f"Found mismatch between old and new plans, key: {key} not found in new plan"
+        assert key in new_plan
 
         delta_plans[key] = output_sharding_plan_delta_single(
             plan, new_plan[key], return_data_volume


### PR DESCRIPTION
Summary:
Remove creating string for every key in plan to due perf Tradeoff 
See https://www.internalfb.com/diff/D83392188?dst_version_fbid=1119237770399547&transaction_fbid=1555559529057501 

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: isururanawaka

Differential Revision: D90123914


