### PR TITLE
Adding per-label precision metric for multi label tasks

### DIFF
--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -49,6 +49,7 @@ from torchrec.metrics.metrics_namespace import (
 )
 from torchrec.metrics.model_utils import parse_task_model_outputs
 from torchrec.metrics.mse import MSEMetric
+from torchrec.metrics.multi_label_precision import MultiLabelPrecisionMetric
 from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ndcg import NDCGMetric
 from torchrec.metrics.ne import NEMetric
@@ -109,6 +110,7 @@ REC_METRICS_MAPPING: Dict[RecMetricEnumBase, Type[RecMetric]] = {
     RecMetricEnum.HINDSIGHT_TARGET_PR: HindsightTargetPRMetric,
     RecMetricEnum.NMSE: NMSEMetric,
     RecMetricEnum.AVERAGE: AverageMetric,
+    RecMetricEnum.MULTI_LABEL_PRECISION: MultiLabelPrecisionMetric,
 }
 
 

--- a/torchrec/metrics/metrics_config.py
+++ b/torchrec/metrics/metrics_config.py
@@ -53,6 +53,7 @@ class RecMetricEnum(RecMetricEnumBase):
     HINDSIGHT_TARGET_PR = "hindsight_target_pr"
     NMSE = "nmse"
     AVERAGE = "average"
+    MULTI_LABEL_PRECISION = "multi_label_precision"
 
 
 @dataclass(unsafe_hash=True, eq=True)

--- a/torchrec/metrics/metrics_namespace.py
+++ b/torchrec/metrics/metrics_namespace.py
@@ -63,6 +63,7 @@ class MetricName(MetricNameBase):
     RECALL_SESSION_LEVEL = "recall_session_level"
     PRECISION_SESSION_LEVEL = "precision_session_level"
     MULTICLASS_RECALL = "multiclass_recall"
+    MULTI_LABEL_PRECISION = "multi_label_precision"
     WEIGHTED_AVG = "weighted_avg"
     TOWER_QPS = "qps"
     ACCURACY = "accuracy"
@@ -126,6 +127,7 @@ class MetricNamespace(MetricNamespaceBase):
     MODEL_CONFIGURATOR = "model_configurator"
 
     MULTICLASS_RECALL = "multiclass_recall"
+    MULTI_LABEL_PRECISION = "multi_label_precision"
 
     WEIGHTED_AVG = "weighted_avg"
     RECALL_SESSION_LEVEL = "recall_session_level"

