### PR TITLE
[detailed] Supporting TorchRec in Python 3.14

### DIFF
--- a/.github/scripts/filter.py
+++ b/.github/scripts/filter.py
@@ -63,7 +63,7 @@ def main():
         if entry["desired_cuda"] == "cu130":
             # fbgemm only supports cuda 12.6, 12.8 and 12.9
             continue
-        if entry["python_version"] in ("3.14", "3.14t", "3.9"):
+        if entry["python_version"] in ("3.14t", "3.9"):
             # stop python3.9 support, and skipp python3.14 due to incompatibility with torch.compile
             # for python version: https://devguide.python.org/versions/
             # for torch.compile: https://github.com/pytorch/pytorch/issues/156856

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -9,9 +9,7 @@
 export PYTORCH_CUDA_PKG=""
 export CONDA_ENV="build_binary"
 
-if [[ ${MATRIX_PYTHON_VERSION} = '3.14' ]]; then
-    exit 0 # fbgemm doesn't support python 3.14 so far
-elif [[ ${MATRIX_PYTHON_VERSION} = '3.14t' ]]; then
+if [[ ${MATRIX_PYTHON_VERSION} = '3.14t' ]]; then
     exit 0 # fbgemm doesn't support python 3.14 so far
     # use conda-forge to install python3.14t
     conda create -y -n "${CONDA_ENV}" python="3.14" python-freethreading -c conda-forge

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - .gitignore
+      - ".github/workflows/[bcprvu]*.yml"
 
 jobs:
   build_docs_job:
@@ -17,8 +20,8 @@ jobs:
       matrix:
         include:
          - os: linux.24_04.4x
-           python-version: 3.12
-           python-tag: "py312"
+           python-version: 3.14
+           python-tag: "py314"
     steps:
     - name: Check ldd --version
       run: ldd --version

--- a/.github/workflows/pyre.yml
+++ b/.github/workflows/pyre.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      - "docs/*"
+      - "third_party/*"
+      - "*.md"
+      - .gitignore
+      - ".github/workflows/[bcdrvu]*.yml"
 
 jobs:
   pyre-check:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -35,6 +35,10 @@ jobs:
             python-version: '3.13'
             python-tag: "py313"
             cuda-tag: "cu126"
+          - os: linux.2xlarge
+            python-version: '3.14'
+            python-tag: "py314"
+            cuda-tag: "cu126"
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Check ldd --version
@@ -115,6 +119,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         cuda-tag:
           - "cu126"
     needs: build_on_cpu

--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -16,6 +16,8 @@ on:
       - "*.md"
       - ".github/workflows/[bcdprv]*.yml"
       - ".github/workflows/unittest_ci_cpu.yml"
+      - '.github/scripts/*.sh'
+      - '.github/scripts/*.py'
   pull_request:
     paths-ignore:
       - "docs/*"
@@ -24,6 +26,8 @@ on:
       - "*.md"
       - ".github/workflows/[bcdprv]*.yml"
       - ".github/workflows/unittest_ci_cpu.yml"
+      - '.github/scripts/*.sh'
+      - '.github/scripts/*.py'
   workflow_dispatch:
     inputs:
       channel:
@@ -52,6 +56,8 @@ jobs:
             tag: "py312"
           - version: "3.13"
             tag: "py313"
+          - version: "3.14"
+            tag: "py314"
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
         exclude:
@@ -59,10 +65,6 @@ jobs:
             cuda-tag: "cu126"
           - is_pr: true
             cuda-tag: "cu128"
-          - is_pr: true
-            cuda-tag: "cu129"
-            python:
-              version: "3.9"
           - is_pr: true
             cuda-tag: "cu129"
             python:
@@ -75,6 +77,10 @@ jobs:
             cuda-tag: "cu129"
             python:
               version: "3.12"
+          - is_pr: true
+            cuda-tag: "cu129"
+            python:
+              version: "3.13"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -16,6 +16,8 @@ on:
       - "*.md"
       - ".github/workflows/[bcdprv]*.yml"
       - ".github/workflows/unittest_ci.yml"
+      - '.github/scripts/*.sh'
+      - '.github/scripts/*.py'
   pull_request:
     paths-ignore:
       - "docs/*"
@@ -24,6 +26,8 @@ on:
       - "*.md"
       - ".github/workflows/[bcdprv]*.yml"
       - ".github/workflows/unittest_ci.yml"
