### PR TITLE
Add fused KJT data A2A across EBC modules (#4120)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -10,7 +10,8 @@
 import itertools
 import logging
 import os
-from typing import Callable, Dict, List, Optional
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -583,6 +584,324 @@ class KJTAllToAllTensorsAwaitable(Awaitable[KeyedJaggedTensor]):
             stride_per_rank=self._stride_per_rank,
             stagger=self._stagger,
         )
+
+
+class FusedKJTAllToAllTensorsAwaitable(Awaitable[List[KeyedJaggedTensor]]):
+    """
+    Fuses KJT data A2A calls across multiple EBC modules.
+
+    Instead of issuing N independent dist.all_to_all_single calls (one per label per
+    EBC), this class groups tensors by label across all EBCs, concatenates them into
+    fused buffers, and issues one fused dist.all_to_all_single per unique label. The
+    results are then split back into per-EBC tensors and reconstructed into KJTs.
+
+    This extends the existing splits fusion (FusedKJTListSplitsAwaitable) to the
+    data phase.
+
+    Args:
+        pg: ProcessGroup for AlltoAll communication.
+        entries: List of (KJTSplitsAllToAllMeta, output_splits, stride_per_rank) tuples,
+            one per EBC/sharding-type awaitable to be fused.
+    """
+
+    def __init__(
+        self,
+        pg: dist.ProcessGroup,
+        # Each entry is (KJTSplitsAllToAllMeta, output_splits, stride_per_rank).
+        # Typed as Any to avoid circular import with embedding_sharding.
+        entries: List[Tuple[Any, List[List[int]], Optional[List[int]]]],
+    ) -> None:
+        super().__init__()
+        self._pg = pg
+        self._workers: int = pg.size()
+        self._device: torch.device = (
+            entries[0][0].device if entries else torch.device("cpu")
+        )
+        self._num_entries: int = len(entries)
+        self._cached_kjts: Optional[List[KeyedJaggedTensor]] = None
+
+        # Store per-entry metadata for reconstruction
+        self._per_entry_meta: List[
+            Tuple[
+                KeyedJaggedTensor,  # input KJT
+                List[int],  # splits
+                List[str],  # labels
+                List[str],  # keys
+                int,  # stagger
+                Dict[str, List[int]],  # input_splits by label
+                Dict[str, List[int]],  # output_splits by label
+                Optional[torch.Tensor],  # recat
+                Optional[List[int]],  # stride_per_rank
+            ]
+        ] = []
+
+        for meta, output_splits, stride_per_rank in entries:
+            if stride_per_rank is not None:
+                _check_int_overflow(
+                    "FusedKJTAllToAllTensorsAwaitable",
+                    stride_per_rank,
+                    "stride_per_rank (BEFORE _get_recat)",
+                    rank=pg.rank(),
+                    world_size=pg.size(),
+                    splits=meta.splits,
+                    local_split=meta.splits[pg.rank()],
+                    keys=meta.keys,
+                )
+
+            input_splits_dict: Dict[str, List[int]] = dict(
+                zip(meta.labels, meta.input_splits)
+            )
+            output_splits_dict: Dict[str, List[int]] = dict(
+                zip(meta.labels, output_splits)
+            )
+            recat = _get_recat(
+                local_split=meta.splits[pg.rank()],
+                num_splits=len(meta.splits),
+                stagger=meta.stagger,
+                device=meta.device,
+                batch_size_per_rank=stride_per_rank,
+            )
+            self._per_entry_meta.append(
+                (
+                    meta._input,
+                    meta.splits,
+                    meta.labels,
+                    meta.keys,
+                    meta.stagger,
+                    input_splits_dict,
+                    output_splits_dict,
+                    recat,
+                    stride_per_rank,
+                )
+            )
+
+        if self._workers == 1:
+            return
+
+        # Group tensors by label across all entries
+        # label -> [(entry_idx, input_tensor, input_split, output_split)]
+        label_groups: Dict[
+            str,
+            List[Tuple[int, torch.Tensor, List[int], List[int]]],
+        ] = defaultdict(list)
+
+        for entry_idx, (meta, output_splits, _stride_per_rank) in enumerate(entries):
+            for label, input_tensor, input_split, output_split in zip(
+                meta.labels,
+                meta.input_tensors,
+                meta.input_splits,
+                output_splits,
+            ):
+                label_groups[label].append(
+                    (entry_idx, input_tensor, input_split, output_split)
+                )
+
+        # For each label, reorder + concat + issue fused A2A
+        world_size = self._workers
+        self._fused_labels: List[str] = list(label_groups.keys())
+        self._fused_output_tensors: List[torch.Tensor] = []
+        self._fused_awaitables: List[dist.Work] = []
+        # Per label: list of (entry_idx, per_rank_output_sizes) for unfusing
+        self._unfuse_meta: List[List[Tuple[int, List[int]]]] = []
+
+        for label in self._fused_labels:
+            group = label_groups[label]
+            n_fused = len(group)
+
+            # Build fused input: interleave per-rank chunks across entries
+            # Input layout: [entry0_rank0, entry1_rank0, ..., entry0_rank1, ...]
+            chunks_per_rank: List[List[torch.Tensor]] = [[] for _ in range(world_size)]
+            fused_input_splits: List[int] = [0] * world_size
+            fused_output_splits: List[int] = [0] * world_size
+            unfuse_info: List[Tuple[int, List[int]]] = []
+
+            for entry_idx, input_tensor, in_split, out_split in group:
+                offset = 0
+                per_rank_out: List[int] = []
+                for rank in range(world_size):
+                    size = in_split[rank]
+                    chunks_per_rank[rank].append(input_tensor[offset : offset + size])
+                    offset += size
+                    fused_input_splits[rank] += size
+                    fused_output_splits[rank] += out_split[rank]
+                    per_rank_out.append(out_split[rank])
+                unfuse_info.append((entry_idx, per_rank_out))
+
+            self._unfuse_meta.append(unfuse_info)
+
+            # Flatten chunks in rank order
+            flat_chunks: List[torch.Tensor] = []
+            for rank in range(world_size):
+                flat_chunks.extend(chunks_per_rank[rank])
+
+            if flat_chunks:
+                fused_input = torch.cat(flat_chunks)
+            else:
+                fused_input = torch.empty(0, device=self._device)
+
+            # Determine output tensor shape
+            sample_tensor = group[0][1]
+            if sample_tensor.dim() == 2:
+                output_size = [sum(fused_output_splits), sample_tensor.size(1)]
+            else:
+                output_size = [sum(fused_output_splits)]
+
+            fused_output = torch.empty(
+                output_size, device=self._device, dtype=sample_tensor.dtype
+            )
+
+            with record_function(f"## all2all_data:kjt_fused {label} n={n_fused} ##"):
+                awaitable = dist.all_to_all_single(
+                    output=fused_output,
+                    input=fused_input,
+                    output_split_sizes=fused_output_splits,
+                    input_split_sizes=fused_input_splits,
+                    group=self._pg,
+                    async_op=True,
+                )
+
+            self._fused_output_tensors.append(fused_output)
+            self._fused_awaitables.append(awaitable)
+
+    def _wait_impl(self) -> List[KeyedJaggedTensor]:
+        if self._workers == 1:
+            kjts: List[KeyedJaggedTensor] = []
+            for (
+                input_kjt,
+                _splits,
+                _labels,
+                _keys,
+                _stagger,
+                _in_splits,
+                _out_splits,
+                _recat,
+                _stride_per_rank,
+            ) in self._per_entry_meta:
+                input_kjt.sync()
+                kjts.append(input_kjt)
+            return kjts
+
+        # Wait on all fused A2A calls
+        for awaitable in self._fused_awaitables:
+            awaitable.wait()
+
+        # Unfuse: split fused outputs back to per-entry tensors
+        # per_entry_tensors[entry_idx][label] = list of per-rank tensor chunks
+        per_entry_tensors: Dict[int, Dict[str, List[torch.Tensor]]] = defaultdict(dict)
+        world_size = self._workers
+
+        for label_idx, label in enumerate(self._fused_labels):
+            fused_output = self._fused_output_tensors[label_idx]
+            unfuse_info = self._unfuse_meta[label_idx]
+            n_entries = len(unfuse_info)
+
+            # Split fused output by rank first
+            fused_output_splits = [
+                sum(info[1][rank] for info in unfuse_info) for rank in range(world_size)
+            ]
+            rank_chunks = torch.split(fused_output, fused_output_splits)
+
+            # Within each rank's chunk, split by entry
+            for rank in range(world_size):
+                rank_chunk = rank_chunks[rank]
+                entry_sizes = [info[1][rank] for info in unfuse_info]
+                if sum(entry_sizes) == 0:
+                    entry_chunks = [rank_chunk[:0] for _ in range(n_entries)]
+                else:
+                    entry_chunks = torch.split(rank_chunk, entry_sizes)
+
+                for i, (entry_idx, _per_rank_out) in enumerate(unfuse_info):
+                    if label not in per_entry_tensors[entry_idx]:
+                        per_entry_tensors[entry_idx][label] = []
+                    per_entry_tensors[entry_idx][label].append(entry_chunks[i])
+
+        # Reconstruct per-entry KJTs
+        # For each entry, concatenate the per-rank pieces for each label,
+        # then call dist_init
+        kjts: List[KeyedJaggedTensor] = []
+        for entry_idx, (
+            input_kjt,
+            _splits,
+            labels,
+            keys,
+            stagger,
+            _in_splits,
+            _out_splits,
+            recat,
+            stride_per_rank,
+        ) in enumerate(self._per_entry_meta):
+            output_tensors: List[torch.Tensor] = []
+            for label in labels:
+                rank_pieces = per_entry_tensors[entry_idx][label]
+                output_tensors.append(torch.cat(rank_pieces))
+
+            kjt = type(input_kjt).dist_init(
+                keys=keys,
+                tensors=output_tensors,
+                variable_stride_per_key=input_kjt.variable_stride_per_key(),
+                num_workers=self._workers,
+                recat=recat,
+                stride_per_rank=stride_per_rank,
+                stagger=stagger,
+            )
+            kjts.append(kjt)
+
+        return kjts
+
+    def get_entry_meta(self, entry_idx: int) -> Tuple[
+        Dict[str, List[int]],  # input_splits
+        Dict[str, List[int]],  # output_splits
+        Optional[torch.Tensor],  # recat
+        Optional[List[int]],  # stride_per_rank
+    ]:
+        """Return per-EBC metadata for the proxy awaitable."""
+        (
+            _input_kjt,
+            _splits,
+            _labels,
+            _keys,
+            _stagger,
+            input_splits,
+            output_splits,
+            recat,
+            stride_per_rank,
+        ) = self._per_entry_meta[entry_idx]
+        return input_splits, output_splits, recat, stride_per_rank
+
+
+class _FusedKJTDataA2AProxyAwaitable(Awaitable[KeyedJaggedTensor]):
+    """
+    Proxy awaitable that references a shared FusedKJTAllToAllTensorsAwaitable.
+
+    Exposes the same per-EBC attributes (_input_splits, _output_splits, _recat,
+    _stride_per_rank) that _set_sharding_context_intra_a2a expects from
+    KJTAllToAllTensorsAwaitable.
+    """
+
+    def __init__(
+        self,
+        fused: FusedKJTAllToAllTensorsAwaitable,
+        entry_idx: int,
+    ) -> None:
+        super().__init__()
+        self._fused = fused
+        self._entry_idx = entry_idx
+
+        # Expose per-EBC attributes for _set_sharding_context_intra_a2a
+        (
+            self._input_splits,
+            self._output_splits,
+            self._recat,
+            self._stride_per_rank,
+        ) = fused.get_entry_meta(entry_idx)
+
+    def _wait_impl(self) -> KeyedJaggedTensor:
+        # All proxies share the same fused awaitable. The first proxy to call
+        # _wait_impl triggers the fused wait; subsequent proxies get cached results.
+        # Use _wait_impl() directly to bypass callbacks and Awaitable.wait() overhead.
+        if self._fused._cached_kjts is None:
+            self._fused._cached_kjts = self._fused._wait_impl()
+        return self._fused._cached_kjts[self._entry_idx]
 
 
 class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -17,9 +17,12 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 import torch
 from torch import distributed as dist, nn
 from torchrec.distributed.dist_data import (
+    _FusedKJTDataA2AProxyAwaitable,
+    FusedKJTAllToAllTensorsAwaitable,
     KJTAllToAllTensorsAwaitable,
     SplitsAllToAllAwaitable,
 )
