### PR TITLE
feat: add ITEP pruning stats and decision logging for IEN/APS

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -44,6 +44,7 @@ class TorchrecComponent(Enum):
     OUTPUT_DIST = "output_dist"
     LOOKUP = "lookup"
     REC_METRICS = "rec_metrics"
+    ITEP = "itep"
 
 
 class EventLoggingHandler(EventLoggingHandlerBase):
@@ -263,6 +264,54 @@ def log_clf_computed(
     table_height: int = 0,
     clf: float = 0.0,
     technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_init_state(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_eviction(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_pruning_trigger(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_checkpoint_save(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_checkpoint_load(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
 ) -> None:
     """No-op OSS stub."""
     pass

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -333,4 +333,20 @@ def log_itep_rowwise_shard(
     pass
 
 
+def log_itep_ien_pruning_stats(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_itep_ien_pruning_decision(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -325,4 +325,12 @@ def log_itep_table_config(
     pass
 
 
+def log_itep_rowwise_shard(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -317,4 +317,12 @@ def log_itep_checkpoint_load(
     pass
 
 
+def log_itep_table_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ITEP,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)

--- a/torchrec/modules/itep_modules.py
+++ b/torchrec/modules/itep_modules.py
@@ -19,6 +19,14 @@ from torch.distributed._shard.metadata import ShardMetadata
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.embedding_types import ShardedEmbeddingTable, ShardingType
+from torchrec.distributed.logging_handlers import (
+    log_itep_checkpoint_load,
+    log_itep_checkpoint_save,
+    log_itep_config,
+    log_itep_eviction,
+    log_itep_init_state,
+    log_itep_pruning_trigger,
+)
 from torchrec.distributed.types import Shard, ShardedTensor, ShardedTensorMetadata
 from torchrec.modules.embedding_modules import reorder_inverse_indices
 from torchrec.modules.pruning_logger import PruningLogger, PruningLoggerDefault
@@ -114,6 +122,18 @@ class GenericITEPModule(nn.Module):
                     "ITEP init: no lookups provided. Skipping init for dummy module."
                 )
 
+            log_itep_config(
+                {
+                    "enable_pruning": str(enable_pruning),
+                    "pruning_interval": str(pruning_interval),
+                    "num_tables": str(len(table_name_to_unpruned_hash_sizes)),
+                    "table_names": ",".join(
+                        sorted(table_name_to_unpruned_hash_sizes.keys())
+                    ),
+                    "has_pg": str(pg is not None),
+                }
+            )
+
     def print_itep_eviction_stats(
         self,
         pruned_indices_offsets: torch.Tensor,
@@ -188,6 +208,19 @@ class GenericITEPModule(nn.Module):
             )
             logger.info(
                 f"Performed ITEP in iter {cur_iter}, evicted {pruned_indices_total_length} ({pruned_indices_ratio:%}) indices."
+            )
+
+            log_itep_eviction(
+                {
+                    "cur_iter": str(cur_iter),
+                    "pruned_indices_total_length": str(
+                        int(pruned_indices_total_length)
+                    ),
+                    "pruned_ratio": f"{pruned_indices_ratio}",
+                    "num_tables_evicted": str(len(sorted_mapping)),
+                    "top_eviction_table": next(iter(sorted_mapping), "none"),
+                    "top_eviction_ratio": str(next(iter(sorted_mapping.values()), 0)),
+                }
             )
 
     def get_table_hash_sizes(self, table: ShardedEmbeddingTable) -> Tuple[int, int]:
@@ -326,6 +359,14 @@ class GenericITEPModule(nn.Module):
 
         logger.info(
             f"ITEP: done init_state with feature_table_map {self.feature_table_map} and buffer_offsets {self.buffer_offsets_list}"
+        )
+
+        log_itep_init_state(
+            {
+                "num_pruned_tables": str(idx),
+                "total_buffer_size": str(buffer_size),
+                "device": str(self.current_device),
+            }
         )
 
         # initialize address_lookup
@@ -503,6 +544,21 @@ class GenericITEPModule(nn.Module):
             # Print eviction stats
             self.print_itep_eviction_stats(
                 pruned_indices_offsets, pruned_indices_total_length, cur_iter
+            )
+
+            log_itep_pruning_trigger(
+                {
+                    "cur_iter": str(cur_iter),
+                    "pruned_indices_total_length": str(
+                        int(pruned_indices_total_length)
+                    ),
+                    "did_reset_momentum": str(
+                        pruned_indices_total_length > 0
+                        and cur_iter > self.pruning_interval
+                    ),
+                    "did_flush_uvm": str(int(pruned_indices_total_length) > 0),
+                    "pruning_interval": str(self.pruning_interval),
+                }
             )
 
         (
@@ -749,6 +805,16 @@ class RowwiseShardedITEPModule(GenericITEPModule):
         logger.info(
             f"ITEP: get_itp_state_dict for {suffix}), got {ckp_tables}, skippped {skipped_tables}"
         )
+
+        log_itep_checkpoint_save(
+            {
+                "suffix": suffix,
+                "num_saved_tables": str(len(ckp_tables)),
+                "num_skipped_tables": str(len(skipped_tables)),
+                "saved_tables": ",".join(ckp_tables),
+            }
+        )
+
         return destination
 
     # pyrefly: ignore[bad-override]
@@ -794,6 +860,16 @@ class RowwiseShardedITEPModule(GenericITEPModule):
         logger.info(
             f"ITEP: load_state_dict, loaded {loaded_keys}, missed {missing_keys}, , unexpected {unexpected_keys}"
         )
+
+        log_itep_checkpoint_load(
+            {
+                "num_loaded_keys": str(len(loaded_keys)),
+                "num_missing_keys": str(len(missing_keys)),
+                "num_unexpected_keys": str(len(unexpected_keys)),
+                "missing_keys": ",".join(missing_keys[:10]),
+            }
+        )
+
         return _IncompatibleKeys(missing_keys, unexpected_keys)
 
     # pyrefly: ignore[bad-override]

--- a/torchrec/modules/itep_modules.py
+++ b/torchrec/modules/itep_modules.py
@@ -26,6 +26,7 @@ from torchrec.distributed.logging_handlers import (
     log_itep_eviction,
     log_itep_init_state,
     log_itep_pruning_trigger,
+    log_itep_rowwise_shard,
 )
 from torchrec.distributed.types import Shard, ShardedTensor, ShardedTensorMetadata
 from torchrec.modules.embedding_modules import reorder_inverse_indices
@@ -700,6 +701,16 @@ class RowwiseShardedITEPModule(GenericITEPModule):
             logger.info(
                 f"ITEP: table {table.name} not pruned, because table name is not present in table_name_to_unpruned_hash_sizes."
             )
+
+        log_itep_rowwise_shard(
+            {
+                "table_name": table.name,
+                "sharding_type": sharding_type,
+                "local_rows": str(local_rows),
+                "local_unpruned_rows": str(local_unpruned_rows),
+                "is_pruned": str(table.name in self.table_name_to_unpruned_hash_sizes),
+            }
+        )
 
         return (local_rows, local_unpruned_rows)
 


### PR DESCRIPTION
Summary:
Add two structured logging events for ITEP pruning observability during
IEN model publishing on APS:

1. log_itep_ien_pruning_stats (JOB scope) — aggregate pruning summary:
   model_type_name, model_entity_id, num_tables_total/pruned/skipped,
   total_embeddings_before/after_pruned.

2. log_itep_ien_pruning_decision (TABLE scope) — per-table pruning
   decision: table_fqn, should_prune, num_embeddings_before/after,
   threshold, embedding_dimension.

These fire after sharding preparation produces pruning decisions in
orchestrator_ads.py, providing Scuba visibility into which tables are
pruned and by how much during the inference publishing pipeline.

Follows the same OSS stub / FB impl / call-site pattern as the parent
ITEP logging diffs.

Reviewed By: miasantreble

Differential Revision: D100034013


