### PR TITLE
Support list of prefixes in copy_state_dict exclude_predfix

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -10,7 +10,7 @@
 import os
 import unittest
 from collections import defaultdict
-from typing import Any, Callable, cast, Dict, List, Optional, OrderedDict, Tuple
+from typing import Any, Callable, cast, Dict, List, Optional, OrderedDict, Tuple, Union
 
 import numpy as np
 import torch
@@ -102,6 +102,7 @@ class InferenceModelParallelTestBase(unittest.TestCase):
         constraints: Optional[Dict[str, ParameterConstraints]] = None,
         # pyrefly: ignore[bad-function-definition]
         generate: ModelInputCallable = ModelInput.generate,
+        exclude_predfix: Optional[Union[str, List[str]]] = None,
     ) -> None:
         default_rank = 0
         cuda_device = torch.device(f"cuda:{default_rank}")
@@ -174,7 +175,11 @@ class InferenceModelParallelTestBase(unittest.TestCase):
         # materialize inference sharded model on one device for dense part
         local_model = local_model.copy(cuda_device)
 
-        copy_state_dict(local_model.state_dict(), global_model.state_dict())
+        copy_state_dict(
+            local_model.state_dict(),
+            global_model.state_dict(),
+            exclude_predfix=exclude_predfix,
+        )
 
         # Run a single training step of the sharded model.
         with torch.inference_mode():

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -675,13 +675,17 @@ def dynamic_sharding_test(
 def copy_state_dict(
     loc: Dict[str, Union[torch.Tensor, ShardedTensor, DTensor]],
     glob: Dict[str, torch.Tensor],
-    exclude_predfix: Optional[str] = None,
+    exclude_predfix: Optional[Union[str, List[str]]] = None,
 ) -> None:
     """
     Copies the contents of the global tensors in glob to the local tensors in loc.
     """
+    if isinstance(exclude_predfix, str):
+        exclude_predfix = [exclude_predfix]
     for name, tensor in loc.items():
-        if exclude_predfix is not None and name.startswith(exclude_predfix):
+        if exclude_predfix is not None and any(
+            name.startswith(p) for p in exclude_predfix
+        ):
             continue
         else:
             assert name in glob, name


### PR DESCRIPTION
Summary:
Extend `copy_state_dict`'s `exclude_predfix` parameter to accept either a single string or a list of strings. This enables callers to exclude multiple key prefixes when copying state between global and local models.

Also add `exclude_predfix` as an optional parameter to `InferenceModelParallelTestBase._test_sharded_forward` (default `None`) so callers can pass through exclude prefixes as needed.

Reviewed By: TroyGarden

Differential Revision: D99794789


