### PR TITLE
Add SSD hardware keys to sharding config

### DIFF
--- a/torchrec/distributed/test_utils/sharding_config.py
+++ b/torchrec/distributed/test_utils/sharding_config.py
@@ -93,8 +93,10 @@ class PlannerConfig:
         _HARDWARE_KEYS = [
             "hbm_cap",
             "ddr_cap",
+            "ssd_cap",
             "hbm_mem_bw",
             "ddr_mem_bw",
+            "ssd_mem_bw",
             "hbm_to_ddr_mem_bw",
             "intra_host_bw",
             "inter_host_bw",


### PR DESCRIPTION
Summary: Add `ssd_cap` and `ssd_mem_bw` to `_HARDWARE_KEYS` in `ShardingConfig` so that benchmark hardware profiles can override SSD capacity and SSD memory bandwidth, matching the existing support for HBM and DDR overrides.

Differential Revision: D100884981


