### PR TITLE
CPUOffloadedRecMetricModule: DtoHs in the update thread

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -103,9 +103,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             *args,
             **kwargs,
         )
-        self.update_thread.start()
-        self.compute_thread.start()
 
+        self.update_job_time_logger: PercentileLogger = PercentileLogger(
+            metric_name="update_job_time_ms", log_interval=1000
+        )
         self.update_queue_size_logger: PercentileLogger = PercentileLogger(
             metric_name="update_queue_size", log_interval=1000
         )
@@ -122,7 +123,15 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             "all_gather_time_ms", log_interval=10
         )
 
+        self.update_thread.start()
+        self.compute_thread.start()
+
         logger.info("CPUOffloadedRecMetricModule initialization complete.")
+
+    @override
+    def update(self, model_out: Dict[str, torch.Tensor], **kwargs: Any) -> None:
+        self._update_rec_metrics(model_out, **kwargs)
+        self.trained_batches += 1
 
     @override
     def _update_rec_metrics(
@@ -145,15 +154,9 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             raise self._captured_exception
 
         try:
-            cpu_model_out, transfer_completed_event = (
-                self._transfer_to_cpu(model_out)
-                if self._model_out_device.type == "cuda"
-                else (model_out, None)
-            )
             self.update_queue.put_nowait(
                 MetricUpdateJob(
-                    model_out=cpu_model_out,
-                    transfer_completed_event=transfer_completed_event,
+                    model_out=model_out,
                     kwargs=kwargs,
                 )
             )
@@ -207,11 +210,17 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         """
 
         with record_function("## CPUOffloadedRecMetricModule:update ##"):
-            if metric_update_job.transfer_completed_event is not None:
-                metric_update_job.transfer_completed_event.synchronize()
+            start_time = time.time()
+            cpu_model_out, transfer_completed_event = (
+                self._transfer_to_cpu(metric_update_job.model_out)
+                if self._model_out_device.type == "cuda"
+                else (metric_update_job.model_out, None)
+            )
+            if transfer_completed_event is not None:
+                transfer_completed_event.synchronize()
             labels, predictions, weights, required_inputs = parse_task_model_outputs(
                 self.rec_tasks,
-                metric_update_job.model_out,
+                cpu_model_out,
                 self.get_required_inputs(),
             )
             if required_inputs:
@@ -227,6 +236,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             if self.throughput_metric:
                 self.throughput_metric.update()
 
+            self.update_job_time_logger.add((time.time() - start_time) * 1000)
+
     @override
     def shutdown(self) -> None:
         """
@@ -241,6 +252,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         if self.compute_thread.is_alive():
             self.compute_thread.join(timeout=30.0)
 
+        self.update_job_time_logger.log_percentiles()
         self.update_queue_size_logger.log_percentiles()
         self.compute_queue_size_logger.log_percentiles()
         self.compute_job_time_logger.log_percentiles()

--- a/torchrec/metrics/metric_job_types.py
+++ b/torchrec/metrics/metric_job_types.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import concurrent
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 from torchrec.metrics.metric_module import MetricValue
@@ -17,29 +17,26 @@ from torchrec.metrics.metric_state_snapshot import MetricStateSnapshot
 
 class MetricUpdateJob:
     """
-    Encapsulates metric update job for CPU processing:
-    update each metric state tensors with intermediate model outputs
+    Encapsulates a metric update job for CPU processing.
+    The model outputs are transferred to CPU (if needed) and used
+    to update each metric's state tensors.
     """
 
-    __slots__ = ["model_out", "transfer_completed_event", "kwargs"]
+    __slots__ = ["model_out", "kwargs"]
 
     def __init__(
         self,
         model_out: Dict[str, torch.Tensor],
-        transfer_completed_event: Optional[torch.cuda.Event],
         kwargs: Dict[str, Any],
     ) -> None:
         """
         Args:
-            model_out: intermediate model outputs to be used for metric updates
-            transfer_completed_event: cuda event to track when the transfer to CPU is completed
+            model_out: intermediate model outputs (may be on GPU; DtoH
+                transfer is handled by the processing thread)
             kwargs: additional arguments from the trainer platform
         """
 
         self.model_out: Dict[str, torch.Tensor] = model_out
-        self.transfer_completed_event: Optional[torch.cuda.Event] = (
-            transfer_completed_event
-        )
         self.kwargs: Dict[str, Any] = kwargs
 
 


### PR DESCRIPTION
Summary:
CPUOffloadedRecMetricModule currently performs DtoH (nonblocking) from the main thread. This can start to become quite expensive when the order of magnitude of the model_out dict size is in the thousands, where each key stores a tensor with 1000+ elements.

Instead of the main thread launching the DtoHs, have the update thread be responsible. This will free the main thread to continue training.

Differential Revision: D87800947


