### PR TITLE
Add option to choose where to delay stashing execution

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_emb_stash.yml
@@ -16,7 +16,8 @@ PipelineConfig:
   pipeline: "sparse-emb-stash"
   kwargs:
     site_fqn: "over.overarch.0"  # dense
-    # delay_stash: true
+    delay_stash: true
+    stash_site_fqn: "dense"
 ModelInputConfig:
   num_float_features: 100
   feature_pooling_avg: 30

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -27,6 +27,7 @@ import torch
 from torch.autograd.profiler import record_function
 from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.memory_stashing import MemoryStashingManager
+from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.train_pipeline.backward_injection import (
     FirstGradTensorFinder,
     InjectionSite,
@@ -1096,6 +1097,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         delay_stash: bool = False,
+        stash_site_fqn: Optional[str] = None,
     ) -> None:
         super().__init__(
             model=model,
@@ -1120,6 +1122,8 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         else:
             self._injection_site = site_fqn
         self._delay_stash = delay_stash
+        self._stash_site_fqn = stash_site_fqn
+        self._stash_hook_handle: Optional[torch.utils.hooks.RemovableHandle] = None
 
         MemoryStashingManager.set_streams(
             self._memcpy_stream,  # pyrefly: ignore[bad-argument-type]
@@ -1127,6 +1131,35 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         )
         if delay_stash:
             MemoryStashingManager.set_delay_stash(True)
+
+    def _try_hook_stash(self) -> None:
+        """Register a forward pre-hook on ``stash_site_fqn`` to execute
+        pending stashes right before that module's forward pass.
+
+        This follows the same pattern used by
+        ``TrainPipelineCustomizedOrderSparseDist`` to hook SDD steps into
+        specific module forwards.  The hook frees HBM (D2H copy +
+        ``resize_(0)``) just before peak-memory modules run, avoiding PCIe
+        contention with ``start_sparse_data_dist``'s H2D copy.
+        """
+        if self._stash_site_fqn is None or self._stash_hook_handle is not None:
+            return
+
+        model = self._model
+        if isinstance(model, DistributedModelParallel):
+            model = model.module
+
+        target = model.get_submodule(self._stash_site_fqn)
+
+        def _execute_stash_hook(module: torch.nn.Module, args: Any) -> None:
+            with record_function("## execute_pending_stashes ##"):
+                MemoryStashingManager.execute_pending_stashes()
+
+        self._stash_hook_handle = target.register_forward_pre_hook(_execute_stash_hook)
+        logger.info(
+            f"MemoryStashingManager: hooked execute_pending_stashes "
+            f"as forward pre-hook on {self._stash_site_fqn}"
+        )
 
     def _pipeline_model(
         self,
@@ -1136,15 +1169,18 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
     ) -> None:
         super()._pipeline_model(batch, context, pipelined_forward)
 
-        if self._delay_stash:
-            # Register execute hook first — tensor hooks fire in registration
-            # order, so execute_pending_stashes runs before restore during
-            # backward.
+        if self._delay_stash and self._stash_site_fqn is None:
+            # No forward hook site specified — fall back to executing
+            # pending stashes via backward hook at the injection site.
             def execute_work(_pipeline: Any) -> None:
                 with record_function("## execute_pending_stashes ##"):
                     MemoryStashingManager.execute_pending_stashes()
 
             self.register_backward_hook(self._injection_site, execute_work)
+
+        # Hook stash execution into the target module's forward if configured.
+        if self._delay_stash:
+            self._try_hook_stash()
 
         def work(_pipeline: Any) -> None:
             with record_function("## restore_embedding_weights ##"):


### PR DESCRIPTION
Summary:
Adds a stash_site_fqn parameter to TrainPipelineEmbeddingStash that controls where execute_pending_stashes runs during the forward pass. Previously, delayed stash execution was only triggered via a backward hook at the injection site. This change allows hooking stash execution as a forward pre-hook on any named submodule, giving fine-grained control over when HBM is freed relative to peak-memory operations.                                                                                                           
                                          
When stash_site_fqn is set, a register_forward_pre_hook is installed on the target module so that pending D2H copies and resize_(0) complete just before that module's       forward pass. When unset, the existing backward-hook fallback is preserved. This lets us experimentally tune stash timing — e.g., stashing before dense vs over — to find the optimal point that minimizes PCIe contention with SDD's H2D copies while maximizing HBM savings.                                                                            
                                          
The benchmark YML (sparse_data_dist_emb_stash.yml) is updated to enable delay_stash: true and set stash_site_fqn, and fixes stash_site_fqn from the incorrect "dense_arch" to
"dense" to match the actual TestSparseNN submodule name.

Reviewed By: TroyGarden

Differential Revision: D100878508


