### PR TITLE
Handle extra placeholder args in pytree EBC-KTRegroup pruning

### DIFF
--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -1121,3 +1121,90 @@ class TestJsonSerializer(unittest.TestCase):
             qualname(EmbeddingBagCollection),
             "torchrec.modules.embedding_modules.EmbeddingBagCollection",
         )
+
+    def test_key_order_with_ebc_and_regroup_extra_args(self) -> None:
+        """Test prune_pytree_flatten_unflatten when the regroup node has
+        extra placeholder args (e.g. from unflatten adding mutation
+        intermediates with list arguments as placeholder inputs)."""
+        tb1_config = EmbeddingBagConfig(
+            name="t1",
+            embedding_dim=3,
+            num_embeddings=10,
+            feature_names=["f1"],
+        )
+        tb2_config = EmbeddingBagConfig(
+            name="t2",
+            embedding_dim=3,
+            num_embeddings=10,
+            feature_names=["f2"],
+        )
+        id_list_features = KeyedJaggedTensor.from_offsets_sync(
+            keys=["f1", "f2"],
+            values=torch.tensor([0, 1, 2, 3, 2]),
+            offsets=torch.tensor([0, 2, 3, 4, 5]),
+        )
+        ebc1 = EmbeddingBagCollection(
+            tables=[tb1_config, tb2_config],
+            is_weighted=False,
+        )
+        ebc2 = EmbeddingBagCollection(
+            tables=[tb2_config, tb1_config],
+            is_weighted=False,
+        )
+        ebc2.load_state_dict(ebc1.state_dict())
+        regroup = KTRegroupAsDict([["f1"], ["f2"]], ["group1", "group2"])
+
+        class mySparse(nn.Module):
+            def __init__(self, ebc, regroup):
+                super().__init__()
+                self.ebc = ebc
+                self.regroup = regroup
+                self.buf = nn.Buffer(torch.zeros(4, 3))
+
+            def forward(
+                self,
+                features: KeyedJaggedTensor,
+            ) -> Dict[str, torch.Tensor]:
+                kt = self.ebc(features)
+                result = self.regroup(keyed_tensors=[kt])
+                # Buffer mutation using cat (list arg) to exercise the
+                # multi-arg path in prune_pytree_flatten_unflatten
+                self.buf.copy_(torch.cat([result["group1"], result["group2"]], dim=0))
+                return result
+
+        class myModel(nn.Module):
+            def __init__(self, ebc, regroup):
+                super().__init__()
+                self.sparse = mySparse(ebc, regroup)
+
+            def forward(
+                self,
+                features: KeyedJaggedTensor,
+            ) -> Dict[str, torch.Tensor]:
+                return self.sparse(features)
+
+        model = myModel(ebc1, regroup)
+        eager_out = model(id_list_features)
+
+        model, sparse_fqns = encapsulate_ir_modules(model, JsonSerializer)
+        ep = torch.export.export(
+            model,
+            (id_list_features,),
+            {},
+            strict=False,
+            preserve_module_call_signature=(tuple(sparse_fqns)),
+        )
+        unflatten_ep = torch.export.unflatten(ep)
+        deserialized_model = decapsulate_ir_modules(
+            unflatten_ep,
+            JsonSerializer,
+            short_circuit_pytree_ebc_regroup=True,
+            finalize_interpreter_modules=True,
+        )
+
+        # pyrefly: ignore[missing-attribute]
+        deserialized_model.sparse.ebc = ebc2
+
+        deserialized_out = deserialized_model(id_list_features)
+        for key in eager_out.keys():
+            torch.testing.assert_close(deserialized_out[key], eager_out[key])

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -394,9 +394,32 @@ def prune_pytree_flatten_unflatten(
     for fqn in in_fqns:
         submodule, node, submod_name = _get_graph_node(module, fqn)
 
-        # kt_regroup node will have either one arg or one kwarg
+        # kt_regroup node will have either one arg or one kwarg.
+        # Extra placeholder args may be prepended by unflatten when mutation
+        # intermediates with list arguments (e.g. aten.cat) are added as
+        # placeholder inputs. Strip them by finding the tree_unflatten arg.
         use_args = len(node.args) == 1
         use_kwargs = len(node.kwargs) == 1
+
+        if not (use_args or use_kwargs):
+            for arg in node.args:
+                if not isinstance(arg, Node):
+                    continue
+                if arg.op != "call_function" or arg.target != operator.getitem:
+                    continue
+                inner = arg.args[0]
+                if not isinstance(inner, Node):
+                    continue
+                if inner.op != "call_function" or inner.target != operator.getitem:
+                    continue
+                node.args = (arg,)
+                use_args = True
+                break
+            if not use_args:
+                # pyrefly: ignore[missing-attribute]
+                submodule.graph.eliminate_dead_code()
+                continue
+
         assert use_args or use_kwargs
 
         # Incase the kt_regroup module is partitioned to a submodule, we need


### PR DESCRIPTION
Summary: The `prune_pytree_flatten_unflatten` function in `_short_circuit_pytree_ebc_regroup` asserts that the call_module node for KTRegroupAsDict has exactly 1 arg or 1 kwarg. This assertion can fail when `torch.export.unflatten` prepends extra placeholder inputs for mutation intermediates with list arguments (e.g. `aten.cat`). This change adds logic to strip the extra placeholders by finding the `getitem(getitem(...))` arg that corresponds to the tree_unflatten output, trimming `node.args` back to that single arg before the assertion. If no matching arg is found, that fqn is skipped (dead code eliminated) instead of crashing.

Differential Revision: D94101191


