### PR TITLE
Add control to delay stashing (#4108)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -16,6 +16,7 @@ PipelineConfig:
   pipeline: "sparse-emb-stash"
   kwargs:
     site_fqn: "over.overarch.0"  # dense
+    # delay_stash: true
 ModelInputConfig:
   num_float_features: 100
   feature_pooling_avg: 30

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -1643,7 +1643,7 @@ class ShardedEmbeddingCollection(
                 if MemoryStashingManager.is_enabled():
                     stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
                     if stash_result is not None:
-                        await_restore, _ = stash_result
+                        await_restore, *_ = stash_result
                         embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore[not-callable]

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1915,7 +1915,7 @@ class ShardedEmbeddingBagCollection(
                 if MemoryStashingManager.is_enabled():
                     stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
                     if stash_result is not None:
-                        await_restore, _ = stash_result
+                        await_restore, _, _execute_stash = stash_result
                         embs.register_hook(await_restore)
                 if hasattr(lookup, "get_resize_awaitables"):
                     # pyrefly: ignore [not-callable]

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -53,6 +53,8 @@ class MemoryStashingManager:
     _optimizer_state_restore_callbacks: List[Callable[..., None]] = []
     _emo_cache_restore_callbacks: List[Callable[..., None]] = []
     _stash_executor: Optional[ThreadPoolExecutor] = None
+    _delay_stash: bool = False
+    _pending_stash_callbacks: List[Callable[[Optional[torch.Tensor]], None]] = []
 
     @classmethod
     def thread_submit(cls, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
@@ -94,6 +96,30 @@ class MemoryStashingManager:
         one_time_rank0_logger.info("MemoryStashingManager: streams initialized")
 
     @classmethod
+    def set_delay_stash(cls, delay: bool) -> None:
+        """Enable or disable delayed stashing.
+
+        When enabled, ``stash_embedding_weights`` collects tensors and records
+        a sync event but does NOT execute the D2H copy or free HBM.  The
+        caller must later invoke ``execute_pending_stashes`` to perform the
+        actual stash and register restore callbacks.
+        """
+        cls._delay_stash = delay
+
+    @classmethod
+    def execute_pending_stashes(cls) -> None:
+        """Execute all pending (delayed) stash operations.
+
+        For each pending stash, invokes the deferred callable which performs
+        the D2H copy, ``resize_(0)`` to free HBM, and registers the restore
+        callback so that a subsequent ``restore_embedding_weights`` call can
+        bring the data back.
+        """
+        for cb in cls._pending_stash_callbacks:
+            cb(None)
+        cls._pending_stash_callbacks.clear()
+
+    @classmethod
     def reset(cls) -> None:
         """Release all resources."""
         logger.info("MemoryStashingManager: resetting all resources")
@@ -102,6 +128,8 @@ class MemoryStashingManager:
         cls._embedding_weight_restore_callbacks.clear()
         cls._optimizer_state_restore_callbacks.clear()
         cls._emo_cache_restore_callbacks.clear()
+        cls._delay_stash = False
+        cls._pending_stash_callbacks.clear()
         if cls._stash_executor is not None:
             cls._stash_executor.shutdown(wait=False)
             cls._stash_executor = None
@@ -138,7 +166,9 @@ class MemoryStashingManager:
         tensors: List[torch.Tensor],
         label: str = "tensor",
         sync_event: Optional[torch.cuda.Event] = None,
+        delay: bool = False,
     ) -> Tuple[
+        Callable[[Optional[torch.Tensor]], None],
         Callable[[Optional[torch.Tensor]], None],
         Callable[[Optional[torch.Tensor]], None],
     ]:
@@ -146,10 +176,10 @@ class MemoryStashingManager:
         Stash a list of CUDA tensors from HBM to CPU asynchronously.
 
         Core implementation shared by ``stash_embedding_weights`` and
-        ``stash_optimizer_state``.  Starts an async copy of each tensor from
-        GPU (HBM) to pinned CPU memory using the shared D2H stream, then frees
-        HBM via ``record_stream`` + ``resize_(0)``.  Returns two callback
-        functions for the restore phase.
+        ``stash_optimizer_state``.  Wraps the D2H copy and HBM free into an
+        ``execute_stash`` callable.  In non-delayed mode the callable is
+        invoked immediately; in delayed mode it is returned for the caller
+        to invoke later.
 
         Args:
             tensors: CUDA tensors to stash.  Non-CUDA / empty tensors are
@@ -161,11 +191,20 @@ class MemoryStashingManager:
                 calling ``torch.cuda.current_stream()``.  This is required
                 when ``_stash_tensors`` runs on a background thread, where
                 ``current_stream()`` would return the wrong (idle) stream.
+            delay: If True, do NOT execute the stash immediately.  The
+                returned ``execute_stash`` callable must be invoked later
+                to perform the actual D2H copy and free HBM.  A sync event
+                is recorded automatically so that the deferred execution
+                waits for the correct GPU work.
 
         Returns:
-            A tuple of two callback functions:
+            A tuple of three callback functions:
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
+            - execute_stash: Performs the D2H copy and frees HBM.  Accepts an
+              optional ``torch.Tensor`` so it can be registered as a backward
+              hook.  In non-delayed mode it has already been called and is
+              safe to call again (no-op on empty tensor list).
         """
         # (hbm_tensor ref, cpu_buffer, original_storage_size)
         stash_data: List[Tuple[torch.Tensor, torch.Tensor, int]] = []
@@ -173,46 +212,57 @@ class MemoryStashingManager:
         # Restore events populated by ``restore`` and consumed by ``await_restore``
         restore_events: List[torch.cuda.Event] = []
 
-        d2h_stream = cls.d2h_stream()
+        # For delayed mode, capture the current stream state now so
+        # execute_stash can correctly synchronize when called later.
+        if delay and sync_event is None:
+            sync_event = torch.cuda.Event()
+            sync_event.record(torch.cuda.current_stream())
 
-        # Ensure all operations on the caller's stream complete before we
-        # start copying — prevents reading while still being written.
-        # When sync_event is provided (background thread), use it instead
-        # of current_stream() which would return the wrong stream.
-        if sync_event is not None:
-            d2h_stream.wait_event(sync_event)
-        else:
-            d2h_stream.wait_stream(torch.cuda.current_stream())
+        def execute_stash(_grad: Optional[torch.Tensor] = None) -> None:
+            """Perform the D2H copy and free HBM."""
+            d2h_stream = cls.d2h_stream()
 
-        size_text = _tensor_size_text(tensors)
-        capped_logger.info(f"stash {label}: {len(tensors)} tensors, total {size_text}")
+            # Ensure all operations on the caller's stream complete before we
+            # start copying — prevents reading while still being written.
+            # When sync_event is provided (delayed or background thread), use
+            # it instead of current_stream() which may have advanced or be the
+            # wrong stream.
+            if sync_event is not None:
+                d2h_stream.wait_event(sync_event)
+            else:
+                d2h_stream.wait_stream(torch.cuda.current_stream())
 
-        # Start async copy from HBM to CPU
-        with record_function(f"stash {label} to host ({size_text})"):
-            with torch.cuda.stream(d2h_stream):
-                for tensor in tensors:
-                    # Create pinned CPU buffer for efficient async DMA transfer
-                    cpu_buffer = torch.empty(
-                        tensor.shape,
-                        dtype=tensor.dtype,
-                        device="cpu",
-                        pin_memory=True,
-                    )
-                    cpu_buffer.copy_(tensor, non_blocking=True)
-                    orig_storage_size = tensor.untyped_storage().size()
-                    stash_data.append((tensor, cpu_buffer, orig_storage_size))
+            size_text = _tensor_size_text(tensors)
+            capped_logger.info(
+                f"stash {label}: {len(tensors)} tensors, total {size_text}"
+            )
 
-                # Two-pass: free HBM storage only after all copies are
-                # enqueued.  Tensors may share the same underlying storage
-                # (e.g. views into an all-to-all output buffer), so freeing
-                # one tensor's storage before copying another would
-                # invalidate the shared data.
-                seen_storage_ptrs: set = set()
-                for tensor, _, _ in stash_data:
-                    storage_ptr = tensor.untyped_storage().data_ptr()
-                    if storage_ptr not in seen_storage_ptrs:
-                        seen_storage_ptrs.add(storage_ptr)
-                        tensor.untyped_storage().resize_(0)
+            # Start async copy from HBM to CPU
+            with record_function(f"stash {label} to host ({size_text})"):
+                with torch.cuda.stream(d2h_stream):
+                    for tensor in tensors:
+                        # Create pinned CPU buffer for efficient async DMA transfer
+                        cpu_buffer = torch.empty(
+                            tensor.shape,
+                            dtype=tensor.dtype,
+                            device="cpu",
+                            pin_memory=True,
+                        )
+                        cpu_buffer.copy_(tensor, non_blocking=True)
+                        orig_storage_size = tensor.untyped_storage().size()
+                        stash_data.append((tensor, cpu_buffer, orig_storage_size))
+
+                    # Two-pass: free HBM storage only after all copies are
+                    # enqueued.  Tensors may share the same underlying storage
+                    # (e.g. views into an all-to-all output buffer), so freeing
+                    # one tensor's storage before copying another would
+                    # invalidate the shared data.
+                    seen_storage_ptrs: set = set()
+                    for tensor, _, _ in stash_data:
+                        storage_ptr = tensor.untyped_storage().data_ptr()
+                        if storage_ptr not in seen_storage_ptrs:
+                            seen_storage_ptrs.add(storage_ptr)
+                            tensor.untyped_storage().resize_(0)
 
         def restore(
             _grad: Optional[torch.Tensor] = None,
@@ -278,7 +328,15 @@ class MemoryStashingManager:
             for restore_event in restore_events:
                 torch.cuda.current_stream().wait_event(restore_event)
 
-        return await_restore, restore
+        if not delay:
+            execute_stash()
+
+            def _noop_stash(_grad: Optional[torch.Tensor] = None) -> None:
+                pass
+
+            return await_restore, restore, _noop_stash
+
+        return await_restore, restore, execute_stash
 
     @classmethod
     def stash_embedding_weights(
@@ -286,6 +344,7 @@ class MemoryStashingManager:
         lookup: nn.Module,
     ) -> Optional[
         Tuple[
+            Callable[[Optional[torch.Tensor]], None],
             Callable[[Optional[torch.Tensor]], None],
             Callable[[Optional[torch.Tensor]], None],
         ]
@@ -297,23 +356,27 @@ class MemoryStashingManager:
         (pinned memory) using the shared D2H stream. HBM is freed immediately
         using ``record_stream`` to let the caching allocator handle stream
         ordering — no background thread or CPU-blocking synchronize needed.
-        Returns two callback functions for the restore phase.
 
         Args:
             lookup: A lookup module (e.g., GroupedPooledEmbeddingsLookup) containing
                 embedding modules with weights to stash.
 
         Returns:
-            A tuple of two callback functions, or None if no tensors were stashed:
+            A tuple of three callback functions, or None if no tensors qualify
+            for stashing (e.g., all tables have ``stash_weights=False``):
             - await_restore: Pauses current stream awaiting restore completion
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
+            - execute_stash: Performs the actual D2H copy and frees HBM.  Takes
+              an optional ``torch.Tensor`` argument so it can be registered as
+              a backward hook.  In immediate mode this is a no-op (stash
+              already happened).  In delayed mode (``set_delay_stash(True)``),
+              this callable is auto-appended to the pending list and should be
+              triggered later via ``execute_pending_stashes()``.
 
         Usage:
-            >>> await_restore, restore = MemoryStashingManager.stash_embedding_weights(lookup)
-            >>> # ... HBM is freed via record_stream (allocator reclaims after D2H completes) ...
-            >>> # Before backward (or next forward):
-            >>> restore()  # Start async restore from CPU to HBM
-            >>> await_restore()  # Wait for restore to complete before using weights
+            >>> await_restore, restore, execute_stash = MemoryStashingManager.stash_embedding_weights(lookup)
+            >>> # In immediate mode: stash already happened, execute_stash is no-op
+            >>> # In delayed mode: call execute_pending_stashes() later to trigger
 
         Note:
             - Uses pinned CPU memory for efficient async transfers
@@ -322,6 +385,7 @@ class MemoryStashingManager:
               the D2H copy completes, avoiding GIL deadlocks from background threads
             - restore starts async copy, await_restore blocks GPU stream until complete
         """
+
         # Handle DDP wrapper - unwrap to get the actual module
         module = lookup.module if hasattr(lookup, "module") else lookup
 
@@ -366,9 +430,25 @@ class MemoryStashingManager:
         if not tensors:
             return None
 
-        await_restore, restore = cls._stash_tensors(tensors, label="embedding")
+        if cls._delay_stash:
+            await_restore, restore, execute_stash = cls._stash_tensors(
+                tensors, label="embedding", delay=True
+            )
+
+            # Wrap execute_stash to also register the restore callback,
+            # which only works after stash_data is populated.
+            def _deferred_stash(_grad: Optional[torch.Tensor] = None) -> None:
+                execute_stash(None)
+                cls._embedding_weight_restore_callbacks.append(restore)
+
+            cls._pending_stash_callbacks.append(_deferred_stash)
+            return await_restore, restore, _deferred_stash
+
+        await_restore, restore, execute_stash = cls._stash_tensors(
+            tensors, label="embedding"
+        )
         cls._embedding_weight_restore_callbacks.append(restore)
-        return await_restore, restore
+        return await_restore, restore, execute_stash
 
     @classmethod
     def restore_emo_cache(
@@ -595,7 +675,7 @@ class MemoryStashingManager:
             f"collected {len(tensors)} state tensors"
         )
 
-        await_restore, restore = cls._stash_tensors(
+        await_restore, restore, _execute_stash = cls._stash_tensors(
             tensors, label="optimizer state", sync_event=sync_event
         )
         cls._optimizer_state_restore_callbacks.append(restore)

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -40,7 +40,9 @@ class TestStashTensors(unittest.TestCase):
         tensor = torch.randn(100, 64, device=self.device)
         original = tensor.clone()
 
-        await_restore, restore = MemoryStashingManager._stash_tensors([tensor])
+        await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
+            [tensor]
+        )
 
         # Verify HBM is freed
         self.assertEqual(tensor.untyped_storage().size(), 0)
@@ -59,7 +61,9 @@ class TestStashTensors(unittest.TestCase):
         t2 = torch.ones(80, 64, device=self.device) * 2
         originals = [t1.clone(), t2.clone()]
 
-        await_restore, restore = MemoryStashingManager._stash_tensors([t1, t2])
+        await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
+            [t1, t2]
+        )
 
         # All freed
         self.assertEqual(t1.untyped_storage().size(), 0)
@@ -75,7 +79,9 @@ class TestStashTensors(unittest.TestCase):
 
     def test_empty_list(self) -> None:
         """Test that an empty tensor list returns no-op callbacks."""
-        await_restore, restore = MemoryStashingManager._stash_tensors([])
+        await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
+            []
+        )
         # Should not raise
         restore(None)
         await_restore(None)
@@ -85,7 +91,9 @@ class TestStashTensors(unittest.TestCase):
         tensor = torch.randn(10, 5, device=self.device, requires_grad=True)
         version_before = tensor._version
 
-        await_restore, restore = MemoryStashingManager._stash_tensors([tensor])
+        await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
+            [tensor]
+        )
         restore(None)
         await_restore(None)
 
