### PR TITLE
Skip KEY_VALUE enumeration when no device has SSD

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -115,6 +115,13 @@ class EmbeddingEnumerator(Enumerator):
             and topology._custom_topology_data.has_data(memory_type)
             else None
         )
+        # Check if any device in the topology has SSD capacity.
+        # If no device has ssd > 0, KEY_VALUE should be skipped during enumeration
+        # even if it's not in GUARDED_COMPUTE_KERNELS, because fits_in() would
+        # reject all KEY_VALUE shards anyway. Skipping early avoids expanding
+        # the search space (and potentially exceeding GridSearchProposer's
+        # max_proposals limit) with options that can never be selected.
+        self._has_ssd: bool = any(device.storage.ssd > 0 for device in topology.devices)
 
         if estimator:
             self._estimators: List[ShardEstimator] = (
@@ -414,6 +421,14 @@ class EmbeddingEnumerator(Enumerator):
         filtered_compute_kernels = list(
             set(constrained_compute_kernels) & set(allowed_compute_kernels)
         )
+
+        # Remove KEY_VALUE if no device has SSD capacity — avoids expanding
+        # the search space with infeasible options that fits_in() would reject.
+        if (
+            not self._has_ssd
+            and EmbeddingComputeKernel.KEY_VALUE.value in filtered_compute_kernels
+        ):
+            filtered_compute_kernels.remove(EmbeddingComputeKernel.KEY_VALUE.value)
 
         # special rules
         if EmbeddingComputeKernel.DENSE.value in filtered_compute_kernels:


### PR DESCRIPTION
Summary:
Skip `KEY_VALUE` compute kernel during enumeration when no device in the  topology has SSD capacity (`ssd_cap > 0`). This avoids expanding the search space with infeasible options that Storage.fits_in() would reject anyway.

Without this, adding `KEY_VALUE` to the enumeration space increases compute kernels from 3 to 4 per table, which can cause GridSearchProposer to exceed its max_proposals limit (default: 10,000) and skip grid search entirely.

The check is done once at `EmbeddingEnumerator` construction time by scanning all devices in the topology. If at least one device has `ssd > 0`, `KEY_VALUE` is kept in the enumeration.

Differential Revision: D99720735


