### PR TITLE
remove unnecessary @seed_and_log in unittest.setUp

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -29,12 +29,11 @@ from torchrec.distributed.test_utils.test_sharding import (
 )
 from torchrec.distributed.types import ModuleSharder, ShardingStrategy, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
-from torchrec.test_utils import seed_and_log, skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class
 from torchrec.types import DataType
 
 
 class ModelParallelTestShared(MultiProcessTestBase):
-    @seed_and_log
     def setUp(self, backend: str = "nccl") -> None:
         super().setUp()
 

--- a/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_quant_sequence_model_parallel.py
@@ -34,7 +34,7 @@ from torchrec.quant.embedding_modules import (
     EmbeddingCollection as QuantEmbeddingCollection,
     quant_prep_enable_quant_state_dict_split_scale_bias_for_types,
 )
-from torchrec.test_utils import seed_and_log, skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class
 
 
 def _quantize(
@@ -113,7 +113,6 @@ class QuantSequenceModelParallelTest(InferenceModelParallelTestBase):
             quant_state_dict_split_scale_bias=quant_state_dict_split_scale_bias,
         )
 
-    @seed_and_log
     def setUp(self) -> None:
         super().setUp()
 

--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -33,7 +33,7 @@ from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import EmbeddingConfig
 from torchrec.modules.embedding_modules import EmbeddingCollection
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-from torchrec.test_utils import seed_and_log, skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class
 
 
 @skip_if_asan_class
@@ -308,7 +308,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
             variable_batch_size=True,
         )
 
-    @seed_and_log
     def setUp(self) -> None:
         super().setUp()
 

--- a/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
@@ -29,7 +29,7 @@ from torchrec.distributed.tests.test_sequence_model import (
 )
 from torchrec.distributed.types import ShardingType
 from torchrec.modules.embedding_configs import EmbeddingConfig
-from torchrec.test_utils import seed_and_log, skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class
 
 
 @skip_if_asan_class
@@ -92,7 +92,6 @@ class SequenceModelParallelHierarchicalTest(MultiProcessTestBase):
         )
 
     # TODO: consolidate the following methods with https://fburl.com/code/62zg0kel
-    @seed_and_log
     def setUp(self) -> None:
         super().setUp()
 

--- a/torchrec/distributed/tests/test_shards_wrapper.py
+++ b/torchrec/distributed/tests/test_shards_wrapper.py
@@ -17,7 +17,7 @@ from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
     MultiProcessTestBase,
 )
-from torchrec.test_utils import seed_and_log, skip_if_asan_class
+from torchrec.test_utils import skip_if_asan_class
 
 
 def all_gather_into_tensor(
@@ -96,7 +96,6 @@ def all_gather_object(
 
 @skip_if_asan_class
 class LocalShardsWrapperDistributedTest(MultiProcessTestBase):
-    @seed_and_log
     def setUp(self, backend: str = "nccl") -> None:
         super().setUp()
 

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -32,7 +32,7 @@ from torchrec.metrics.test_utils.mock_metrics import (
     MockRecMetric,
 )
 from torchrec.metrics.throughput import ThroughputMetric
-from torchrec.test_utils import get_free_port, seed_and_log, skip_if_asan_class
+from torchrec.test_utils import get_free_port, skip_if_asan_class
 
 
 def wait_until_true(
@@ -440,7 +440,6 @@ class CPUOffloadedMetricModuleDistributedTest(MultiProcessTestBase):
     metric_module.update()/compute() path.
     """
 
-    @seed_and_log
     def setUp(self) -> None:
         super().setUp()
 

--- a/torchrec/metrics/tests/test_metric_module.py
+++ b/torchrec/metrics/tests/test_metric_module.py
@@ -1038,7 +1038,6 @@ class MetricsConfigPostInitTest(unittest.TestCase):
 @skip_if_asan_class
 class MetricModuleDistributedTest(MultiProcessTestBase):
 
-    @seed_and_log
     def setUp(self, backend: str = "nccl") -> None:
         super().setUp()
         self.backend = backend


### PR DESCRIPTION
Summary:
# context
* remove redundent `seen_and_log` decorator in unittest.setUp method
* it's for init the seed before each test case
```
def seed_and_log(wrapped_func: Callable) -> Callable:
    # pyre-ignore [2, 3]
    def _wrapper(*args, **kwargs):
        seed = int(time.time() * 1000) % (1 << 31)
        print(f"Using random seed: {seed}")
        torch.manual_seed(seed)
        random.seed(seed)
        np.random.seed(seed)
        return wrapped_func(*args, **kwargs)

    return _wrapper
```

* A typical pattern is that this setUp method calls super().setUp, which is already decorated by `seen_and_log`:
```
class ModelParallelTestShared(MultiProcessTestBase):
    seed_and_log
    def setUp(self, backend: str = "nccl") -> None:
        super().setUp()
        ...

class MultiProcessTestBase(unittest.TestCase):
    seed_and_log
    def setUp(self) -> None:
        ...
```

Differential Revision: D90950699