--- a/torchrec/metrics/multi_label_precision.py
+++ b/torchrec/metrics/multi_label_precision.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+from torchrec.metrics.metrics_namespace import MetricName, MetricNamespace, MetricPrefix
+from torchrec.metrics.rec_metric import (
+    MetricComputationReport,
+    RecMetric,
+    RecMetricComputation,
+)
+
+
+def compute_multi_label_precision(
+    num_true_positives: torch.Tensor, num_false_positives: torch.Tensor
+) -> torch.Tensor:
+    total = num_true_positives + num_false_positives
+    return torch.where(
+        total == 0.0,
+        torch.zeros_like(total),
+        num_true_positives / total,
+    )
+
+
+class MultiLabelPrecisionMetricComputation(RecMetricComputation):
+    r"""Multi-label precision metric computation class.
+
+    This class computes precision for multi-label classification tasks where each
+    sample can belong to multiple classes simultaneously. Unlike binary or
+    multi-class classification, multi-label classification allows for multiple
+    positive labels per sample.
+
+    **Input Format:**
+        Both predictions and labels must be integer-encoded tensors where each
+        integer represents a binary vector encoded using LSB-first bit ordering.
+        For example, with num_labels=3:
+            - Integer 5 (binary 101) decodes to [1, 0, 1] (labels 0 and 2 are positive)
+            - Integer 3 (binary 011) decodes to [1, 1, 0] (labels 0 and 1 are positive)
+
+    **Precision Formula:**
+        Precision = TP / (TP + FP)
+
+    Where:
+        - TP (True Positives): Decoded prediction == 1 AND decoded label == 1
+        - FP (False Positives): Decoded prediction == 1 AND decoded label == 0
+
+    Args:
+        num_labels: Number of labels in the multi-label classification task.
+            This determines how many bits to decode from each integer. Default: 1
+        label_names: Optional list of human-readable names for each label.
+            If not provided, defaults to ["label_0", "label_1", ..., "label_{n-1}"]
+        *args: Additional positional arguments passed to RecMetricComputation
+        **kwargs: Additional keyword arguments passed to RecMetricComputation
+
+    Example:
+        >>> # predictions and labels are integer-encoded
+        >>> # e.g., prediction=5 means labels [1,0,1], label=3 means [1,1,0]
+        >>> metric = MultiLabelPrecisionMetric(
+        ...     world_size=1,
+        ...     my_rank=0,
+        ...     batch_size=32,
+        ...     tasks=[task],
+        ...     num_labels=3,
+        ...     label_names=["cat", "dog", "horse"],
+        ... )
+        >>> metric.update(predictions=int_preds, labels=int_labels, weights=None)
+        >>> results = metric.compute()  # Returns per-label precision
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        num_labels: int = 1,
+        label_names: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._num_labels: Optional[int] = num_labels  # Store num_labels from config
+        self._label_names: List[str] = (
+            [f"label_{i}" for i in range(self._num_labels)]
+            if label_names is None
+            else label_names
+        )
+
+        self._per_label_states_initialized = False
+
+        for label_name in self._label_names:
+            self._add_state(
+                f"true_pos_sum_{label_name}",
+                torch.zeros(1, dtype=torch.double),
+                add_window_state=True,
+                dist_reduce_fx="sum",
+                persistent=True,
+            )
+            self._add_state(
+                f"false_pos_sum_{label_name}",
+                torch.zeros(1, dtype=torch.double),
+                add_window_state=True,
+                dist_reduce_fx="sum",
+                persistent=True,
+            )
+
+    def _decode_integer_to_labels(
+        self,
+        tensor: torch.Tensor,
+        num_labels: int,
+    ) -> torch.Tensor:
+        """Convert integer-encoded tensors to binary label vectors (LSB first).
+
+        Each integer is decoded to a binary vector where bit i represents label i.
+        Uses LSB-first ordering: the least significant bit corresponds to label 0.
+        """
+        device = tensor.device
+        dtype = tensor.dtype
+        powers_of_two = (2 ** torch.arange(num_labels, device=device)).to(dtype)
+        tensor_expanded = tensor.reshape(-1, 1)
+        label_tensor = (tensor_expanded // powers_of_two) % 2
+        return label_tensor.to(torch.int32)
+
+    def _prepare_inputs(
+        self,
+        predictions: torch.Tensor,
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Decode integer-encoded inputs and prepare for precision computation.
+
+        Converts integer-encoded predictions and labels to binary multi-label
+        format and expands weights to match the decoded tensor shape.
+        """
+        # predictions and labels are integer-encoded [batch_size] or [batch_size, 1]
+        predictions = self._decode_integer_to_labels(
+            predictions.flatten(), self._num_labels
+        )
+        labels = self._decode_integer_to_labels(labels.flatten(), self._num_labels)
+        # Expand weights to match
+        if weights is not None:
+            weights = weights.flatten().unsqueeze(-1).expand(-1, self._num_labels)
+        else:
+            weights = torch.ones_like(predictions, dtype=torch.float32)
+        return predictions, labels, weights
+
+    def _update_label_states(
+        self,
+        label_idx: int,
+        label_name: str,
+        predictions: torch.Tensor,
+        labels: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> None:
+        """Compute and update TP/FP states for a single label."""
+        pred_i = predictions[:, label_idx]
+        target_i = labels[:, label_idx]
+        weight_i = weights[:, label_idx]
+
+        # Compute TP and FP for this label (predictions are already binary 0/1)
+        true_pos = torch.sum(weight_i * (pred_i * target_i))
+        false_pos = torch.sum(weight_i * (pred_i * (1 - target_i)))
+
+        # Update lifetime states
+        tp_state = getattr(self, f"true_pos_sum_{label_name}")
+        fp_state = getattr(self, f"false_pos_sum_{label_name}")
+        tp_state.add_(true_pos)
+        fp_state.add_(false_pos)
+
+        # Update window states
+        batch_size = predictions.shape[0]
+        self._aggregate_window_state(f"true_pos_sum_{label_name}", true_pos, batch_size)
+        self._aggregate_window_state(
+            f"false_pos_sum_{label_name}", false_pos, batch_size
+        )
+
+    def update(
+        self,
+        *,
+        predictions: Optional[torch.Tensor],
+        labels: torch.Tensor,
+        weights: Optional[torch.Tensor],
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        """Update metric states with a new batch of integer-encoded data."""
+        device = predictions.device
+        self.to(device)
+
+        predictions, labels, weights = self._prepare_inputs(
+            predictions, labels, weights
+        )
+
+        for i, label_name in enumerate(self._label_names):
+            self._update_label_states(i, label_name, predictions, labels, weights)
+
+    def _compute(self) -> List[MetricComputationReport]:
+        reports = []
+
+        # Per-label precision reports
+        for label_name in self._label_names:
+            tp_state = getattr(self, f"true_pos_sum_{label_name}")
+            fp_state = getattr(self, f"false_pos_sum_{label_name}")
+
+            # Lifetime precision for this label
+            reports.append(
+                MetricComputationReport(
+                    name=MetricName.MULTI_LABEL_PRECISION,
+                    metric_prefix=MetricPrefix.LIFETIME,
+                    value=compute_multi_label_precision(tp_state, fp_state),
+                    description=f"{label_name}",
+                )
+            )
+
+            # Window precision for this label
+            reports.append(
+                MetricComputationReport(
+                    name=MetricName.MULTI_LABEL_PRECISION,
+                    metric_prefix=MetricPrefix.WINDOW,
+                    value=compute_multi_label_precision(
+                        self.get_window_state(f"true_pos_sum_{label_name}"),
+                        self.get_window_state(f"false_pos_sum_{label_name}"),
+                    ),
+                    description=f"{label_name}",
+                )
+            )
+        return reports
+
+
+class MultiLabelPrecisionMetric(RecMetric):
+    _namespace: MetricNamespace = MetricNamespace.MULTI_LABEL_PRECISION
+    _computation_class: Type[RecMetricComputation] = (
+        MultiLabelPrecisionMetricComputation
+    )

--- a/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
+++ b/torchrec/metrics/tests/metric_fqn_golden_snapshot.json
@@ -141,6 +141,17 @@
     ],
     "variant": ""
   },