+      - '.github/scripts/*.sh'
+      - '.github/scripts/*.py'
   workflow_dispatch:
     inputs:
       channel:
@@ -51,6 +55,8 @@ jobs:
             tag: "py312"
           - version: "3.13"
             tag: "py313"
+          - version: "3.14"
+            tag: "py314"
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
         exclude:
@@ -63,6 +69,9 @@ jobs:
           - is_pr: true
             python:
               version: "3.12"
+          - is_pr: true
+            python:
+              version: "3.13"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ def main(argv: List[str]) -> None:
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
             "Programming Language :: Python :: 3.13",
+            "Programming Language :: Python :: 3.14",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
         ],
     )

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 
+import sys
 import unittest
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -15,10 +16,7 @@ import hypothesis.strategies as st
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import assume, given, settings, Verbosity
-from torchrec.distributed.embedding import (
-    EmbeddingCollectionContext,
-    ShardedEmbeddingCollection,
-)
+from torchrec.distributed.embedding import EmbeddingCollectionContext
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
 from torchrec.distributed.planner import ParameterConstraints
@@ -31,7 +29,6 @@ from torchrec.distributed.tests.test_sequence_model import (
 )
 from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import EmbeddingConfig
-from torchrec.modules.embedding_modules import EmbeddingCollection
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.test_utils import skip_if_asan_class
 
@@ -530,8 +527,14 @@ class DedupIndicesWeightAccumulationTest(unittest.TestCase):
 @skip_if_asan_class
 class TDSequenceModelParallelTest(SequenceModelParallelTest):
 
+    def setUp(self) -> None:
+        super().setUp()
+        if sys.version_info >= (3, 14):
+            # TODO: check TensorDict for py314: https://github.com/pytorch/tensordict/releases
+            self.skipTest("TensorDict is not supported in python3.14")
+
     def test_sharding_variable_batch(self) -> None:
-        pass
+        self.skipTest("TensorDict doesn't support variable batch size yet")
 
     def _test_sharding(
         self,

--- a/torchrec/metrics/tests/test_mse.py
+++ b/torchrec/metrics/tests/test_mse.py
@@ -99,6 +99,12 @@ class TestRSquaredMetric(TestMetric):
         )
 
 
+_r_squared_metric_test_helper: Callable[..., None] = partial(
+    metric_test_helper, include_r_squared=True
+)
+update_wrapper(_r_squared_metric_test_helper, metric_test_helper)
+
+
 class MSEMetricTest(unittest.TestCase):
     clazz: Type[RecMetric] = MSEMetric
     task_name: str = "mse"
@@ -189,11 +195,6 @@ class MSEMetricTest(unittest.TestCase):
             entry_point=metric_test_helper,
         )
 
-    _r_squared_metric_test_helper: Callable[..., None] = partial(
-        metric_test_helper, include_r_squared=True
-    )
-    update_wrapper(_r_squared_metric_test_helper, metric_test_helper)
-
     def test_r_squared_unfused(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=MSEMetric,
@@ -205,7 +206,7 @@ class MSEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._r_squared_metric_test_helper,
+            entry_point=_r_squared_metric_test_helper,
         )
 
     def test_r_squared_fused_tasks(self) -> None:
@@ -219,7 +220,7 @@ class MSEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._r_squared_metric_test_helper,
+            entry_point=_r_squared_metric_test_helper,
         )
 
     def test_r_squared_fused_tasks_and_states(self) -> None:
@@ -233,7 +234,7 @@ class MSEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._r_squared_metric_test_helper,
+            entry_point=_r_squared_metric_test_helper,
         )
 
 

--- a/torchrec/metrics/tests/test_ne.py
+++ b/torchrec/metrics/tests/test_ne.py
@@ -104,6 +104,12 @@ class TestLoglossMetric(TestMetric):
         )
 
 
+_logloss_metric_test_helper: Callable[..., None] = partial(
+    metric_test_helper, include_logloss=True
+)
+update_wrapper(_logloss_metric_test_helper, metric_test_helper)
+
+
 class NEMetricTest(unittest.TestCase):
     target_clazz: Type[RecMetric] = NEMetric
     target_compute_mode: RecComputeMode = RecComputeMode.UNFUSED_TASKS_COMPUTATION
