### PR TITLE
Rename ModelParallelBase to _ModelParallelBase to prevent test duplication (#4087)

### DIFF
--- a/torchrec/distributed/logger.py
+++ b/torchrec/distributed/logger.py
@@ -58,7 +58,7 @@ Notes:
 import functools
 import inspect
 import logging
-from typing import Any, Callable, Dict, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 from torch import distributed as dist
 from torchrec.distributed.logging_handlers import (
@@ -93,13 +93,16 @@ class LazyStr:
 
     # Use __slots__ to avoid per-instance __dict__, saving memory and
     # speeding up attribute access since these may be created frequently.
-    __slots__ = ("_fn",)
+    __slots__ = ("_fn", "_str")
 
     def __init__(self, fn: Callable[[], str]) -> None:
         self._fn = fn
+        self._str: Optional[str] = None
 
     def __str__(self) -> str:
-        return self._fn()
+        if self._str is None:
+            self._str = self._fn()
+        return self._str
 
 
 # Some inputs like can get extremely large.

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -319,12 +319,14 @@ class ModelParallelTestShared(MultiProcessTestBase):
 
 
 @skip_if_asan_class
-class ModelParallelBase(ModelParallelTestShared):
+class _ModelParallelBase(ModelParallelTestShared):
     # tests will skip if no backend specified
     backend = ""
 
     @classmethod
     def setUpClass(cls) -> None:
+        if cls.backend == "":
+            raise unittest.SkipTest("This test class is intentionally skipped.")
         if cls.backend not in ("nccl", "gloo"):
             raise unittest.SkipTest(f"No valid backend specified: {cls.backend}")
 

--- a/torchrec/distributed/tests/test_logger.py
+++ b/torchrec/distributed/tests/test_logger.py
@@ -362,15 +362,15 @@ class TestLazyStr(unittest.TestCase):
     def test_fn_not_called_until_str(self) -> None:
         """Test that the callable is not evaluated at construction time."""
         self.assertEqual(self.count, 0)
-        logging.info(self.lazy_msg)
+        logging.error(self.lazy_msg)
         self.assertEqual(self.count, 1)
 
     def test_fn_called_each_time(self) -> None:
-        """Test that __str__ calls the callable on every invocation."""
+        """Test that __str__ calls the callable only once."""
         self.assertEqual(str(self.lazy_msg), "call_1")
-        self.assertEqual(str(self.lazy_msg), "call_2")
-        logging.info("%s", self.lazy_msg)
-        self.assertEqual(self.count, 3)
+        self.assertEqual(str(self.lazy_msg), "call_1")
+        logging.error("%s", self.lazy_msg)
+        self.assertEqual(self.count, 1)
 
     def test_skipped_when_log_level_inactive(self) -> None:
         """Test that LazyStr defers evaluation when log level filters the message."""

--- a/torchrec/distributed/tests/test_model_parallel_gloo.py
+++ b/torchrec/distributed/tests/test_model_parallel_gloo.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from torchrec.distributed.test_utils.test_model_parallel import ModelParallelBase
+from torchrec.distributed.test_utils.test_model_parallel import _ModelParallelBase
 from torchrec.distributed.test_utils.test_model_parallel_base import (
     ModelParallelSparseOnlyBase,
     ModelParallelStateDictBase,
@@ -16,7 +16,7 @@ from torchrec.distributed.test_utils.test_model_parallel_base import (
 # CPU tests for Gloo.
 
 
-class ModelParallelTestGloo(ModelParallelBase):
+class ModelParallelTestGloo(_ModelParallelBase):
     backend = "gloo"
 
 

--- a/torchrec/distributed/tests/test_model_parallel_gloo_gpu.py
+++ b/torchrec/distributed/tests/test_model_parallel_gloo_gpu.py
@@ -7,10 +7,10 @@
 
 # pyre-strict
 
-from torchrec.distributed.test_utils.test_model_parallel import ModelParallelBase
+from torchrec.distributed.test_utils.test_model_parallel import _ModelParallelBase
 
 # GPU tests for Gloo.
 
 
-class ModelParallelTestGloo(ModelParallelBase):
+class ModelParallelTestGlooGPU(_ModelParallelBase):
     backend = "gloo"

--- a/torchrec/distributed/tests/test_model_parallel_nccl.py
+++ b/torchrec/distributed/tests/test_model_parallel_nccl.py
@@ -7,8 +7,8 @@
 
 # pyre-strict
 
-from torchrec.distributed.test_utils.test_model_parallel import ModelParallelBase
+from torchrec.distributed.test_utils.test_model_parallel import _ModelParallelBase
 
 
-class ModelParallelTestNccl(ModelParallelBase):
+class ModelParallelTestNccl(_ModelParallelBase):
     backend = "nccl"


### PR DESCRIPTION
Summary:

Rename `ModelParallelBase` to `_ModelParallelBase` to prevent unittest from discovering and running the base test class directly, which caused test case duplication. Add explicit `SkipTest` guard for empty backend as additional protection.

Reviewed By: kausv

Differential Revision: D100268336


