### PR TITLE
Scale batch_outputs by min(1, input_length)

### DIFF
--- a/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
+++ b/torchrec/distributed/planner/estimator/tests/test_estimator_types.py
@@ -18,6 +18,7 @@ Tests the core dataclasses and config classes:
 """
 
 import unittest
+from unittest.mock import patch
 
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.estimator.annotations import (
@@ -436,6 +437,87 @@ class ShardPerfContextTest(unittest.TestCase):
             is_pooled=False,
         )
         self.assertEqual(ctx.batch_outputs, ctx.batch_inputs)
+
+    def test_batch_outputs_sparse_vbe_with_scaling(self) -> None:
+        """Test batch_outputs is scaled by min(1, input_length) for sparse VBE.
+
+        When input_length < 1.0, batch_outputs should be proportionally
+        smaller. Without this fix, all VBE features had the same
+        batch_outputs regardless of sparsity, causing up to 59,000x
+        overestimated comms volume for pooling_factor=0.001.
+        """
+        with patch("torch._utils_internal.justknobs_check", return_value=True):
+            ctx = ShardPerfContext(
+                input_lengths=[0.1, 10.0],
+                num_poolings=[1.0, 1.0],
+                batch_sizes=[100, 100],
+                is_pooled=True,
+            )
+            # min(1,0.1)*1*100 + min(1,10)*1*100 = 10 + 100 = 110
+            self.assertAlmostEqual(ctx.batch_outputs, 110.0)
+
+    def test_batch_outputs_sparse_vbe_without_scaling_overestimates(self) -> None:
+        """Test that without scaling, sparse VBE batch_outputs is overestimated.
+
+        With JK disabled (old behavior), batch_outputs ignores input_length,
+        treating sparse features the same as dense ones.
+        """
+        with patch("torch._utils_internal.justknobs_check", return_value=False):
+            ctx = ShardPerfContext(
+                input_lengths=[0.1, 10.0],
+                num_poolings=[1.0, 1.0],
+                batch_sizes=[100, 100],
+                is_pooled=True,
+            )
+            # Without scaling (old bug): 1*100 + 1*100 = 200
+            self.assertAlmostEqual(ctx.batch_outputs, 200.0)
+
+    def test_batch_outputs_extremely_sparse_vbe(self) -> None:
+        """Test batch_outputs with extremely sparse VBE (pooling_factor=0.001).
+
+        Demonstrates the production scenario from job aps-f1051869957 where
+        VBE tables with pooling_factor=0.001 had massively overestimated
+        comms volume.
+        """
+        with patch("torch._utils_internal.justknobs_check", return_value=True):
+            ctx = ShardPerfContext(
+                input_lengths=[0.001],
+                num_poolings=[1.0],
+                batch_sizes=[1000],
+                is_pooled=True,
+            )
+            # With scaling: min(1, 0.001)*1*1000 = 1.0
+            self.assertAlmostEqual(ctx.batch_outputs, 1.0)
+
+        with patch("torch._utils_internal.justknobs_check", return_value=False):
+            ctx2 = ShardPerfContext(
+                input_lengths=[0.001],
+                num_poolings=[1.0],
+                batch_sizes=[1000],
+                is_pooled=True,
+            )
+            # Without scaling: 1*1000 = 1000.0 (1000x overestimate!)
+            self.assertAlmostEqual(ctx2.batch_outputs, 1000.0)
+
+    def test_batch_outputs_dense_features_unaffected(self) -> None:
+        """Test that dense features (input_length >= 1) are unaffected by scaling."""
+        with patch("torch._utils_internal.justknobs_check", return_value=True):
+            ctx_scaled = ShardPerfContext(
+                input_lengths=[10.0, 20.0],
+                num_poolings=[1.0, 2.0],
+                batch_sizes=[32, 32],
+                is_pooled=True,
+            )
+        with patch("torch._utils_internal.justknobs_check", return_value=False):
+            ctx_unscaled = ShardPerfContext(
+                input_lengths=[10.0, 20.0],
+                num_poolings=[1.0, 2.0],
+                batch_sizes=[32, 32],
+                is_pooled=True,
+            )
+        # Both should be 96.0: min(1,10)*1*32 + min(1,20)*2*32 = 32+64 = 96
+        self.assertEqual(ctx_scaled.batch_outputs, 96.0)
+        self.assertEqual(ctx_unscaled.batch_outputs, 96.0)
 
     def test_is_uvm_caching_property(self) -> None:
         """Test is_uvm_caching computed property."""

--- a/torchrec/distributed/planner/estimator/types.py
+++ b/torchrec/distributed/planner/estimator/types.py
@@ -22,6 +22,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
+import torch
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
     BIGINT_DTYPE,
@@ -817,10 +818,22 @@ class ShardPerfContext:
         """
         Raw batch outputs.
 