@@ -208,11 +214,6 @@ class NEMetricTest(unittest.TestCase):
         self.assertTrue(torch.all(~ne.isnan()))
         self.assertTrue(torch.equal(ne.eq(eta), torch.tensor([False, True, False])))
 
-    _logloss_metric_test_helper: Callable[..., None] = partial(
-        metric_test_helper, include_logloss=True
-    )
-    update_wrapper(_logloss_metric_test_helper, metric_test_helper)
-
     def test_logloss_unfused(self) -> None:
         rec_metric_value_test_launcher(
             target_clazz=NEMetric,
@@ -224,7 +225,7 @@ class NEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._logloss_metric_test_helper,
+            entry_point=_logloss_metric_test_helper,
         )
 
     def test_logloss_fused_tasks(self) -> None:
@@ -238,7 +239,7 @@ class NEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._logloss_metric_test_helper,
+            entry_point=_logloss_metric_test_helper,
         )
 
     def test_logloss_fused_tasks_and_states(self) -> None:
@@ -252,7 +253,7 @@ class NEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._logloss_metric_test_helper,
+            entry_point=_logloss_metric_test_helper,
         )
 
     def test_logloss_update_fused(self) -> None:
@@ -266,7 +267,7 @@ class NEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._logloss_metric_test_helper,
+            entry_point=_logloss_metric_test_helper,
         )
 
         rec_metric_value_test_launcher(
@@ -279,7 +280,7 @@ class NEMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._logloss_metric_test_helper,
+            entry_point=_logloss_metric_test_helper,
             batch_window_size=10,
         )
 

--- a/torchrec/metrics/tests/test_tower_qps.py
+++ b/torchrec/metrics/tests/test_tower_qps.py
@@ -161,6 +161,14 @@ class TestTowerQPSMetric(TestMetric):
         )
 
 
+_test_tower_qps: Callable[..., None] = partial(
+    metric_test_helper,
+    is_time_dependent=True,
+    time_dependent_metric={TowerQPSMetric: "torchrec.metrics.tower_qps"},
+)
+update_wrapper(_test_tower_qps, metric_test_helper)
+
+
 class TowerQPSMetricTest(unittest.TestCase):
     def setUp(self) -> None:
         self.world_size = 1
@@ -168,13 +176,6 @@ class TowerQPSMetricTest(unittest.TestCase):
 
     target_clazz: Type[RecMetric] = TowerQPSMetric
     task_names: str = "qps"
-
-    _test_tower_qps: Callable[..., None] = partial(
-        metric_test_helper,
-        is_time_dependent=True,
-        time_dependent_metric={TowerQPSMetric: "torchrec.metrics.tower_qps"},
-    )
-    update_wrapper(_test_tower_qps, metric_test_helper)
 
     def test_tower_qps_during_warmup_unfused(self) -> None:
         rec_metric_value_test_launcher(
@@ -187,7 +188,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
         )
 
     def test_tower_qps_unfused(self) -> None:
@@ -201,7 +202,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
             test_nsteps=DURING_WARMUP_NSTEPS,
         )
 
@@ -216,7 +217,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
             test_nsteps=AFTER_WARMUP_NSTEPS,
         )
 
@@ -231,7 +232,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=False,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
             test_nsteps=AFTER_WARMUP_NSTEPS,
         )
 
@@ -246,7 +247,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=True,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
             test_nsteps=AFTER_WARMUP_NSTEPS,
         )
 
@@ -261,7 +262,7 @@ class TowerQPSMetricTest(unittest.TestCase):
             compute_on_all_ranks=False,
             should_validate_update=True,
             world_size=WORLD_SIZE,
-            entry_point=self._test_tower_qps,
+            entry_point=_test_tower_qps,
             test_nsteps=AFTER_WARMUP_NSTEPS,
         )
 


### PR DESCRIPTION
# Supporting TorchRec in Python 3.14
## TL;DR
- TorchRec is now available in Python 3.14
- Python 3.14 allows free-threaded builds without GIL, which unblocks CPU-side efficiency improvements.
- An interesting side effect in the Python 3.14 multiprocessing package caused over 20 test failures, which will be elaborated on in the context.

