### PR TITLE
Fix _rewrite_model tracing failure when error_on_nested_fx_trace is enabled

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -136,6 +136,55 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         self.assertEqual(missing_keys, [])
         self.assertEqual(unexpected_keys, [])
 
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_rewrite_model_compiled_with_error_on_nested_fx_trace(self) -> None:
+        """Test that _rewrite_model can trace a compiled model even when
+        error_on_nested_fx_trace is True, thanks to the config.patch override.
+
+        The compiled module must contain ShardedModules so the FX tracer traces
+        *into* it (non-leaf), triggering dynamo's eval frame hook which checks
+        the error_on_nested_fx_trace config."""
+        sharding_type = ShardingType.TABLE_WISE.value
+        kernel_type = EmbeddingComputeKernel.FUSED.value
+        fused_params = {}
+
+        model = self._setup_model()
+        sharded_model, optim = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type, fused_params
+        )
+
+        # Compile the sparse sub-module which contains ShardedModules (ebc,
+        # weighted_ebc).  Because it contains ShardedModules the FX tracer will
+        # treat it as non-leaf and trace into it, invoking the OptimizedModule's
+        # __call__ which goes through dynamo's eval frame and checks
+        # error_on_nested_fx_trace.
+        inner = sharded_model.module
+        # pyrefly: ignore[missing-attribute]
+        compiled_sparse = torch.compile(inner.sparse, backend="eager", fullgraph=False)
+        setattr(inner, "sparse", compiled_sparse)
+
+        # Set error_on_nested_fx_trace to True globally — without the fix in
+        # _rewrite_model this would cause tracing to raise an error.
+        original_value = torch._dynamo.config.error_on_nested_fx_trace
+        torch._dynamo.config.error_on_nested_fx_trace = True
+        try:
+            pipelined_forwards, _, original_forwards, _, _ = _rewrite_model(
+                model=sharded_model,
+                batch=None,
+                context=TrainPipelineContext(),
+                dist_stream=None,
+            )
+
+            # Verify that sharded modules were successfully pipelined
+            self.assertGreater(len(pipelined_forwards), 0)
+            for mod in pipelined_forwards:
+                self.assertIsInstance(mod.forward, PipelinedForward)
+        finally:
+            torch._dynamo.config.error_on_nested_fx_trace = original_value
+
     def test_pipelined_postproc_state_dict(self) -> None:
         class TestModule(torch.nn.Module):
             def __init__(self):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -418,7 +418,19 @@ def _rewrite_model(  # noqa C901
             concrete_args = batch.to_proxy_tuple(model)
 
     tracer = Tracer(leaf_modules=_get_leaf_module_names(model))
-    graph = tracer.trace(model, concrete_args=concrete_args)
+
+    # When a compiled (torch.compile) module contains ShardedModules, the FX
+    # tracer will trace into it (non-leaf), which triggers dynamo's eval-frame
+    # hook. If error_on_nested_fx_trace is True, dynamo rejects the nested FX
+    # trace and raises an error.  Temporarily patch the config to False so the
+    # FX tracer can operate on compiled models regardless of the global setting.
+    if torch._utils_internal.justknobs_check(
+        "pytorch/torchrec:killswitch_rewrite_model_patch_nested_fx_trace",
+    ):
+        with torch._dynamo.config.patch(error_on_nested_fx_trace=False):
+            graph = tracer.trace(model, concrete_args=concrete_args)
+    else:
+        graph = tracer.trace(model, concrete_args=concrete_args)
 
     # Select sharded modules, which are top-level in the forward call graph,
     # i.e. don't have input transformations, i.e. rely only on 'builtins.getattr'.


### PR DESCRIPTION
Summary:
When `torch._dynamo.config.error_on_nested_fx_trace` is set to `True`, calling `_rewrite_model` on a compiled model fails because `Tracer.trace()` triggers a nested FX trace which dynamo rejects.

This diff wraps the `tracer.trace()` call in `_rewrite_model` with `torch._dynamo.config.patch(error_on_nested_fx_trace=False)` so that the FX tracer can operate on compiled models regardless of the global config setting.

Reviewed By: TroyGarden

Differential Revision: D100346015