+from torchrec.pt2.checks import is_torchdynamo_compiling
 
 # This is required to support older torch package exports that do not contain
 # _check_int_overflow. During repackaging the
@@ -710,7 +713,10 @@ def _set_sharding_context_intra_a2a(
         tensors_awaitables,
         getattr(ctx, "sharding_contexts", []),
     ):
-        if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
+        if isinstance(
+            awaitable,
+            (KJTAllToAllTensorsAwaitable, _FusedKJTDataA2AProxyAwaitable),
+        ):
             if hasattr(sharding_context, "input_splits"):
                 sharding_context.input_splits = awaitable._input_splits["values"]
             if hasattr(sharding_context, "output_splits"):
@@ -922,6 +928,17 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
             if splits_tensors and pg is not None
             else None
         )
+        self._pg = pg
+
+        # Gate fused data A2A in __init__ (eager mode) to avoid dynamo graph
+        # breaks. Stored as instance var so _wait_impl can use it.
+        self._fuse_data_a2a: bool = False
+        try:
+            self._fuse_data_a2a = torch._utils_internal.justknobs_check(
+                "pytorch/torchrec:enable_fused_kjt_data_a2a"
+            )
+        except Exception:
+            pass
 
     def _wait_impl(self) -> List[KJTListAwaitable]:
         if self._splits_awaitable:
