### PR TITLE
Attempt to fix github CI failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ tensordict
 torchmetrics==1.0.3
 torchx
 tqdm
+triton
 usort
 parameterized
 PyYAML


### PR DESCRIPTION
Summary:
Example failure https://github.com/meta-pytorch/torchrec/actions/runs/20792264464/job/59717018870?pr=3650


```
/opt/conda/envs/build_binary/lib/python3.13/site-packages/fbgemm_gpu/triton/quantize.py:13: in <module>
    import triton  # manual
    ^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'triton'
```

Differential Revision: D90334535


