### PR TITLE
Add logging for free_features_storage_early

### DIFF
--- a/torchrec/distributed/logger.py
+++ b/torchrec/distributed/logger.py
@@ -77,6 +77,31 @@ from typing_extensions import ParamSpec
 # Module exports - intentionally empty as these are internal utilities
 __all__: list[str] = []
 
+
+class LazyStr:
+    """Lazy string wrapper that defers evaluation until the string is needed.
+
+    Wraps a callable that produces a string. The callable is only invoked
+    when ``__str__`` is called, which happens when the logging framework
+    formats the message. If the log level is not active, the callable is
+    never evaluated.
+
+    Usage::
+
+        logger.debug(LazyStr(lambda: f"freed {expensive()} KJTs"))
+    """
+
+    # Use __slots__ to avoid per-instance __dict__, saving memory and
+    # speeding up attribute access since these may be created frequently.
+    __slots__ = ("_fn",)
+
+    def __init__(self, fn: Callable[[], str]) -> None:
+        self._fn = fn
+
+    def __str__(self) -> str:
+        return self._fn()
+
+
 # Some inputs like can get extremely large.
 # Adding logic to limit the input size by truncating any args larger than this size
 ARG_SIZE_LIMIT = 800000

--- a/torchrec/distributed/tests/test_logger.py
+++ b/torchrec/distributed/tests/test_logger.py
@@ -20,6 +20,9 @@ from torchrec.distributed.logger import (
     _get_or_create_logger,
     _torchrec_method_logger,
     ARG_SIZE_LIMIT,
+    LazyStr,
+    one_time_logger,
+    one_time_rank0_logger,
 )
 from torchrec.distributed.logging_handlers import _log_handlers, SingleRankStaticLogger
 
@@ -339,3 +342,46 @@ class TestLoggerUtils(unittest.TestCase):
                     self.assertEqual(msg_dict["group"], str(mock_process_group))
                     self.assertEqual(msg_dict["world_size"], "8")
                     self.assertEqual(msg_dict["rank"], "3")