+  "MultiLabelPrecisionMetric_UNFUSED_TASKS_COMPUTATION": {
+    "compute_mode": "UNFUSED_TASKS_COMPUTATION",
+    "metric_class": "MultiLabelPrecisionMetric",
+    "non_persistent_buffer_fqns": [],
+    "persistent_buffer_fqns": [],
+    "state_dict_keys": [
+      "_metrics_computations.0.false_pos_sum_label_0",
+      "_metrics_computations.0.true_pos_sum_label_0"
+    ],
+    "variant": ""
+  },
   "NDCGMetric_UNFUSED_TASKS_COMPUTATION": {
     "compute_mode": "UNFUSED_TASKS_COMPUTATION",
     "metric_class": "NDCGMetric",

--- a/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
+++ b/torchrec/metrics/tests/test_metric_fqn_backward_compatibility.py
@@ -50,6 +50,7 @@ from torchrec.metrics.mae import MAEMetric
 from torchrec.metrics.metric_module import RecMetricModule
 from torchrec.metrics.metrics_config import RecComputeMode, RecTaskInfo
 from torchrec.metrics.mse import MSEMetric
+from torchrec.metrics.multi_label_precision import MultiLabelPrecisionMetric
 from torchrec.metrics.multiclass_recall import MulticlassRecallMetric
 from torchrec.metrics.ndcg import NDCGMetric
 from torchrec.metrics.ne import NEMetric
@@ -228,6 +229,12 @@ METRICS_TO_TEST: List[
     (NDCGMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
     (XAUCMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
     (ScalarMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
+    (
+        MultiLabelPrecisionMetric,
+        [RecComputeMode.UNFUSED_TASKS_COMPUTATION],
+        {"num_labels": 1},
+        [""],
+    ),
     # Metrics with non-persistent state (AUC family)
     (AUCMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
     (AUPRCMetric, [RecComputeMode.UNFUSED_TASKS_COMPUTATION], {}, [""]),
@@ -641,6 +648,13 @@ class MetricFQNBackwardCompatibilityTest(unittest.TestCase):
             MulticlassRecallMetric,
             RecComputeMode.UNFUSED_TASKS_COMPUTATION,
             number_of_classes=3,
+        )
+
+    def test_multi_label_precision_metric(self) -> None:
+        self._check_metric_compatibility(
+            MultiLabelPrecisionMetric,
+            RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            num_labels=1,
         )
 
     def test_segmented_ne_metric(self) -> None:

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -384,6 +384,8 @@ class MetricModuleTest(unittest.TestCase):
             "rec_metrics.rec_metrics.31._metrics_computations.0.prediction_sum",
             "rec_metrics.rec_metrics.31._metrics_computations.0.label_sum",
             "rec_metrics.rec_metrics.31._metrics_computations.0.weighted_num_samples",
+            "rec_metrics.rec_metrics.32._metrics_computations.0.false_pos_sum_label_0",
+            "rec_metrics.rec_metrics.32._metrics_computations.0.true_pos_sum_label_0",
             "throughput_metric.total_examples",
             "throughput_metric.warmup_examples",
             "throughput_metric.time_lapse_after_warmup",

--- a/torchrec/metrics/tests/test_multi_label_precision.py
+++ b/torchrec/metrics/tests/test_multi_label_precision.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+
+import torch
+from torchrec.metrics.multi_label_precision import (
+    compute_multi_label_precision,
+    MultiLabelPrecisionMetric,
+    MultiLabelPrecisionMetricComputation,
+)
+from torchrec.metrics.rec_metric import RecComputeMode, RecTaskInfo
+
+
+class MultiLabelPrecisionMetricTest(unittest.TestCase):
+    """Tests for MultiLabelPrecisionMetricComputation with integer-encoded inputs.
+
+    The metric expects predictions and labels to be integer-encoded using
+    LSB-first bit ordering. For example, with num_labels=3:
+        - Integer 5 (binary 101) decodes to [1, 0, 1] (labels 0 and 2 are positive)
+        - Integer 3 (binary 011) decodes to [1, 1, 0] (labels 0 and 1 are positive)
+        - Integer 7 (binary 111) decodes to [1, 1, 1] (all labels are positive)
+    """
+
+    def _create_computation(
+        self, num_labels: int = 1, label_names: list[str] | None = None
+    ) -> MultiLabelPrecisionMetricComputation:
+        """Helper to create a MultiLabelPrecisionMetricComputation instance."""
+        return MultiLabelPrecisionMetricComputation(
+            my_rank=0,
+            batch_size=100,
+            n_tasks=1,
+            window_size=100,
+            compute_on_all_ranks=False,
+            should_validate_update=False,
+            process_group=None,
+            num_labels=num_labels,
+            label_names=label_names,
+        )
+
+    def _create_metric(
+        self,
+        num_labels: int = 1,
+        label_names: List[str] | None = None,
+        compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+    ) -> MultiLabelPrecisionMetric:
+        """Helper to create a MultiLabelPrecisionMetric instance."""
+        tasks = [
+            RecTaskInfo(
+                name="test_task",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+        ]
+        return MultiLabelPrecisionMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=100,
+            tasks=tasks,
+            compute_mode=compute_mode,
+            window_size=100,
+            num_labels=num_labels,
+            label_names=label_names,
+        )
+
+    def test_custom_label_names_creates_per_label_states(self) -> None:
+        """Verify that custom label_names creates states for each label"""
+        label_names = ["purchase", "add_to_cart", "view"]
+
+        computation = self._create_computation(num_labels=3, label_names=label_names)
+
+        for label_name in label_names:
+            self.assertTrue(
+                hasattr(computation, f"true_pos_sum_{label_name}"),
+                f"Missing true_pos_sum_{label_name} state",
+            )
+            self.assertTrue(
+                hasattr(computation, f"false_pos_sum_{label_name}"),
+                f"Missing false_pos_sum_{label_name} state",
+            )
+
+    def test_default_label_names_generated_from_num_labels(self) -> None:
+        """Verify that default label names are generated when not provided"""
+        num_labels = 4
+
+        computation = self._create_computation(num_labels=num_labels)
+
+        for i in range(num_labels):
+            expected_label = f"label_{i}"
+            self.assertTrue(
+                hasattr(computation, f"true_pos_sum_{expected_label}"),
+                f"Missing true_pos_sum_{expected_label} state",
+            )
+            self.assertTrue(
+                hasattr(computation, f"false_pos_sum_{expected_label}"),
+                f"Missing false_pos_sum_{expected_label} state",
+            )
+
+    def test_compute_multi_label_precision_basic(self) -> None:
+        """Test basic precision calculation: TP / (TP + FP)"""
+        true_positives = torch.tensor([3.0])
+        false_positives = torch.tensor([1.0])
+
+        result = compute_multi_label_precision(true_positives, false_positives)
+        expected = torch.tensor([0.75])
+
+        torch.testing.assert_close(result, expected, atol=1e-6, rtol=1e-6)
+
+    def test_compute_multi_label_precision_zero_denominator(self) -> None:
+        """Test precision returns 0 when TP + FP = 0"""
+        true_positives = torch.tensor([0.0])
+        false_positives = torch.tensor([0.0])
+
+        result = compute_multi_label_precision(true_positives, false_positives)
+        expected = torch.tensor([0.0])
+
+        torch.testing.assert_close(result, expected, atol=1e-6, rtol=1e-6)
+
+    def test_decode_integer_to_labels(self) -> None:
+        """Test that integer decoding produces correct binary vectors"""
+        computation = self._create_computation(num_labels=3)
+
+        tensor = torch.tensor([5, 3])
+        result = computation._decode_integer_to_labels(tensor, num_labels=3)
+
+        expected = torch.tensor([[1, 0, 1], [1, 1, 0]], dtype=torch.int32)
+        torch.testing.assert_close(result, expected)
+
+    def test_decode_integer_to_labels_single_label(self) -> None:
+        """Test decoding with num_labels=1"""
+        computation = self._create_computation(num_labels=1)
+
+        tensor = torch.tensor([0, 1, 0, 1])
+        result = computation._decode_integer_to_labels(tensor, num_labels=1)
+
+        expected = torch.tensor([[0], [1], [0], [1]], dtype=torch.int32)
+        torch.testing.assert_close(result, expected)
+
+    def test_update_accumulates_tp_fp(self) -> None:
+        """Test that update correctly accumulates TP and FP"""
+        computation = self._create_computation(num_labels=2)
+
+        predictions = torch.tensor([3, 3])
+        labels = torch.tensor([1, 3])
+        weights = torch.ones(2)
+
+        computation.update(predictions=predictions, labels=labels, weights=weights)
+
+        self.assertEqual(computation.true_pos_sum_label_0.item(), 2.0)
+        self.assertEqual(computation.false_pos_sum_label_0.item(), 0.0)
+        self.assertEqual(computation.true_pos_sum_label_1.item(), 1.0)
+        self.assertEqual(computation.false_pos_sum_label_1.item(), 1.0)
+
+    def test_update_with_weights(self) -> None:
+        """Test that weights are applied correctly"""
+        computation = self._create_computation(num_labels=2)
+
+        predictions = torch.tensor([3, 3])
+        labels = torch.tensor([1, 2])
+        weights = torch.tensor([2.0, 1.0])
+
+        computation.update(predictions=predictions, labels=labels, weights=weights)
+
+        self.assertEqual(computation.true_pos_sum_label_0.item(), 2.0)
+        self.assertEqual(computation.false_pos_sum_label_0.item(), 1.0)
+        self.assertEqual(computation.true_pos_sum_label_1.item(), 1.0)
+        self.assertEqual(computation.false_pos_sum_label_1.item(), 2.0)
+
+    # =========================================================================
+    # Per-label metric tests for different compute modes
+    # =========================================================================
+
+    def test_metric_unfused_mode_per_label_output(self) -> None:
+        """Test MultiLabelPrecisionMetric in UNFUSED mode produces per-label metrics."""
+        num_labels = 3
+        label_names = ["click", "purchase", "view"]
+        metric = self._create_metric(
+            num_labels=num_labels,
+            label_names=label_names,
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+        )
+
+        # Batch 1: predictions=7 (all 1s), labels=5 (101 -> click=1, purchase=0, view=1)
+        # click: TP=1, FP=0; purchase: TP=0, FP=1; view: TP=1, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([7])},
+            labels={"test_task": torch.tensor([5])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        # Batch 2: predictions=3 (011), labels=3 (011 -> click=1, purchase=1, view=0)
+        # click: TP=1, FP=0; purchase: TP=1, FP=0; view: TP=0, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([3])},
+            labels={"test_task": torch.tensor([3])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        results = metric.compute()
+
+        # Verify per-label results exist
+        for label_name in label_names:
+            lifetime_key = f"multi_label_precision-test_task|lifetime_multi_label_precision{label_name}"
+            window_key = f"multi_label_precision-test_task|window_multi_label_precision{label_name}"
+            self.assertIn(
+                lifetime_key, results, f"Missing lifetime metric for {label_name}"
+            )
+            self.assertIn(
+                window_key, results, f"Missing window metric for {label_name}"
+            )
+
+        # Verify precision values
+        # click: TP=2, FP=0 -> precision=1.0
+        # purchase: TP=1, FP=1 -> precision=0.5
+        # view: TP=1, FP=0 -> precision=1.0
+        click_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionclick"
+        ]
+        purchase_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionpurchase"
+        ]
+        view_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionview"
+        ]
+
+        self.assertAlmostEqual(click_precision.item(), 1.0, places=5)
+        self.assertAlmostEqual(purchase_precision.item(), 0.5, places=5)
+        self.assertAlmostEqual(view_precision.item(), 1.0, places=5)
+
+    def test_metric_fused_mode_per_label_output(self) -> None:
+        """Test MultiLabelPrecisionMetric in FUSED mode produces per-label metrics."""
+        num_labels = 2
+        metric = self._create_metric(
+            num_labels=num_labels,
+            compute_mode=RecComputeMode.FUSED_TASKS_COMPUTATION,
+        )
+
+        # predictions=3 (11), labels=1 (01)
+        # label_0: TP=1, FP=0; label_1: TP=0, FP=1
+        metric.update(
+            predictions={"test_task": torch.tensor([3])},
+            labels={"test_task": torch.tensor([1])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        results = metric.compute()
+
+        # Verify per-label results exist
+        for i in range(num_labels):
+            label_name = f"label_{i}"
+            lifetime_key = f"multi_label_precision-test_task|lifetime_multi_label_precision{label_name}"
+            self.assertIn(
+                lifetime_key, results, f"Missing lifetime metric for {label_name}"
+            )
+
+        # label_0: precision=1.0 (TP=1, FP=0)
+        # label_1: precision=0.0 (TP=0, FP=1)
+        label0_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_0"
+        ]
+        label1_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_1"
+        ]
+
+        self.assertAlmostEqual(label0_precision.item(), 1.0, places=5)
+        self.assertAlmostEqual(label1_precision.item(), 0.0, places=5)
+
+    def test_metric_multiple_batches_accumulation(self) -> None:
+        """Test that metric correctly accumulates states across multiple batches."""
+        num_labels = 2
+        metric = self._create_metric(num_labels=num_labels)
+
+        # Batch 1: pred=3 (11), label=1 (01) -> label_0: TP=1, FP=0; label_1: TP=0, FP=1
+        metric.update(
+            predictions={"test_task": torch.tensor([3])},
+            labels={"test_task": torch.tensor([1])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        # Batch 2: pred=3 (11), label=3 (11) -> label_0: TP=1, FP=0; label_1: TP=1, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([3])},
+            labels={"test_task": torch.tensor([3])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        # Batch 3: pred=2 (10), label=0 (00) -> label_0: TP=0, FP=0; label_1: TP=0, FP=1
+        metric.update(
+            predictions={"test_task": torch.tensor([2])},
+            labels={"test_task": torch.tensor([0])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        results = metric.compute()
+
+        # label_0: TP=2, FP=0 -> precision=1.0
+        # label_1: TP=1, FP=2 -> precision=0.333...
+        label0_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_0"
+        ]
+        label1_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_1"
+        ]
+
+        self.assertAlmostEqual(label0_precision.item(), 1.0, places=4)
+        self.assertAlmostEqual(label1_precision.item(), 1.0 / 3.0, places=4)
+
+    def test_metric_with_batch_weights(self) -> None:
+        """Test that sample weights are correctly applied in metric computation."""
+        num_labels = 2
+        metric = self._create_metric(num_labels=num_labels)
+
+        # Two samples with different weights
+        # Sample 1 (weight=2): pred=3 (11), label=1 (01) -> label_0: TP=2, FP=0; label_1: TP=0, FP=2
+        # Sample 2 (weight=1): pred=3 (11), label=2 (10) -> label_0: TP=0, FP=1; label_1: TP=1, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([3, 3])},
+            labels={"test_task": torch.tensor([1, 2])},
+            weights={"test_task": torch.tensor([2.0, 1.0])},
+        )
+
+        results = metric.compute()
+
+        # label_0: TP=2, FP=1 -> precision=2/3
+        # label_1: TP=1, FP=2 -> precision=1/3
+        label0_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_0"
+        ]
+        label1_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_1"
+        ]
+
+        self.assertAlmostEqual(label0_precision.item(), 2.0 / 3.0, places=4)
+        self.assertAlmostEqual(label1_precision.item(), 1.0 / 3.0, places=4)
+
+    def test_metric_window_vs_lifetime(self) -> None:
+        """Test that window and lifetime metrics track separately."""
+        num_labels = 1
+        # Window size must be larger than batch size
+        tasks = [
+            RecTaskInfo(
+                name="test_task",
+                label_name="label",
+                prediction_name="prediction",
+                weight_name="weight",
+            )
+        ]
+        metric = MultiLabelPrecisionMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=tasks,
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=2,  # Only keep last 2 batches in window
+            num_labels=num_labels,
+        )
+
+        # Batch 1: pred=1, label=0 -> FP=1, TP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([1])},
+            labels={"test_task": torch.tensor([0])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        # Batch 2: pred=1, label=1 -> TP=1, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([1])},
+            labels={"test_task": torch.tensor([1])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        # Batch 3: pred=1, label=1 -> TP=1, FP=0
+        metric.update(
+            predictions={"test_task": torch.tensor([1])},
+            labels={"test_task": torch.tensor([1])},
+            weights={"test_task": torch.tensor([1.0])},
+        )
+
+        results = metric.compute()
+
+        # Lifetime: TP=2, FP=1 -> precision=2/3
+        lifetime_precision = results[
+            "multi_label_precision-test_task|lifetime_multi_label_precisionlabel_0"
+        ]
+        self.assertAlmostEqual(lifetime_precision.item(), 2.0 / 3.0, places=4)
+
+        # Window should only have last 2 batches (batch 2 and 3): TP=2, FP=0 -> precision=1.0
+        window_precision = results[
+            "multi_label_precision-test_task|window_multi_label_precisionlabel_0"
+        ]
+        self.assertAlmostEqual(window_precision.item(), 1.0, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff enables tracking precision values at per-label level for multi-label task during training on tensorboard.

This module computes precision for multi-label classification tasks where each sample can belong to multiple classes simultaneously. Unlike binary or multi-class classification, multi-label classification allows for multiple positive labels per sample.

 **Input Format:**
 Both predictions and labels must be integer-encoded tensors where each integer represents a binary vector encoded using LSB-first bit ordering.

For example, with num_labels=3:
            - Integer 5 (binary 101) decodes to [1, 0, 1] (labels 0 and 2 are positive)
            - Integer 3 (binary 011) decodes to [1, 1, 0] (labels 0 and 1 are positive)

**Precision Formula:**
        Precision = TP / (TP + FP)

    Where:
        - TP (True Positives): Decoded prediction == 1 AND decoded label == 1
        - FP (False Positives): Decoded prediction == 1 AND decoded label == 0

Differential Revision: D87835212
