### PR TITLE
Fix required_inputs mutation across iterations in _update_unfused

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -719,6 +719,7 @@ class RecMetric(nn.Module, abc.ABC):
 
         Iterates over tasks and updates each metric computation independently.
         """
+        original_required_inputs = kwargs.get("required_inputs")
         for task, metric_ in zip(self._tasks, self._metrics_computations):
             if task.name not in predictions:
                 continue
@@ -782,15 +783,16 @@ class RecMetric(nn.Module, abc.ABC):
                     metric_.has_valid_update.logical_or_(has_valid_weights)
                 else:
                     continue
-            if "required_inputs" in kwargs:
-                # Expand scalars to match the shape of the predictions
+            if original_required_inputs is not None:
+                # Reshape from original inputs each iteration to avoid
+                # reading already-reshaped values from a prior task.
                 kwargs["required_inputs"] = {
                     k: (
                         v.view(task_labels.size())
                         if v.numel() > 1
                         else v.expand(task_labels.size())
                     )
-                    for k, v in kwargs["required_inputs"].items()
+                    for k, v in original_required_inputs.items()
                 }
             # pyrefly: ignore[not-callable]
             metric_.update(

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -404,3 +404,48 @@ class RecMetricTensorSizeLoggingTest(unittest.TestCase):
         self.assertIn("predictions_numel", metadata)
         self.assertIn("labels_numel", metadata)
         self.assertNotIn("weights_numel", metadata)
+
+    def test_unfused_required_inputs_not_mutated_across_tasks(self) -> None:
+        """Verify that scalar required_inputs are reshaped from originals on each
+        task iteration, not from already-reshaped values of a prior iteration.
+
+        Uses different batch sizes per task (4 vs 6) so that task_labels.size()
+        differs across iterations. Without the fix, expand(1, 4) on iteration 1
+        produces a tensor with numel=4; on iteration 2, numel > 1 routes to
+        view(1, 6) which fails because 4 elements cannot be viewed as (1, 6).
+        """
+        task_names = ["t1", "t2"]
+        tasks = gen_test_tasks(task_names)
+        ne = NEMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=4,
+            tasks=tasks,
+            compute_mode=RecComputeMode.UNFUSED_TASKS_COMPUTATION,
+            window_size=100,
+            fused_update_limit=0,
+        )
+        # Different batch sizes per task to trigger the bug.
+        predictions = {
+            "t1": torch.rand(4, dtype=torch.double),
+            "t2": torch.rand(6, dtype=torch.double),
+        }
+        labels = {
+            "t1": torch.rand(4, dtype=torch.double),
+            "t2": torch.rand(6, dtype=torch.double),
+        }
+        weights = {
+            "t1": torch.ones(4, dtype=torch.double),
+            "t2": torch.ones(6, dtype=torch.double),
+        }
+        # Scalar required_input: numel=1, triggers expand() path.
+        required_inputs = {"scale": torch.tensor([5.0])}
+
+        # Should not raise — without the fix, iteration 2 would crash with
+        # RuntimeError because view(1, 6) cannot reshape 4 elements.
+        ne.update(
+            predictions=predictions,
+            labels=labels,
+            weights=weights,
+            required_inputs=required_inputs,
+        )


### PR DESCRIPTION
Summary:
In RecMetric._update(), the unfused tasks loop reassigns kwargs["required_inputs"] inside the per-task iteration. On iteration N+1, the dict comprehension reads from already-reshaped values from iteration N rather than the original inputs. With different batch sizes per task and a scalar required_input, expand(1, M) on iteration 1 produces a tensor with numel=M; on iteration 2, numel > 1 routes to view(1, N) which crashes with RuntimeError because M elements cannot be viewed as (1, N).

Fix: capture the original required_inputs dict before the loop and read from it on each iteration.

Differential Revision: D100736141