+
+
+class TestLazyStr(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.count = 0
+
+        def counter() -> str:
+            self.count += 1
+            return f"call_{self.count}"
+
+        self.lazy_msg = LazyStr(counter)
+
+    def test_str_calls_fn(self) -> None:
+        """Test that __str__ invokes the wrapped callable."""
+        self.assertEqual(str(self.lazy_msg), "call_1")
+
+    def test_fn_not_called_until_str(self) -> None:
+        """Test that the callable is not evaluated at construction time."""
+        self.assertEqual(self.count, 0)
+        logging.info(self.lazy_msg)
+        self.assertEqual(self.count, 1)
+
+    def test_fn_called_each_time(self) -> None:
+        """Test that __str__ calls the callable on every invocation."""
+        self.assertEqual(str(self.lazy_msg), "call_1")
+        self.assertEqual(str(self.lazy_msg), "call_2")
+        logging.info("%s", self.lazy_msg)
+        self.assertEqual(self.count, 3)
+
+    def test_skipped_when_log_level_inactive(self) -> None:
+        """Test that LazyStr defers evaluation when log level filters the message."""
+        one_time_rank0_logger.setLevel(logging.INFO)
+        self.assertEqual(str(self.lazy_msg), "call_1")
+        for _ in range(3):
+            one_time_rank0_logger.debug(self.lazy_msg)
+        self.assertEqual(self.count, 1)
+
+    def test_with_one_time_logger(self) -> None:
+        """Test that LazyStr works with one_time_logger (Cap1Logger)."""
+        for _ in range(3):
+            one_time_logger.info(self.lazy_msg)
+        self.assertLess(self.count, 2)

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -542,7 +542,8 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         logger.info(
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "
             f"execute_all_batches: {self._execute_all_batches} "
-            f"enable_inplace_copy_batch: {enable_inplace_copy_batch}"
+            f"enable_inplace_copy_batch: {enable_inplace_copy_batch} "
+            f"free_features_storage_early: {free_features_storage_early}"
         )
 
         if device.type == "cuda":
@@ -880,6 +881,11 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                 if hasattr(module, "_free_features_storage_early"):
                     # pyrefly: ignore [bad-argument-type]
                     module._free_features_storage_early = True
+                    fqn = getattr(module.forward, "name", "unknown")
+                    logger.info(
+                        f"free_features_storage_early enabled on "
+                        f"{fqn}({type(module).__name__})"
+                    )
         # initializes input dist, so we can override input dist forwards
         self.start_sparse_data_dist(batch, context)
         self._original_kjt_dist_forwards = _override_input_dist_forwards(

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -36,7 +36,7 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
-from torchrec.distributed.logger import one_time_rank0_logger
+from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
     EmbeddingTrainPipelineContext,
@@ -165,13 +165,22 @@ def _clear_releasable_inputs(context: TrainPipelineContext) -> None:
         if context.version == 0
         else context.module_contexts
     )
+    size = 0
     for module_ctx in contexts_dict.values():
         early_released: list[KeyedJaggedTensor] = getattr(
             module_ctx, "early_releasable_inputs", []
         )
         for kjt in early_released:
-            kjt.clear_storage()
+            size += kjt.clear_storage()
         early_released.clear()
+    if size > 0:
+
+        def get_kjt_size() -> str:
+            msg: str = f"clear_releasable_inputs {size / 1024**3:.2f} GB"
+            logger.info(msg)
+            return msg
+
+        one_time_logger.info(LazyStr(get_kjt_size))
 
 
 def _start_data_dist(

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -3122,7 +3122,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         return splits
 
     @torch.jit.unused
-    def clear_storage(self) -> None:
+    def clear_storage(self) -> int:
         """
         Frees the underlying storage of all internal tensors (_values, _lengths,
         _offsets, _weights) by resizing their untyped storage to zero.
@@ -3130,13 +3130,18 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         The Python KJT object remains alive but its tensor data is released,
         allowing GPU HBM to be reclaimed early.
         """
+        size = self._values.element_size() * self._values.numel()
         self._values.untyped_storage().resize_(0)
         if self._lengths is not None:
+            size += self._lengths.element_size() * self._lengths.numel()
             self._lengths.untyped_storage().resize_(0)
         if self._offsets is not None:
+            size += self._offsets.element_size() * self._offsets.numel()
             self._offsets.untyped_storage().resize_(0)
         if self._weights is not None:
+            size += self._weights.element_size() * self._weights.numel()
             self._weights.untyped_storage().resize_(0)
+        return size
 
     def dist_tensors(self) -> List[torch.Tensor]:
         tensors = [self.lengths(), self.values()]


### PR DESCRIPTION
Summary:
## 1. Context
The `free_features_storage_early` feature frees KJT tensor storage after input_dist permute to reclaim HBM early. However, there was no logging to observe whether the feature was enabled, which modules it applied to, or how much memory was actually freed. This makes it difficult to debug memory issues or verify the feature is working correctly in production.

## 2. Approach
1. **Pipeline init logging**: Add `free_features_storage_early` to the existing `logger.info` in `TrainPipelineSparseDist.__init__` so it's logged alongside other pipeline flags.
2. **Per-module logging in `_pipeline_model`**: Log fqn and class name for each module that gets the flag enabled (e.g., `model.sparse.ebc(ShardedEmbeddingBagCollection)`).
3. **Storage size logging in `_clear_releasable_inputs`**: Accumulate bytes freed from `clear_storage()` and log total size in GB. Uses `one_time_logger` (all ranks, capped at 1) since different ranks may have different KJT sizes due to sharding. Also logs via `logger.info` for local log capture.
4. **`clear_storage()` returns freed size**: Modified `KJT.clear_storage()` to compute and return total bytes freed using `element_size() * numel()` before resizing storage to zero.
5. **`LazyStr` for deferred formatting**: The storage size log message is wrapped in `LazyStr` so string formatting is deferred until the logger actually emits.

## 4. Analysis
1. **Low risk**: All changes are additive logging. No behavioral changes to the pipeline or sharding logic.
2. **Per-rank logging**: `one_time_logger` (Cap1Logger) is used instead of `one_time_rank0_logger` for storage size because different ranks may free different amounts of memory depending on the sharding plan.
3. **BC for `clear_storage()`**: Return type changed from `None` to `int`. Existing callers that ignore the return value are unaffected.

## 5. Changes
1. **`train_pipelines.py`**: Add `free_features_storage_early` to init `logger.info`; add per-module `logger.info` in `_pipeline_model` with fqn and class name.
2. **`utils.py`**: Add storage size accumulation and `one_time_logger.info(LazyStr(...))` in `_clear_releasable_inputs`; import `LazyStr` and `one_time_logger`.
3. **`jagged_tensor.py`**: Modify `clear_storage()` to return total bytes freed as `int`.

Differential Revision: D100227977


