### PR TITLE
fix: add cu132 CUDA mapping and skip pt2 tests on free-threaded Python

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -98,6 +98,8 @@ if [[ ${MATRIX_GPU_ARCH_TYPE} = 'cuda' ]]; then
         export CUDA_VERSION="cu129"
     elif [[ ${MATRIX_GPU_ARCH_VERSION} = '13.0' ]]; then
         export CUDA_VERSION="cu130"
+    elif [[ ${MATRIX_GPU_ARCH_VERSION} = '13.2' ]]; then
+        export CUDA_VERSION="cu132"
     else
         export CUDA_VERSION="cu126"
     fi

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -127,9 +127,15 @@ jobs:
         echo "numpy succeeded"
         conda run -n build_binary \
           pip install pytest
+        # torch.compile/dynamo segfaults on free-threaded Python (GIL disabled)
+        PT2_IGNORES=""
+        if [[ "${{ matrix.python.free_threaded }}" == "true" ]]; then
+          PT2_IGNORES="--ignore=torchrec/distributed/tests/test_pt2.py --ignore=torchrec/distributed/tests/test_pt2_multiprocess.py"
+        fi
         conda run -n build_binary \
           python -m pytest torchrec -v -s -W ignore::pytest.PytestCollectionWarning --continue-on-collection-errors \
         --ignore-glob=**/test_utils/ \
+        $PT2_IGNORES \
         -k "not _disabled_in_oss_compatibility"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ inputs.repository }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Summary:
Two fixes for GitHub CI failures:

1. Add CUDA 13.2 (cu132) mapping in validate_binaries.sh. Without this, cu132 falls through to the cu126 default, causing fbgemm-gpu ABI mismatch (undefined symbol _ZN2at4cuda24getCurrentCUDABlasHandleEv).

2. Skip test_pt2.py and test_pt2_multiprocess.py on free-threaded Python 3.14t in the CPU CI workflow. torch.compile/dynamo segfaults when GIL is disabled — this is a known PyTorch limitation with free-threaded Python.

Differential Revision: D100165746


