### PR TITLE
Adding doc to grouped embeddings, and moving class-attributes (#4119)

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -559,6 +559,15 @@ class GroupedPooledEmbeddingsLookup(
 ):
     """
     Lookup modules for Pooled embeddings (i.e EmbeddingBags)
+
+    Args:
+        grouped_configs (List[GroupedEmbeddingConfig]): configs of multiple grouped embeddings
+        device: (Optional[torch.device]): default compute device
+        pg: (Optional[dist.ProcessGroup]): process group for the shard
+        feature_processor: (Optional[BaseGroupedFeatureProcessor]): feature processor on KJT
+        scale_weight_gradients: (bool): whether to scale feature weights by the gradient
+        sharding_type: (Optional[ShardingType]): sharding type for the grouped embeddings
+        env: (Optional[ShardingEnv]): sharding environment for the grouped embeddings
     """
 
     _dummy_embs_tensor: torch.Tensor
@@ -863,7 +872,7 @@ class GroupedPooledEmbeddingsLookup(
 
         return vbe_output, vbe_offsets
 
-    def _apply_fearture_processor_and_gradient_scaling(
+    def _apply_feature_processor_and_gradient_scaling(
         self,
         features: KeyedJaggedTensor,
         config: GroupedEmbeddingConfig,
@@ -907,7 +916,7 @@ class GroupedPooledEmbeddingsLookup(
             features_by_group,
             self._feature_score_auto_collections,
         ):
-            features = self._apply_fearture_processor_and_gradient_scaling(
+            features = self._apply_feature_processor_and_gradient_scaling(
                 features, config, fs_auto_collection
             )
             lookup = emb_op(features)
@@ -945,7 +954,7 @@ class GroupedPooledEmbeddingsLookup(
             features_by_group,
             vbe_offsets,
         ):
-            features = self._apply_fearture_processor_and_gradient_scaling(
+            features = self._apply_feature_processor_and_gradient_scaling(
                 features, config
             )
 

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -198,6 +198,8 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
     Lookup modules for Sequence embeddings (i.e Embeddings)
     """
 
+    _dummy_embs_tensor: torch.Tensor
+
     def __init__(
         self,
         grouped_configs: List[GroupedEmbeddingConfig],
@@ -558,6 +560,8 @@ class GroupedPooledEmbeddingsLookup(
     """
     Lookup modules for Pooled embeddings (i.e EmbeddingBags)
     """
+
+    _dummy_embs_tensor: torch.Tensor
 
     def __init__(
         self,

--- a/torchrec/distributed/fp_embeddingbag.py
+++ b/torchrec/distributed/fp_embeddingbag.py
@@ -139,6 +139,7 @@ class ShardedFeatureProcessedEmbeddingBagCollection(
                 kjt_list.append(
                     apply_feature_processors_to_kjt(
                         features,
+                        # pyrefly: ignore[bad-argument-type]
                         self._feature_processors,
                     )
                 )

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -526,6 +526,9 @@ def _construct_jagged_tensors(
                     )
                 )
 
+        assert rw_feature_length_after_bucketize is not None
+        assert rw_unbucketize_tensor is not None
+        assert rw_bucket_mapping_tensor is not None
         return _construct_jagged_tensors_rw(
             input_embeddings,
             embedding_names,
@@ -1112,6 +1115,8 @@ class QuantEmbeddingCollectionSharder(
 
 
 class ShardedQuantEcInputDist(torch.nn.Module):
+    _features_order_tensor: torch.Tensor
+
     """
     This module implements distributed inputs of a ShardedQuantEmbeddingCollection.
 

--- a/torchrec/distributed/quant_embedding.py
+++ b/torchrec/distributed/quant_embedding.py
@@ -1115,14 +1115,12 @@ class QuantEmbeddingCollectionSharder(
 
 
 class ShardedQuantEcInputDist(torch.nn.Module):
-    _features_order_tensor: torch.Tensor
-
     """
     This module implements distributed inputs of a ShardedQuantEmbeddingCollection.
 
     Args:
         input_feature_names (List[str]): EmbeddingCollection feature names.
-        sharding_type_to_sharding (Dict[
+        sharding_type_device_group_to_sharding (Dict[
             str,
             EmbeddingSharding[
                 InferSequenceShardingContext,
@@ -1137,7 +1135,7 @@ class ShardedQuantEcInputDist(torch.nn.Module):
     Example::
 
         sqec_input_dist = ShardedQuantEcInputDist(
-            sharding_type_to_sharding={
+            sharding_type_device_group_to_sharding={
                 ShardingType.TABLE_WISE: InferTwSequenceEmbeddingSharding(
                     [],
                     ShardingEnv(
@@ -1159,6 +1157,8 @@ class ShardedQuantEcInputDist(torch.nn.Module):
 
         sqec_input_dist(features)
     """
+
+    _features_order_tensor: torch.Tensor
 
     def __init__(
         self,

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -341,6 +341,7 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
                     # pyrefly: ignore[not-callable]
                     input = self.postproc_module(input)
                 else:
+                    # pyrefly: ignore[bad-argument-type, bad-assignment]
                     input = enrich_hstu_features(input, 0.3)
                 return self.dense_forward(input, self.sparse_forward(input))
 

--- a/torchrec/metrics/tests/test_gauc.py
+++ b/torchrec/metrics/tests/test_gauc.py
@@ -32,7 +32,8 @@ class TestGAUCMetric(TestMetric):
         }
 
     @staticmethod
-    def _compute(states: Dict[str, torch.Tensor]) -> torch.Tensor:
+    # pyrefly: ignore[bad-override]
+    def _compute(states: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         return compute_window_auc(
             states["auc_sum"],
             states["num_samples"],

--- a/torchrec/modules/fp_embedding_modules.py
+++ b/torchrec/modules/fp_embedding_modules.py
@@ -61,6 +61,7 @@ class FeatureProcessorDictWrapper(FeatureProcessorsCollection):
         self._feature_processors = feature_processors
 
     def forward(self, features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+        # pyrefly: ignore[bad-argument-type]
         return apply_feature_processors_to_kjt(features, self._feature_processors)
 
 

--- a/torchrec/modules/hash_mc_evictions.py
+++ b/torchrec/modules/hash_mc_evictions.py
@@ -106,7 +106,7 @@ class HashZchPerFeatureTtlScorer(HashZchEvictionScorer):
 
 @torch.fx.wrap
 def get_eviction_scorer(
-    policy_name: str, config: HashZchEvictionConfig
+    policy_name: HashZchEvictionPolicyName, config: HashZchEvictionConfig
 ) -> HashZchEvictionScorer:
     if policy_name == HashZchEvictionPolicyName.SINGLE_TTL_EVICTION:
         return HashZchSingleTtlScorer(config)

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -80,9 +80,6 @@ def _compute_lengths_from_hits(
 
 
 class TrainInputMapper(torch.nn.Module):
-    _zch_size_per_training_rank: torch.Tensor
-    _train_rank_offsets: torch.Tensor
-
     """
     Module used to generate sizes and offsets information corresponding to
     the train ranks for inference inputs. This is due to we currently merge
@@ -103,6 +100,9 @@ class TrainInputMapper(torch.nn.Module):
         mapper = TrainInputMapper(...)
         mapper(values, output_offset)
     """
+
+    _zch_size_per_training_rank: torch.Tensor
+    _train_rank_offsets: torch.Tensor
 
     def __init__(
         self,

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -80,6 +80,9 @@ def _compute_lengths_from_hits(
 
 
 class TrainInputMapper(torch.nn.Module):
+    _zch_size_per_training_rank: torch.Tensor
+    _train_rank_offsets: torch.Tensor
+
     """
     Module used to generate sizes and offsets information corresponding to
     the train ranks for inference inputs. This is due to we currently merge

--- a/torchrec/modules/keyed_jagged_tensor_pool.py
+++ b/torchrec/modules/keyed_jagged_tensor_pool.py
@@ -236,7 +236,9 @@ class KeyedJaggedTensorPool(ObjectPool[KeyedJaggedTensor]):
             self._is_weighted,
             self._values_dtype,
             self._device,
+            # pyrefly: ignore[bad-argument-type]
             self._lookup,
+            # pyrefly: ignore[bad-argument-type]
             self._weights.dtype if self._is_weighted else None,
         )
 

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -1030,6 +1030,9 @@ def _mch_remap(
 
 
 class MCHManagedCollisionModule(ManagedCollisionModule):
+    _mch_sorted_raw_ids: torch.Tensor
+    _mch_remapped_ids_mapping: torch.Tensor
+
     """
     ZCH managed collision module
 

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -322,7 +322,7 @@ def construct_jagged_tensors_inference(
                 embeddings, 0, reverse_indices.to(torch.int32)
             )
         elif remove_padding:
-            embeddings = _slice_1d_tensor(embeddings, 0, lengths.sum().item())
+            embeddings = _slice_1d_tensor(embeddings, 0, int(lengths.sum().item()))
 
         ret: Dict[str, JaggedTensor] = {}
 

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -122,6 +122,7 @@ class TestJaggedTensor(unittest.TestCase):
 
         # wrong type
         jt = "not a jagged tensor"
+        # pyrefly: ignore[bad-argument-type]
         self.assertFalse(jt_is_equal(jt, jt_1))
 
     def test_str(self) -> None:

--- a/torchrec/sparse/tests/test_keyed_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_jagged_tensor.py
@@ -1115,6 +1115,7 @@ class TestKeyedJaggedTensor(unittest.TestCase):
 
         # Non-KeyedJaggedTensor input
         non_kjt_input = "not a KeyedJaggedTensor instance"
+        # pyrefly: ignore[bad-argument-type]
         self.assertFalse(kjt_is_equal(kt, non_kjt_input))
 
     def test_meta_device_compatibility(self) -> None:


### PR DESCRIPTION
Summary:

Adds doc to grouped embeddings, and fix typo in a method.

Fixed typo in another docstring of quant_embeddings.

Moved class attributes to after the doc

Differential Revision: D101062999
