### PR TITLE
Replace deprecated _get_pg_default_device with _get_object_coll_device

### DIFF
--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -38,7 +38,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 from torch.autograd.profiler import record_function
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.distributed.distributed_c10d import _get_pg_default_device
+from torch.distributed.distributed_c10d import _get_object_coll_device
 from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
 from torchrec.types import DataType, ModuleNoCopyMixin
 
@@ -919,7 +919,7 @@ class ShardingEnv:
         self.process_group: Optional[dist.ProcessGroup] = pg
         self.device_mesh: Optional[DeviceMesh] = (
             init_device_mesh(
-                device_type=_get_pg_default_device(pg).type,
+                device_type=_get_object_coll_device(pg),
                 mesh_shape=(dist.get_world_size(pg),),
             )
             if pg


### PR DESCRIPTION
Summary:
## Problem

`ShardingEnv.__init__` calls `_get_pg_default_device(pg)` which emits two `UserWarning`s on every invocation:

```
UserWarning: Multiple backends are registered with this ProcessGroup. We cannot determine which one is the default. Returning cpu. Please consider using other APIs.

UserWarning: `_get_pg_default_device` will be deprecated, it only stays for backward-compatibility reason. If you need to find a device for object collectives, please use `_get_object_coll_device`. If you need to query the device types supported by group, please use `_device_capability(group)`.
```

## Fix

Replace with the recommended `_get_object_coll_device`, which returns `str` directly (no `.type` needed).

## Prod Safety

Both functions read `group._device_types` and apply the same single/multi-backend selection rules. Edge case differences (see [`_get_object_coll_device`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py#L821-L884) vs [`_get_pg_default_device`](https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py#L887-L964)):

| Scenario | `_get_pg_default_device` | `_get_object_coll_device` |
|---|---|---|
| 1 backend | `devices[0]` (torch.device) | `devices[0].type` (str) |
| 0 backends | raises RuntimeError | returns `"cpu"` |
| Multiple backends | returns device + **warns** | returns device silently |

In practice, `ShardingEnv` always receives a ProcessGroup with at least one registered backend, so behavior is unchanged.

Differential Revision: D100528267