-        For pooled: sum of num_poolings * batch_sizes.
+        For pooled: sum of num_poolings * batch_sizes, optionally scaled by
+        min(1, input_length) to account for sparse VBE features where
+        only a fraction of samples have data. Gated by JK
+        ``pytorch/torchrec:scale_batch_outputs_by_input_length``.
         For unpooled: same as batch_inputs.
         """
         if self.is_pooled:
+            if torch._utils_internal.justknobs_check(
+                "pytorch/torchrec:scale_batch_outputs_by_input_length"
+            ):
+                return sum(
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(
+                        self.input_lengths, self.num_poolings, self.batch_sizes
+                    )
+                )
             return sum(x * y for x, y in zip(self.num_poolings, self.batch_sizes))
         return self.batch_inputs
 

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -606,11 +606,20 @@ def _calculate_dp_shard_io_sizes(
     batch_inputs = sum(
         [x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)]
     )
-    batch_outputs = (
-        sum([x * y for x, y in zip(num_poolings, batch_sizes)])
-        if is_pooled
-        else batch_inputs
-    )
+    if is_pooled:
+        if torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:scale_batch_outputs_by_input_length"
+        ):
+            batch_outputs = sum(
+                [
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(input_lengths, num_poolings, batch_sizes)
+                ]
+            )
+        else:
+            batch_outputs = sum([x * y for x, y in zip(num_poolings, batch_sizes)])
+    else:
+        batch_outputs = batch_inputs
 
     input_sizes = [math.ceil(batch_inputs * input_data_type_size)] * num_shards
     output_sizes = [
@@ -633,11 +642,20 @@ def _calculate_tw_shard_io_sizes(
     batch_inputs = sum(
         [x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)]
     )
-    batch_outputs = (
-        sum([x * y for x, y in zip(num_poolings, batch_sizes)])
-        if is_pooled
-        else batch_inputs
-    )
+    if is_pooled:
+        if torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:scale_batch_outputs_by_input_length"
+        ):
+            batch_outputs = sum(
+                [
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(input_lengths, num_poolings, batch_sizes)
+                ]
+            )
+        else:
+            batch_outputs = sum([x * y for x, y in zip(num_poolings, batch_sizes)])
+    else:
+        batch_outputs = batch_inputs
 
     input_sizes = [math.ceil(batch_inputs * world_size * input_data_type_size)]
     output_sizes = [
@@ -660,11 +678,20 @@ def _calculate_cw_shard_io_sizes(
     batch_inputs = sum(
         [x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)]
     )
-    batch_outputs = (
-        sum([x * y for x, y in zip(num_poolings, batch_sizes)])
-        if is_pooled
-        else batch_inputs
-    )
+    if is_pooled:
+        if torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:scale_batch_outputs_by_input_length"
+        ):
+            batch_outputs = sum(
+                [
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(input_lengths, num_poolings, batch_sizes)
+                ]
+            )
+        else:
+            batch_outputs = sum([x * y for x, y in zip(num_poolings, batch_sizes)])
+    else:
+        batch_outputs = batch_inputs
 
     input_sizes = [math.ceil(batch_inputs * world_size * input_data_type_size)] * len(
         shard_sizes
@@ -693,11 +720,20 @@ def _calculate_rw_shard_io_sizes(
         sum([x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)])
         / world_size
     )
-    batch_outputs = (
-        sum([x * y for x, y in zip(num_poolings, batch_sizes)])
-        if is_pooled
-        else batch_inputs
-    )
+    if is_pooled:
+        if torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:scale_batch_outputs_by_input_length"
+        ):
+            batch_outputs = sum(
+                [
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(input_lengths, num_poolings, batch_sizes)
+                ]
+            )
+        else:
+            batch_outputs = sum([x * y for x, y in zip(num_poolings, batch_sizes)])
+    else:
+        batch_outputs = batch_inputs
 
     input_sizes = [
         (
@@ -736,11 +772,20 @@ def _calculate_twrw_shard_io_sizes(
         sum([x * y * z for x, y, z in zip(input_lengths, num_poolings, batch_sizes)])
         / local_world_size
     )
-    batch_outputs = (
-        sum([x * y for x, y in zip(num_poolings, batch_sizes)])
-        if is_pooled
-        else batch_inputs
-    )
+    if is_pooled:
+        if torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:scale_batch_outputs_by_input_length"
+        ):
+            batch_outputs = sum(
+                [
+                    min(1.0, il) * x * y
+                    for il, x, y in zip(input_lengths, num_poolings, batch_sizes)
+                ]
+            )
+        else:
+            batch_outputs = sum([x * y for x, y in zip(num_poolings, batch_sizes)])
+    else:
+        batch_outputs = batch_inputs
 
     input_sizes = [
         (


### PR DESCRIPTION
Summary:
Re-landing D100005461 (reverted by revert commit 42fbb20edf94) with the missing e2e deterministic test baseline fix included.

The planner's batch_outputs computation for perf estimation uses sum(num_poolings * batch_sizes), which assumes every sample produces output for every feature. For tables with variable batch size and sparse features (average input_length < 1), only a fraction of samples have data, so the actual comms volume and compute can be much smaller than predicted.

This scales batch_outputs by min(1, input_length) per feature, reducing the estimated fwd_comms/bwd_comms time and storage estimates. Gated by JK pytorch/torchrec:scale_batch_outputs_by_input_length.

This version also updates the e2e deterministic test baseline at tests/ne/e2e_deterministic_tests/baselines/fusionsg_200x_seq_e2e_ne.yaml which was missed in the original diff and caused T264107019.

Differential Revision: D100339411