@@ -96,7 +104,9 @@ class TestStashTensors(unittest.TestCase):
         tensor = torch.randn(10, 5, device=self.device)
         original = tensor.clone()
 
-        await_restore, restore = MemoryStashingManager._stash_tensors([tensor])
+        await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
+            [tensor]
+        )
 
         dummy_grad = torch.tensor([1.0])
         restore(dummy_grad)
@@ -175,7 +185,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Verify HBM is freed
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -204,7 +214,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Verify all are stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)
@@ -235,7 +245,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Verify stash worked
         self.assertEqual(original_weights.untyped_storage().size(), 0)
@@ -263,7 +273,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         # Stash and restore
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
@@ -305,7 +315,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Only CUDA weights should be stashed
         self.assertEqual(cuda_weights.untyped_storage().size(), 0)
@@ -343,7 +353,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Valid weights should be stashed
         self.assertEqual(valid_weights.untyped_storage().size(), 0)
@@ -369,9 +379,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
-        # Register restore via class method and await_restore as backward hook
+        # Register restore via class method
         output.register_hook(
             lambda _grad: MemoryStashingManager.restore_embedding_weights()
         )
@@ -400,7 +410,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Only the stash_weights=True group should be stashed
         self.assertEqual(stash_weights.untyped_storage().size(), 0)