@@ -929,7 +946,29 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
             splits_per_awaitable = _split(splits_list, self._lengths)
         else:
             splits_per_awaitable = [[] for _ in range(len(self._lengths))]
-        tensors_awaitables = []
+
+        if (
+            self._fuse_data_a2a
+            and self._pg is not None
+            and not is_torchdynamo_compiling()
+        ):
+            tensors_awaitables = self._fused_data_a2a_path(splits_per_awaitable)
+        else:
+            tensors_awaitables = self._unfused_data_a2a_path(splits_per_awaitable)
+
+        output = []
+        awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
+        for awaitables, ctx in zip(awaitables_per_output, self._contexts):
+            _set_sharding_context_intra_a2a(awaitables, ctx)
+            output.append(KJTListAwaitable(awaitables, ctx))
+        return output
+
+    def _unfused_data_a2a_path(
+        self,
+        splits_per_awaitable: List[List[List[int]]],
+    ) -> List[Awaitable[KeyedJaggedTensor]]:
+        """Existing unfused code path — one KJTAllToAllTensorsAwaitable per entry."""
+        tensors_awaitables: List[Awaitable[KeyedJaggedTensor]] = []
         for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
             if not splits:  # NoWait
                 assert isinstance(awaitable, Awaitable)
@@ -943,8 +982,6 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                 output_splits = splits[:-1]
                 stride_per_rank = splits[-1]
 
