### PR TITLE
Fix prefetch_emo benchmark config and add sync_batch option

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -133,6 +133,7 @@ class RunOptions(BenchFuncConfig):
     num_iters: Optional[int] = None
     output_json: bool = False
     sync_fwd: bool = True
+    sync_batch: bool = False
 
 
 # single-rank runner
@@ -280,7 +281,10 @@ def runner(
                         if metric_module.should_compute():
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
-                    fwd_event.synchronize()
+                    if run_option.sync_fwd:
+                        fwd_event.synchronize()
+                    if run_option.sync_batch:
+                        torch.cuda.synchronize()
                 except StopIteration:
                     break
 

--- a/torchrec/distributed/benchmark/yaml/prefetch_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_emo.yml
@@ -10,6 +10,7 @@ RunOptions:
   name: "prefetch_emo"
   memory_snapshot: True
   loglevel: "INFO"
+  sync_batch: True
   # export_stacks: True # enable this to export stack traces
 PipelineConfig:
   pipeline: "prefetch"  # "sparse"
@@ -51,3 +52,5 @@ PlannerConfig:
     large_table:
       compute_kernels: [fused_uvm_caching]
       sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True


### PR DESCRIPTION
Summary:
Fixed the prefetch_emo benchmark config to set `prefetch_pipeline=True` on the UVM caching table, resolving this error:
```
ERROR:root:Invalid setting on <class '...SplitTableBatchedEmbeddingBagsCodegen'> modules. prefetch_pipeline must be set to True.
```

Also added a `sync_batch` option to `RunOptions` for full `torch.cuda.synchronize()` timing, which gives more accurate measurements for multi-stream pipelines.

## Results
| short name | GPU Runtime (P90) | CPU Runtime (P90) | GPU Peak Mem reserved (P90) |
|--|--|--|--|
| before | 4152.31 ms | 3561.53 ms | 27.89 GB |
| after | 3362.94 ms | 2946.45 ms | 26.98 GB |

* before

<img width="4616" height="1626" alt="image" src="https://github.com/user-attachments/assets/efbaab92-111c-4a72-bded-baa7be5788e0" />


* after

<img width="4634" height="1642" alt="image" src="https://github.com/user-attachments/assets/4ed840b9-c5bb-42e7-a413-183d648e0f40" />


* repro
```
python -m torchrec.distributed.benchmark.benchmark_train_pipeline \
    --yaml_config=torchrec/distributed/benchmark/yaml/prefetch_emo.yml \
    --name=[before|after]
```

Differential Revision: D100527106