@@ -449,7 +459,7 @@ class TestStashEmbeddingWeights(unittest.TestCase):
 
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
-        await_restore, _restore = result
+        await_restore, _restore, _execute_stash = result
 
         # Both should be stashed
         self.assertEqual(weights_1.untyped_storage().size(), 0)

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -1095,6 +1095,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         enqueue_batch_after_forward: bool = False,
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
+        delay_stash: bool = False,
     ) -> None:
         super().__init__(
             model=model,
@@ -1118,11 +1119,14 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
             )
         else:
             self._injection_site = site_fqn
+        self._delay_stash = delay_stash
 
         MemoryStashingManager.set_streams(
             self._memcpy_stream,  # pyrefly: ignore[bad-argument-type]
             torch.cuda.Stream(device=device),
         )
+        if delay_stash:
+            MemoryStashingManager.set_delay_stash(True)
 
     def _pipeline_model(
         self,
@@ -1131,6 +1135,16 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         pipelined_forward: Type[PipelinedForward] = PipelinedForward,
     ) -> None:
         super()._pipeline_model(batch, context, pipelined_forward)
+
+        if self._delay_stash:
+            # Register execute hook first — tensor hooks fire in registration
+            # order, so execute_pending_stashes runs before restore during
+            # backward.
+            def execute_work(_pipeline: Any) -> None:
+                with record_function("## execute_pending_stashes ##"):
+                    MemoryStashingManager.execute_pending_stashes()
+
+            self.register_backward_hook(self._injection_site, execute_work)
 
         def work(_pipeline: Any) -> None:
             with record_function("## restore_embedding_weights ##"):


### PR DESCRIPTION
Summary:

EMS stashing's DtoH copy can occasionally cause PCIe contention with HtoD copy in start_sparse_data_dist. Causing long wait in start_sparse_data_dist, and reducing overall QPS. This is the first diff to expose an option to delay stashing to mitigate this regression. 


Next diff will allow more fine grain control for where stashing is triggered.

Reviewed By: TroyGarden

Differential Revision: D100842657