-            # Log corrupted stride_per_rank at the point where splits
-            # are unpacked.
             if stride_per_rank is not None:
                 _check_int_overflow(
                     "ListOfKJTListSplitsAwaitable",
@@ -969,12 +1006,63 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
                     stride_per_rank=stride_per_rank,
                 )
             )
-        output = []
-        awaitables_per_output = _split(tensors_awaitables, self._output_lengths)
-        for awaitables, ctx in zip(awaitables_per_output, self._contexts):
-            _set_sharding_context_intra_a2a(awaitables, ctx)
-            output.append(KJTListAwaitable(awaitables, ctx))
-        return output
+        return tensors_awaitables
+
+    def _fused_data_a2a_path(
+        self,
+        splits_per_awaitable: List[List[List[int]]],
+    ) -> List[Awaitable[KeyedJaggedTensor]]:
+        """Fused code path — coalesces data A2A across all entries."""
+        # Resolve output_splits and stride_per_rank for each awaitable
+        resolved: List[
+            Optional[Tuple[KJTSplitsAllToAllMeta, List[List[int]], Optional[List[int]]]]
+        ] = []
+        nowait_results: List[Awaitable[KeyedJaggedTensor]] = []
+
+        for splits, awaitable in zip(splits_per_awaitable, self._awaitables):
+            if not splits:  # NoWait
+                assert isinstance(awaitable, Awaitable)
+                nowait_results.append(awaitable.wait())
+                resolved.append(None)
+            else:
+                assert isinstance(awaitable, KJTSplitsAllToAllMeta)
+                if awaitable._input.variable_stride_per_key():
+                    output_splits = splits
+                    stride_per_rank = None
+                else:
+                    output_splits = splits[:-1]
+                    stride_per_rank = splits[-1]
+                resolved.append((awaitable, output_splits, stride_per_rank))
+
+        # Collect fuseable entries (skip NoWait)
+        fuseable = [r for r in resolved if r is not None]
+
+        # Need at least 2 entries to benefit from fusion
+        if len(fuseable) < 2:
+            # Fall back to unfused path
+            return self._unfused_data_a2a_path(splits_per_awaitable)
+
+        assert self._pg is not None
+        fused = FusedKJTAllToAllTensorsAwaitable(
+            pg=self._pg,
+            entries=fuseable,
+        )
+
+        # Build tensors_awaitables list preserving original order
+        tensors_awaitables: List[Awaitable[KeyedJaggedTensor]] = []
+        fused_idx = 0
+        nowait_idx = 0
+        for entry in resolved:
+            if entry is None:
+                tensors_awaitables.append(nowait_results[nowait_idx])
+                nowait_idx += 1
+            else:
+                tensors_awaitables.append(
+                    _FusedKJTDataA2AProxyAwaitable(fused, fused_idx)
+                )
+                fused_idx += 1
+
+        return tensors_awaitables
 
 
 class ListOfKJTListAwaitable(Awaitable[ListOfKJTList]):

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -10,14 +10,16 @@
 import itertools
 import random
 import unittest
