### PR TITLE
Disable unittests of torch.compile on Python 3.13t (#4091)

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -9,6 +9,7 @@
 import copy
 import itertools
 import sys
+import sysconfig
 import unittest
 from enum import auto, Enum
 from typing import Any, Dict, List, Tuple
@@ -63,6 +64,10 @@ from torchrec.sparse.jagged_tensor import (
     KeyedJaggedTensor,
     KeyedTensor,
 )
+
+
+def _is_free_threaded():
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
 def make_kjt(
@@ -267,6 +272,11 @@ def _test_compile_fwd_bwd(
             _assert_close(compile_bwd_out, eager_bwd_out)
 
 
+@unittest.skipIf(
+    _is_free_threaded(),
+    "torch.compile/torch.export segfaults on free-threaded Python, "
+    "see https://dev-discuss.pytorch.org/t/torch-compile-support-for-python-3-14-completed/3276",
+)
 class TestPt2(unittest.TestCase):
     def setUp(self):
         super().setUp()

--- a/torchrec/metrics/tests/test_xauc.py
+++ b/torchrec/metrics/tests/test_xauc.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import sysconfig
 import unittest
 from typing import Dict
 from unittest.mock import patch
@@ -18,6 +19,10 @@ from torchrec.metrics.xauc import XAUCMetric
 
 WORLD_SIZE = 4
 BATCH_SIZE = 10
+
+
+def _is_free_threaded() -> bool:
+    return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
 def generate_model_output() -> Dict[str, torch._tensor.Tensor]:
@@ -58,6 +63,11 @@ class XAUCMetricTest(unittest.TestCase):
             msg=f"Actual: {actual_metric}, Expected: {expected_metric}",
         )
 
+    @unittest.skipIf(
+        _is_free_threaded(),
+        "torch.compile segfaults on free-threaded Python, "
+        "see https://dev-discuss.pytorch.org/t/torch-compile-support-for-python-3-14-completed/3276",
+    )
     def test_xauc_compile(self) -> None:
         xauc_compile = XAUCMetric(
             world_size=WORLD_SIZE,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/torchrec/pull/4091

Differential Revision: D100432566


