### PR TITLE
Fix SSD kernel tests after SSD_CAP=0 default change

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -388,6 +388,7 @@ class ModelParallelSingleRankBase(unittest.TestCase):
                 local_world_size=trec_dist.comm.get_local_size(env.world_size),
                 world_size=env.world_size,
                 compute_device=self.device.type,
+                ssd_cap=2 * 1024**4,
             ),
             constraints=constraints,
         )

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -886,6 +886,7 @@ def sharding_single_rank_test_single_process(
             compute_device=device.type,
             local_world_size=node_group_size if node_group_size else local_size,
             pod_size=pod_size,
+            ssd_cap=2 * 1024**4,
         ),
         constraints=constraints,
     )
@@ -898,6 +899,7 @@ def sharding_single_rank_test_single_process(
                     world_size=config.sharding_group_size,
                     compute_device=device.type,
                     local_world_size=config.node_group_size,
+                    ssd_cap=2 * 1024**4,
                 ),
                 constraints=constraints,
             )


### PR DESCRIPTION
Summary:
D98990460 changed the default `SSD_CAP` in `torchrec/distributed/planner/constants.py` to 0 (disable SSD by default), but did not update unit tests that depend on SSD storage being available. Tests that constrain compute_kernels to `key_value` (SSD-backed) now fail at planner enumeration with:

```
RuntimeError: No available sharding type and compute kernel combination
after applying user provided constraints for table_X
```

This diff fixes the broken tests by explicitly setting `ssd_cap=2 * 1024**4` (2 TiB) on the `Topology()` instances used by SSD test paths. Three sites updated:

- `test_model_parallel_base.py:391` — `ModelParallelSingleRankBase._generate_dmps_and_batch`
- `test_sharding.py:889` — `sharding_single_rank_test_single_process` (main planner)
- `test_sharding.py:902` — `sharding_single_rank_test_single_process` (submodule planner for 2D parallelism)

Differential Revision: D101197505