-from typing import Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import hypothesis.strategies as st
 import torch
 import torch.distributed as dist
 from hypothesis import given, settings
 from torchrec.distributed.dist_data import (
+    _FusedKJTDataA2AProxyAwaitable,
     _get_recat,
+    FusedKJTAllToAllTensorsAwaitable,
     JaggedTensorAllToAll,
     KJTAllToAll,
     KJTAllToAllSplitsAwaitable,
@@ -27,6 +29,7 @@ from torchrec.distributed.dist_data import (
     SequenceEmbeddingsAllToAll,
     VariableBatchPooledEmbeddingsAllToAll,
 )
+from torchrec.distributed.embedding_sharding import KJTSplitsAllToAllMeta
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
     get_qcomm_codecs,
@@ -1549,3 +1552,281 @@ class GetRecatOverflowTest(unittest.TestCase):
         )
         self.assertIsNotNone(result)
         self.assertEqual(result.dtype, torch.int32)
+
+
+def _run_fused_kjt_a2a_test(
+    rank: int,
+    world_size: int,
+    backend: str,
+    num_entries: int,
+    is_weighted: bool,
+) -> None:
+    """Test function run in each process for FusedKJTAllToAllTensorsAwaitable."""
+    dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+    device = torch.device(f"cuda:{rank}") if backend == "nccl" else torch.device("cpu")
+    pg = dist.group.WORLD
+    assert pg is not None
+
+    B = 2  # batch size per rank
+    entries_data: List[
+        Tuple[KJTSplitsAllToAllMeta, List[List[int]], Optional[List[int]]]
+    ] = []
+    for entry_idx in range(num_entries):
+        # Use even feature counts so splits are uniform across ranks.
+        # This ensures output_splits == input_splits (symmetric A2A).
+        n_features = (2 + entry_idx) * world_size
+        keys = [f"E{entry_idx}_F{f}" for f in range(n_features)]
+        features_per_rank = n_features // world_size
+        splits = [features_per_rank] * world_size
+
+        # All ranks produce identical data for ALL features (B samples each).
+        # With uniform splits and identical data, output_splits == input_splits.
+        lengths = torch.ones(n_features * B, dtype=torch.int32, device=device)
+        total_vals = int(lengths.sum().item())
+        values = torch.arange(total_vals, dtype=torch.int64, device=device)
+        weights = torch.ones(total_vals, device=device) if is_weighted else None
+
+        kjt_kwargs: Dict[str, Any] = {
+            "keys": keys,
+            "values": values,
+            "lengths": lengths,
+        }
+        if weights is not None:
+            kjt_kwargs["weights"] = weights
+        kjt = KeyedJaggedTensor(**kjt_kwargs)
+
+        labels = ["lengths", "values"]
+        input_tensors_list: List[torch.Tensor] = [lengths, values]
+        if weights is not None:
+            labels.append("weights")
+            input_tensors_list.append(weights)
+
+        # With uniform splits: each rank sends features_per_rank * B elements
+        # to each other rank, and receives the same amount.
+        input_splits: List[List[int]] = []
+        for _label in labels:
+            per_rank = [features_per_rank * B] * world_size
+            input_splits.append(per_rank)
+
+        # Uniform splits => output_splits == input_splits
+        output_splits = input_splits
+        stride_per_rank = [B] * world_size
+
+        splits_tensors = [torch.tensor(s, device=device) for s in input_splits]
+        splits_tensors.append(torch.tensor(stride_per_rank, device=device))
+
+        # Output keys: features this rank will own after A2A.
+        # With uniform splits, rank r owns features [r*fpr, (r+1)*fpr).
+        output_keys = keys[rank * features_per_rank : (rank + 1) * features_per_rank]
+
+        meta = KJTSplitsAllToAllMeta(
+            pg=pg,
+            _input=kjt,
+            splits=splits,
+            splits_tensors=splits_tensors,
+            input_splits=input_splits,
+            input_tensors=input_tensors_list,
+            labels=labels,
+            keys=output_keys,
+            device=device,
+            stagger=1,
+        )
+        entries_data.append((meta, output_splits, stride_per_rank))
+
+    # Run FUSED path
+    fused = FusedKJTAllToAllTensorsAwaitable(pg=pg, entries=entries_data)
+    fused_kjts = fused._wait_impl()
+
+    # Verify fused output is well-formed and values are correct
+    assert (
+        len(fused_kjts) == num_entries
+    ), f"Expected {num_entries} KJTs, got {len(fused_kjts)}"
+    for i, kjt in enumerate(fused_kjts):
+        assert len(kjt.keys()) > 0, f"Entry {i} has no keys"
+        assert kjt.lengths().sum().item() == kjt.values().numel(), (
+            f"Entry {i} lengths sum ({kjt.lengths().sum().item()}) != "
+            f"values count ({kjt.values().numel()})"
+        )
+        if is_weighted:
+            assert (
+                kjt.weights_or_none() is not None
+            ), f"Entry {i} expected weights but got None"
+            assert kjt.weights().numel() == kjt.values().numel(), (
+                f"Entry {i} weights count ({kjt.weights().numel()}) != "
+                f"values count ({kjt.values().numel()})"
+            )
+
+        # Value-level check: with uniform splits and identical data on all
+        # ranks, the A2A output lengths should all be 1 (since input lengths
+        # are all 1) and values should be a contiguous range.
+        torch.testing.assert_close(
+            kjt.lengths().cpu(),
+            torch.ones(kjt.lengths().numel(), dtype=torch.int32),
+            msg=f"Entry {i} lengths values mismatch",
+        )
+        # Total values count should equal features_per_rank * B * world_size
+        n_features = (2 + i) * world_size
+        features_per_rank = n_features // world_size
+        expected_vals = features_per_rank * B * world_size
+        assert (
+            kjt.values().numel() == expected_vals
+        ), f"Entry {i} expected {expected_vals} values, got {kjt.values().numel()}"
+
+    dist.destroy_process_group()
+
+
+def _run_fused_proxy_attributes_test(
+    rank: int,
+    world_size: int,
+    backend: str,
+) -> None:
+    """Test that proxy awaitable attributes match expected values."""
+    dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+    device = torch.device(f"cuda:{rank}") if backend == "nccl" else torch.device("cpu")
+    pg = dist.group.WORLD
+    assert pg is not None
+
+    B = 2
+    entries_data: List[
+        Tuple[KJTSplitsAllToAllMeta, List[List[int]], Optional[List[int]]]
+    ] = []
+    for entry_idx in range(2):
+        # Uniform splits so output_splits == input_splits
+        n_features = (2 + entry_idx) * world_size
+        keys = [f"E{entry_idx}_F{f}" for f in range(n_features)]
+        features_per_rank = n_features // world_size
+        splits = [features_per_rank] * world_size
+
+        lengths = torch.ones(n_features * B, dtype=torch.int32, device=device)
+        total_vals = int(lengths.sum().item())
+        values = torch.arange(total_vals, dtype=torch.int64, device=device)
+
+        kjt = KeyedJaggedTensor(keys=keys, values=values, lengths=lengths)
+
+        labels = ["lengths", "values"]
+        input_tensors_list = [lengths, values]
+        input_splits = [
+            [features_per_rank * B] * world_size,
+            [features_per_rank * B] * world_size,
+        ]
+        output_splits = input_splits
+        stride_per_rank = [B] * world_size
+
+        splits_tensors = [torch.tensor(s, device=device) for s in input_splits]
+        splits_tensors.append(torch.tensor(stride_per_rank, device=device))
+
+        output_keys = keys[rank * features_per_rank : (rank + 1) * features_per_rank]
+
+        meta = KJTSplitsAllToAllMeta(
+            pg=pg,
+            _input=kjt,
+            splits=splits,
+            splits_tensors=splits_tensors,
+            input_splits=input_splits,
+            input_tensors=input_tensors_list,
+            labels=labels,
+            keys=output_keys,
+            device=device,
+            stagger=1,
+        )
+        entries_data.append((meta, output_splits, stride_per_rank))
+
+    # Build fused + proxies (no wait needed — just check attributes)
+    fused = FusedKJTAllToAllTensorsAwaitable(pg=pg, entries=entries_data)
+
+    for entry_idx, (meta, output_splits, stride_per_rank) in enumerate(entries_data):
+        proxy = _FusedKJTDataA2AProxyAwaitable(fused, entry_idx)
+
+        expected_input_splits = dict(zip(meta.labels, meta.input_splits))
+        expected_output_splits = dict(zip(meta.labels, output_splits))
+
+        assert (
+            proxy._input_splits == expected_input_splits
+        ), f"Entry {entry_idx} input_splits mismatch"
+        assert (
+            proxy._output_splits == expected_output_splits
+        ), f"Entry {entry_idx} output_splits mismatch"
+        assert (
+            proxy._stride_per_rank == stride_per_rank
+        ), f"Entry {entry_idx} stride_per_rank mismatch"
+        local_split = meta.splits[pg.rank()]
+        if local_split > 0:
+            assert proxy._recat is not None
+        else:
+            assert proxy._recat is None
+
+    # Wait to complete the A2A (required so NCCL doesn't hang on cleanup)
+    fused._wait_impl()
+
+    dist.destroy_process_group()
+
+
+class FusedKJTAllToAllTensorsTest(MultiProcessTestBase):
+    def test_fused_2_ebcs_same_labels_gloo(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fused_kjt_a2a_test,
+            world_size=2,
+            num_entries=2,
+            is_weighted=False,
+            backend="gloo",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_fused_2_ebcs_same_labels(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fused_kjt_a2a_test,
+            world_size=2,
+            num_entries=2,
+            is_weighted=False,
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_fused_2_ebcs_weighted(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fused_kjt_a2a_test,
+            world_size=2,
+            num_entries=2,
+            is_weighted=True,
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_fused_4_ebcs(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fused_kjt_a2a_test,
+            world_size=2,
+            num_entries=4,
+            is_weighted=False,
+            backend="nccl",
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() <= 1,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    def test_fused_proxy_attributes_match_unfused(self) -> None:
+        self._run_multi_process_test(
+            callable=_run_fused_proxy_attributes_test,
+            world_size=2,
+            backend="nccl",
+        )
+
+    def test_fused_single_worker(self) -> None:
+        """Test that single-worker (world_size=1) short-circuits correctly."""
+        self._run_multi_process_test(
+            callable=_run_fused_kjt_a2a_test,
+            world_size=1,
+            num_entries=2,
+            is_weighted=False,
+            backend="gloo",
+        )

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -2505,3 +2505,79 @@ class TrainPipelineSparseDistCompAutogradTest(TrainPipelineSparseDistTest):
         execute_all_batches: bool,
     ) -> None:
         super().test_equal_to_non_pipelined()
+
+
+class FusedKJTDataA2AIntegrationTest(TrainPipelineSparseDistTestBase):
+    """Integration tests for fused KJT data A2A through the full pipeline."""
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_fused_data_a2a_pipeline_parity(self) -> None:
+        """Verify fused data A2A produces identical results to unfused through
+        the full TrainPipelineSparseDist pipeline."""
+        data = self._generate_data(num_batches=7, batch_size=32)
+        model = self._setup_model()
+
+        sharding_type = ShardingType.TABLE_WISE.value
+        kernel_type = EmbeddingComputeKernel.FUSED.value
+
+        # Baseline: unfused (feature gate OFF)
+        sharded_model_baseline, optim_baseline = (
+            self._generate_sharded_model_and_optimizer(
+                model, sharding_type, kernel_type
+            )
+        )
+
+        # Experiment: fused (feature gate ON)
+        sharded_model_fused, optim_fused = self._generate_sharded_model_and_optimizer(
+            model, sharding_type, kernel_type
+        )
+        copy_state_dict(
+            sharded_model_baseline.state_dict(),
+            sharded_model_fused.state_dict(),
+        )
+
+        # Baseline pipeline (unfused)
+        pipeline_baseline = self.pipeline_class(
+            model=sharded_model_baseline,
+            optimizer=optim_baseline,
+            device=self.device,
+        )
+
+        # Fused pipeline — mock feature gate ON at the import site in
+        # embedding_sharding where FusedKJTListSplitsAwaitable reads it.
+        # Note: with world_size=1 the fused A2A short-circuits (workers==1),
+        # so this tests that the gating and pipeline integration don't crash.
+        # Value-level parity of the fused reorder logic is covered by the
+        # multi-rank unit tests in test_dist_data.py.
+        with patch(
+            "torchrec.distributed.embedding_sharding.torch._utils_internal.justknobs_check",
+            side_effect=lambda name: name
+            == "pytorch/torchrec:enable_fused_kjt_data_a2a",
+        ):
+            pipeline_fused = self.pipeline_class(
+                model=sharded_model_fused,
+                optimizer=optim_fused,
+                device=self.device,
+            )
+
+        dataloader_baseline = iter(data)
+        dataloader_fused = iter(data)
+
+        for _batch in data[:-2]:
+            pred_baseline = pipeline_baseline.progress(dataloader_baseline)
+            with patch(
+                "torchrec.distributed.embedding_sharding.torch._utils_internal.justknobs_check",
+                side_effect=lambda name: name
+                == "pytorch/torchrec:enable_fused_kjt_data_a2a",
+            ):
+                pred_fused = pipeline_fused.progress(dataloader_fused)
+
+            if pred_baseline is not None and pred_fused is not None:
+                torch.testing.assert_close(
+                    pred_baseline,
+                    pred_fused,
+                    msg="Fused vs unfused pipeline output mismatch",
+                )


### PR DESCRIPTION
Summary:

Extends the existing splits fusion (`FusedKJTListSplitsAwaitable`) to the data phase of KJT all-to-all. Instead of issuing N independent `dist.all_to_all_single` calls (one per label per EBC), this coalesces same-label tensors across all EBCs into fused buffers and issues one call per unique label. For a model with 4 EBCs, this reduces input dist data A2A from ~10 to 2-3 calls per step.

Gated behind JustKnob `pytorch/torchrec:enable_fused_kjt_data_a2a` (off by default). Disabled under `torch.compile` to avoid graph breaks.

Differential Revision: D101021016


