### PR TITLE
Replace deprecated is_fx_tracing with is_fx_symbolic_tracing

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -133,6 +133,7 @@ class RunOptions(BenchFuncConfig):
     num_iters: Optional[int] = None
     output_json: bool = False
     sync_fwd: bool = True
+    sync_batch: bool = False
 
 
 # single-rank runner
@@ -280,7 +281,10 @@ def runner(
                         if metric_module.should_compute():
                             with record_function("## metric_compute ##"):
                                 metric_module.compute()
-                    fwd_event.synchronize()
+                    if run_option.sync_fwd:
+                        fwd_event.synchronize()
+                    if run_option.sync_batch:
+                        torch.cuda.synchronize()
                 except StopIteration:
                     break
 

--- a/torchrec/distributed/benchmark/yaml/prefetch_emo.yml
+++ b/torchrec/distributed/benchmark/yaml/prefetch_emo.yml
@@ -10,6 +10,7 @@ RunOptions:
   name: "prefetch_emo"
   memory_snapshot: True
   loglevel: "INFO"
+  sync_batch: True
   # export_stacks: True # enable this to export stack traces
 PipelineConfig:
   pipeline: "prefetch"  # "sparse"
@@ -51,3 +52,5 @@ PlannerConfig:
     large_table:
       compute_kernels: [fused_uvm_caching]
       sharding_types: [row_wise]
+      cache_params:
+        prefetch_pipeline: True

--- a/torchrec/distributed/test_utils/test_model.py
+++ b/torchrec/distributed/test_utils/test_model.py
@@ -2869,7 +2869,7 @@ class TestMixedEmbeddingSparseArch(TestSparseNNBase, CopyableMixin):
         dense_r = self.dense(input.float_features)
         if (
             self._enable_activation_stashing
-            and not torch.fx._symbolic_trace.is_fx_tracing()
+            and not torch.fx._symbolic_trace.is_fx_symbolic_tracing()
         ):
             dense_r.register_hook(self._restore_callback)
         over_r = self.over(dense_r, sparse_output)
@@ -2932,7 +2932,7 @@ class TestMixedEmbeddingSparseArch(TestSparseNNBase, CopyableMixin):
             ec_embeddings = torch.cat(padded_embeddings, dim=1)
             if (
                 self._enable_activation_stashing
-                and not torch.fx._symbolic_trace.is_fx_tracing()
+                and not torch.fx._symbolic_trace.is_fx_symbolic_tracing()
             ):
                 await_restore, restore = MemoryStashingManager._stash_tensors(
                     [ec_result[e]._values for e in self._ec_features]

--- a/torchrec/distributed/train_pipeline/tests/test_postproc.py
+++ b/torchrec/distributed/train_pipeline/tests/test_postproc.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
-from torch.fx._symbolic_trace import is_fx_tracing
+from torch.fx._symbolic_trace import is_fx_symbolic_tracing
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.test_utils.test_model import (
     ModelInput,
@@ -657,7 +657,7 @@ class TrainPipelinePostprocTest(TrainPipelineSparseDistTestBase):
                 input_list: List[Union[torch.Tensor, int]],
                 input_dict: Dict[str, Union[torch.Tensor, int]],
             ) -> ModelInput:
-                if not is_fx_tracing():
+                if not is_fx_symbolic_tracing():
                     for idx, value in enumerate(input_list):
                         if isinstance(value, torch.fx.Node):
                             test_runner.fail(

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -38,7 +38,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 )
 from torch.autograd.profiler import record_function
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
-from torch.distributed.distributed_c10d import _get_pg_default_device
+from torch.distributed.distributed_c10d import _get_object_coll_device
 from torchrec.tensor_types import UInt2Tensor, UInt4Tensor
 from torchrec.types import DataType, ModuleNoCopyMixin
 
@@ -919,7 +919,7 @@ class ShardingEnv:
         self.process_group: Optional[dist.ProcessGroup] = pg
         self.device_mesh: Optional[DeviceMesh] = (
             init_device_mesh(
-                device_type=_get_pg_default_device(pg).type,
+                device_type=_get_object_coll_device(pg),
                 mesh_shape=(dist.get_world_size(pg),),
             )
             if pg

--- a/torchrec/fx/utils.py
+++ b/torchrec/fx/utils.py
@@ -11,7 +11,7 @@ import inspect
 from typing import Any, Dict, List, Set
 
 import torch
-from torch.fx._symbolic_trace import is_fx_tracing
+from torch.fx._symbolic_trace import is_fx_symbolic_tracing
 
 # Not importing DistributedModelParallel here to avoid circular dependencies as DMP depends on torchrec.fx.tracer
 # def dmp_fx_trace_forward(dmp: DistributedModelParallel)
@@ -131,7 +131,7 @@ def _fx_marker(s: str, any_proxy_unused: Any) -> None:
 
 
 def fx_marker(s: str, any_proxy_unused: Any) -> None:
-    if is_fx_tracing():
+    if is_fx_symbolic_tracing():
         _fx_marker(s, any_proxy_unused)
 
 
@@ -147,5 +147,5 @@ def is_marker_node(node: torch.fx.Node, marker_name: str) -> bool:
 
 @torch.jit.ignore
 def assert_fx_safe(condition: bool, message: str) -> None:
-    if not is_fx_tracing():
+    if not is_fx_symbolic_tracing():
         assert condition, message


### PR DESCRIPTION
Summary:
## Problem

`is_fx_tracing()` from `torch.fx._symbolic_trace` emits a warning on every call:

```
is_fx_tracing will return true for both fx.symbolic_trace and torch.export. Please use is_fx_tracing_symbolic_tracing() for specifically fx.symbolic_trace or torch.compiler.is_compiling() for specifically torch.export/compile.
```

## Fix

Replace with `is_fx_symbolic_tracing()`, which returns `True` only during `fx.symbolic_trace` (not during `torch.export/compile`). All usages in these files are guarding symbolic-trace-specific behavior (skipping assertions, skipping hooks), so `is_fx_symbolic_tracing` is the correct replacement.

## Prod Safety

[`is_fx_symbolic_tracing`](https://github.com/pytorch/pytorch/blob/main/torch/fx/_symbolic_trace.py#L66-L67) is defined as `return _is_fx_tracing_flag and not torch.compiler.is_compiling()`. Since TorchRec's FX tracing uses `fx.symbolic_trace` (not `torch.export`), the behavior is identical — these code paths were never entered during `torch.export/compile` anyway.

Note: ~40 additional usages in `fb/` files import from Meta internal wrappers (`caffe2.torch.fb.model_transform.symbolic_tracing`, `hpc.models.fx_utils`) and are left to their respective owners.

Differential Revision: D100528990


