### PR TITLE
Add logging for inplace_copy_batch size

### DIFF
--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -25,7 +25,7 @@ from typing import (
 
 import torch
 from torch.autograd.profiler import record_function
-from torchrec.distributed.logger import one_time_rank0_logger
+from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.train_pipeline.backward_injection import (
@@ -47,6 +47,7 @@ from torchrec.distributed.train_pipeline.runtime_forwards import (
 from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
 from torchrec.distributed.train_pipeline.types import PipelineState
 from torchrec.distributed.train_pipeline.utils import (
+    _batch_tensor_size,
     _override_input_dist_forwards,
     _rewrite_model,
     _start_data_dist,
@@ -754,6 +755,15 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
         with record_function(f"## inplace_copy_batch_to_gpu {context.index} ##"):
             batch = self._next_batch(dataloader_iter)
             if batch is not None:
+                if not self._inplace_copy_batch_size_logged:
+                    self._inplace_copy_batch_size_logged = True
+                    size = _batch_tensor_size(batch)
+
+                    one_time_logger.info(
+                        LazyStr(
+                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
+                        )
+                    )
                 future_batch = self._copy_executor.submit(
                     _to_device,
                     batch,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -37,7 +37,7 @@ from torchrec.distributed.embedding import EmbeddingCollectionAwaitable  # noqa:
 from torchrec.distributed.embeddingbag import (
     EmbeddingBagCollectionAwaitable,  # noqa: F401
 )
-from torchrec.distributed.logger import one_time_rank0_logger
+from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.backward_injection import (
@@ -67,6 +67,7 @@ from torchrec.distributed.train_pipeline.runtime_forwards import (
 from torchrec.distributed.train_pipeline.tracing import PipelinedPostproc
 from torchrec.distributed.train_pipeline.types import PipelineState
 from torchrec.distributed.train_pipeline.utils import (
+    _batch_tensor_size,
     _override_input_dist_forwards,
     _pipeline_detach_model,
     _rewrite_model,
@@ -238,6 +239,7 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
         )
         self._batch_count = 0
         self._enable_inplace_copy_batch = enable_inplace_copy_batch
+        self._inplace_copy_batch_size_logged = False
         logger.info(
             f"train_pipeline uses enable_inplace_copy_batch: {enable_inplace_copy_batch}"
         )
@@ -295,6 +297,13 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
 
     def _copy_batch_to_gpu(self, cur_batch: In) -> None:
         if self._enable_inplace_copy_batch:
+            if not self._inplace_copy_batch_size_logged:
+                self._inplace_copy_batch_size_logged = True
+                size = _batch_tensor_size(cur_batch)
+
+                one_time_logger.info(
+                    LazyStr(lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB")
+                )
             with record_function("## inplace_copy_batch_to_gpu ##"):
                 self._cur_batch = _to_device(
                     cur_batch,
@@ -538,6 +547,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._enable_inplace_copy_batch = enable_inplace_copy_batch
         self._free_features_storage_early = free_features_storage_early
         self._batch_count = 0
+        self._inplace_copy_batch_size_logged = False
 
         logger.info(
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "
@@ -1012,6 +1022,15 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         with record_function(f"## inplace_copy_batch_to_gpu {context.index} ##"):
             batch = self._next_batch(dataloader_iter)
             if batch is not None:
+                if not self._inplace_copy_batch_size_logged:
+                    self._inplace_copy_batch_size_logged = True
+                    size = _batch_tensor_size(batch)
+
+                    one_time_logger.info(
+                        LazyStr(
+                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
+                        )
+                    )
                 batch = _to_device(
                     batch,
                     self._device,

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -29,6 +29,7 @@ from typing import (
 
 import torch
 from torch.profiler import record_function
+from torch.utils._pytree import tree_flatten
 from torchrec.distributed.dist_data import KJTAllToAll, KJTAllToAllTensorsAwaitable
 from torchrec.distributed.embedding_sharding import (
     FusedKJTListSplitsAwaitable,
@@ -67,6 +68,21 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Multistreamable, Pipelineable
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _batch_tensor_size(batch: Any) -> int:
+    """Compute total tensor storage size in bytes for a batch.
+
+    Uses pytree to flatten the batch into leaf tensors, then sums
+    element_size() * numel() for each. All operations are O(1) tensor
+    metadata reads — no data is accessed.
+    """
+    leaves, _ = tree_flatten(batch)
+    return sum(
+        leaf.element_size() * leaf.numel()
+        for leaf in leaves
+        if isinstance(leaf, torch.Tensor)
+    )
 
 
 def _to_device(


### PR DESCRIPTION
Summary:
This diff adds one-time logging to the `inplace_copy_batch` technique to track how much data (in GB) is being copied to GPU via the in-place path. This gives visibility into the memory footprint of H2D transfers, which serves as a proxy for memory savings enabled by the technique (3-5 GB per rank in production RecSys models).

## Changes
1. **`utils.py`**: Add `_batch_tensor_size(batch)` helper that uses `torch.utils._pytree.tree_flatten` to flatten the batch into leaf tensors, then sums `element_size() * numel()` for each. This leverages existing pytree registrations for KJT, JaggedTensor, KeyedTensor, etc., so it automatically handles any registered batch type. All operations are O(1) tensor metadata reads.
2. **`train_pipelines.py`**: Add flag-gated logging to `TrainPipelineBase._copy_batch_to_gpu` and `TrainPipelineSparseDist.inplace_copy_batch_to_gpu`. Size is computed only on the first batch (via `_inplace_copy_batch_size_logged` flag), then logged once via `one_time_logger` + `LazyStr` for deferred string formatting.
3. **`experimental_pipelines.py`**: Same logging added to `TrainPipelineSparseDistT.inplace_copy_batch_to_gpu` (threaded variant).

**Performance:** Zero steady-state overhead — size computation runs only once (first batch), `LazyStr` defers formatting, and `one_time_logger` caps at 1 emission per call site.

Differential Revision: D101420284


