### PR TITLE
Fix type-checking errors across torchrec modules

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -198,6 +198,8 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
     Lookup modules for Sequence embeddings (i.e Embeddings)
     """
 
+    _dummy_embs_tensor: torch.Tensor
+
     def __init__(
         self,
         grouped_configs: List[GroupedEmbeddingConfig],
@@ -558,6 +560,8 @@ class GroupedPooledEmbeddingsLookup(
     """
     Lookup modules for Pooled embeddings (i.e EmbeddingBags)
     """
+
+    _dummy_embs_tensor: torch.Tensor
 
     def __init__(
         self,

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -139,6 +139,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
                 kjt_list.append(
                     apply_feature_processors_to_kjt(
                         features,
+                        # pyrefly: ignore[bad-argument-type]
                         self._feature_processors,
                     )
                 )

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -526,6 +526,9 @@ def _construct_jagged_tensors(
                     )
                 )
 
+        assert rw_feature_length_after_bucketize is not None
+        assert rw_unbucketize_tensor is not None
+        assert rw_bucket_mapping_tensor is not None
         return _construct_jagged_tensors_rw(
             input_embeddings,
             embedding_names,
@@ -1112,6 +1115,8 @@ class QuantEmbeddingCollectionSharder(
 
 
 class ShardedQuantEcInputDist(torch.nn.Module):
+    _features_order_tensor: torch.Tensor
+
     """
     This module implements distributed inputs of a ShardedQuantEmbeddingCollection.
 

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -341,6 +341,7 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
                     # pyrefly: ignore[not-callable]
                     input = self.postproc_module(input)
                 else:
+                    # pyrefly: ignore[bad-argument-type, bad-assignment]
                     input = enrich_hstu_features(input, 0.3)
                 return self.dense_forward(input, self.sparse_forward(input))
 

--- a/torchrec/metrics/tests/test_gauc.py
+++ b/torchrec/metrics/tests/test_gauc.py
@@ -32,7 +32,8 @@ class TestGAUCMetric(TestMetric):
         }
 
     @staticmethod
-    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+    # pyrefly: ignore[bad-override]
+    def _compute(states: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         return compute_window_auc(
             states["auc_sum"],
             states["num_samples"],

--- a/torchrec/modules/fp_embedding_modules.py
+++ b/torchrec/modules/fp_embedding_modules.py
@@ -61,6 +61,7 @@ class FeatureProcessorDictWrapper(FeatureProcessorsCollection):
         self._feature_processors = feature_processors
 
     def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        # pyrefly: ignore[bad-argument-type]
         return apply_feature_processors_to_kjt(features, self._feature_processors)
 
 

--- a/torchrec/modules/hash_mc_evictions.py
+++ b/torchrec/modules/hash_mc_evictions.py
@@ -106,7 +106,7 @@ class HashZchPerFeatureTtlScorer(HashZchEvictionScorer):
 
 @torch.fx.wrap
 def get_eviction_scorer(
-    policy_name: str, config: HashZchEvictionConfig
+    policy_name: HashZchEvictionPolicyName, config: HashZchEvictionConfig
 ) -> HashZchEvictionScorer:
     if policy_name == HashZchEvictionPolicyName.SINGLE_TTL_EVICTION:
         return HashZchSingleTtlScorer(config)

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -80,6 +80,9 @@ def _compute_lengths_from_hits(
 
 
 class TrainInputMapper(torch.nn.Module):
+    _zch_size_per_training_rank: torch.Tensor
+    _train_rank_offsets: torch.Tensor
+
     """
     Module used to generate sizes and offsets information corresponding to
     the train ranks for inference inputs. This is due to we currently merge

--- a/torchrec/modules/keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/keyed_jagged_tensor_pool.py
@@ -236,7 +236,9 @@ class KeyedJaggedTensorPool(ObjectPool[KeyedJaggedTensor]):
             self._is_weighted,
             self._values_dtype,
             self._device,
+            # pyrefly: ignore[bad-argument-type]
             self._lookup,
+            # pyrefly: ignore[bad-argument-type]
             self._weights.dtype if self._is_weighted else None,
         )
 

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -1030,6 +1030,9 @@ def _mch_remap(
 
 
 class MCHManagedCollisionModule(ManagedCollisionModule):
+    _mch_sorted_raw_ids: torch.Tensor
+    _mch_remapped_ids_mapping: torch.Tensor
+
     """
     ZCH managed collision module
 

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -322,7 +322,7 @@ def construct_jagged_tensors_inference(
                 embeddings, 0, reverse_indices.to(torch.int32)
             )
         elif remove_padding:
-            embeddings = _slice_1d_tensor(embeddings, 0, lengths.sum().item())
+            embeddings = _slice_1d_tensor(embeddings, 0, int(lengths.sum().item()))
 
         ret: Dict[str, JaggedTensor] = {}
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -122,6 +122,7 @@ class TestJaggedTensor(unittest.TestCase):
 
         # wrong type
         jt = "not a jagged tensor"
+        # pyrefly: ignore[bad-argument-type]
         self.assertFalse(jt_is_equal(jt, jt_1))
 
     def test_str(self) -> None:

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1115,6 +1115,7 @@ class TestKeyedJaggedTensor(unittest.TestCase):
 
         # Non-KeyedJaggedTensor input
         non_kjt_input = "not a KeyedJaggedTensor instance"
+        # pyrefly: ignore[bad-argument-type]
         self.assertFalse(kjt_is_equal(kt, non_kjt_input))
 
     def test_meta_device_compatibility(self) -> None:


### PR DESCRIPTION
Summary:
Fix 15 pyrefly type-checking errors across 13 files in torchrec:

**Genuine type fixes:**
- modules/utils.py: Wrap `lengths.sum().item()` with `int()` to narrow `bool | float | int` to `int`
- distributed/quant_embedding.py: Add `assert is not None` for Optional tensors passed to non-Optional params; add `_features_order_tensor: torch.Tensor` class annotation for buffer
- distributed/embedding_lookup.py: Add `_dummy_embs_tensor: torch.Tensor` class annotations for registered buffers in GroupedEmbeddingsLookup and GroupedPooledEmbeddingsLookup
- modules/mc_modules.py: Add `_mch_sorted_raw_ids` and `_mch_remapped_ids_mapping` class annotations for buffers
- modules/hash_mc_modules.py: Add `_zch_size_per_training_rank` and `_train_rank_offsets` class annotations for buffers
- modules/hash_mc_evictions.py: Change `get_eviction_scorer` param type from `str` to `HashZchEvictionPolicyName`
- fb/modules/binary_stochastic_selector.py: Add `assert self.num_features is not None`
- metrics/tests/test_gauc.py: Fix `_compute` return type to `Dict[str, torch.Tensor]`

**Intentional type suppressions (where type system cannot express intent):**
- modules/fp_embedding_modules.py, distributed/fp_embeddingbag.py: ModuleDict used as dict
- modules/keyed_jagged_tensor_pool.py: Parent class passed where child expected (hack for torch.jit.script)
- sparse/tests/test_jagged_tensor.py, sparse/tests/test_keyed_jagged_tensor.py: Tests deliberately passing wrong types
- distributed/train_pipeline/tests/test_train_pipelines_utils.py: Test uses ModelInput where KeyedJaggedTensor expected

Differential Revision: D101042306