## Background
TorchRec did not previously support Python 3.14 primarily due to dependency and runtime blockers:
- TorchRec relies on FBGEMM for CUDA kernels, and FBGEMM only added Python 3.14 support last week, making upstream-compatible builds infeasible before then. 
- In addition, some TorchRec features depend on torch.compile, which had Python 3.14 issues that caused test failures; those failures now appear to be resolved.

We want to support Python 3.14 now because it introduces optional [free-threading](https://py-free-threading.github.io/) (no-GIL), which could benefit CPU-side performance work—such as offloading RecMetrics to CPU and CPU embedding lookup in bulk eval—by enabling better parallelism without the traditional GIL bottleneck.

Enabling Python 3.14 is not a “flip the switch” change: TorchRec initially had 20+ 3.14-specific test failures, and some were driven by Python 3.14 runtime behavior changes (notably multiprocessing’s default start-method change and its side effects). Support was also gated by ecosystem readiness—e.g., tensordict did not yet officially support 3.14.

This work resolves these blockers by making TorchRec resilient to the new multiprocessing defaults and unblocking the TensorDict gap via our compatibility approach. We’ll share detailed failure modes and learnings in later sections of this doc.

## Multiprocessing in Python 3.14
Default Multiprocessing Start Method: In Python 3.14, the default start method for the multiprocessing and concurrent.futures.ProcessPoolExecutor modules on POSIX platforms (like Linux) [changed from fork to forkserver](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods). 

Lots of multi-rank test cases (Not only the TorchRec library, but also others) are built based on [MultiProcessTestBase](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/test_utils/multi_process.py#L118-L124), and there are some required multi-rank environment variables such as MASTER_ADDR (e.g., localhost) and MASTER_PORT (e.g., 36927) will be set during the setUp phase for every multi-rank test case.

There is an assumption that we previously took for granted that the environment variables are the same in the forkserver process and in the main process right before the multiprocessing start call ([codepointer](https://github.com/meta-pytorch/torchrec/blob/main/torchrec/distributed/test_utils/multi_process.py#L151-L165)):
```
def test_multi_rank(self, method="forkserver"):
    print(f"env in main: {os.environ}")

    with mp.get_context(method).Pool(processes=world_size) as pool:
        for i in range(world_size):
           async_result = pool.apply_async(callable, rank=i)
        ....

def callable(rank: int):
    print(f"env in rank-{rank}: {os.environ}")
```
However, this assumption is incorrect in the pytest use case, where we run all test cases within a single command in the GitHub workflow. Multiprocessing caches the environment variables from the first time it invokes the multiprocessing context. Specifically, the test cases are not well-isolated, and the environment variables from the first test case (that invokes mp.context) are used for all subsequent test cases. This problem was not exposed when the Python version was under 3.13 because all the multi-rank test cases shared the same required environment variables.

Another multiprocessing use case in the TorchRec test suite is the [PyTorch DataLoader](https://github.com/pytorch/pytorch/blob/main/torch/utils/data/dataloader.py#L184-L188). It uses the default start method for mp.context when evoking CriteoDataLoader. However, in this use case, there are no multi-rank related environment variables available, and the default start method becomes “forkserver” when the Python version changes to Python 3.14.

- Github job [example](https://github.com/meta-pytorch/torchrec/actions/runs/21119222549/job/60729354787): [compare](https://fburl.com/decoder/es88l89t)
<img width="1661" height="351" alt="image" src="https://github.com/user-attachments/assets/9dd49ee2-6b4a-4ea3-a142-1949ea2012b7" />
- the actual test env indicates the test is “test_model_parallel_gloo.py::ModelParallelTestGloo::test_sharding_cw”
- the subprocess env uses the cached value from a different (the first) test: "test_criteo.py::CriteoDataLoaderTest::test_fewer_tsvs_than_workers"
- Consequently, the required multi-rank environment variables are missing, which causes test failures.

## Workaround for Python 3.14 Compatibility
- change the start method from "forkserver" to "spawn" when the Python version is above 3.14. According to the official documentation, spawn is slower than forkserver and requires the callable function to be "pickle-able" (i.e., it must be a top-level function in practice).
- TensorDict does not support Python 3.14 yet. We therefore disable the TensorDict-related test class TDSequenceModelParallelTest which uses TensorDict as the alternative sparse input.
- In some RecMetric-related test cases, promote the entry_point (callable) function from the instance method to the top level function to make it compatible with spawn for object pickling.
 


Differential Revision: D90621404


