### PR TITLE
fill in default argument for sparse_data_dist_ssd.yml

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
@@ -10,6 +10,8 @@ RunOptions:
   # export_stacks: True # enable this to export stack traces
 PipelineConfig:
   pipeline: "sparse"
+ModelInputConfig:
+  feature_pooling_avg: 10
 EmbeddingTablesConfig:
   num_unweighted_features: 100
   num_weighted_features: 100


### PR DESCRIPTION
Summary:
If i run 
```
buck2 run fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline --     --yaml_config=torchrec/distributed/benchmark/yaml/sparse_data_dist_ssd.yml
```
it will show error: `TypeError: unsupported operand type(s) for /: '_MISSING_TYPE' and 'int'`

In the previous PR https://github.com/meta-pytorch/torchrec/pull/3640 I added an error message indicating a required parameter. In this one, I will make the command work by adding default value in the yml file

Reviewed By: TroyGarden

Differential Revision: D90213403


