### PR TITLE
Fix optimizer state sizing to use float32 instead of weight dtype

### DIFF
--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -783,9 +783,8 @@ def _calculate_storage_specific_sizes(
         sharding_type,
     )
     optimizer_sizes = _calculate_optimizer_sizes(
-        tensor_sizes,
+        shard_sizes,
         optimizer_class,
-        shape,
     )
     cache_aux_state_sizes: List[int] = _calculate_cache_aux_state_sizes(
         shard_sizes,
@@ -839,24 +838,79 @@ def _calculate_cache_aux_state_sizes(
 
 
 def _calculate_optimizer_sizes(
-    tensor_sizes: List[int],
+    shard_sizes: List[List[int]],
     optimizer_class: Optional[Type[torch.optim.Optimizer]],
-    sharding_tensor_shape: torch.Size,
 ) -> List[int]:
-    optimizer_multiplier: float = _get_optimizer_multipler(
-        optimizer_class,
-        sharding_tensor_shape,
-    )
-    optimizer_sizes: List[int] = [
-        math.ceil(tensor_size * optimizer_multiplier) for tensor_size in tensor_sizes
-    ]
-    return optimizer_sizes
+    """Estimate FBGEMM-allocated optimizer state bytes per shard.
+
+    Memory decomposition:
+      - Optimizer class -> state schema (which buffers, full vs rowwise).
+      - Sharding        -> how the schema is partitioned per rank
+                           (this function operates on a single shard).
+      - FBGEMM          -> state dtype (float32, independent of weight
+                           dtype).
+
+    So bytes per shard = (count and shape from optimizer) * 4 (FBGEMM).
+
+    Source of truth for the float32 invariant: `momentum{1,2}_dtype` in
+    `fbgemm_gpu/split_table_batched_embeddings_ops_training.py`
+    (SplitTableBatchedEmbeddingBagsCodegen.__init__) defaults to
+    `torch.float32`; an `assert` gates `optimizer_state_dtypes` overrides
+    to PARTIAL_ROWWISE_ADAM / ENSEMBLE_ROWWISE_ADAGRAD only. Treating
+    state as float32 is exact for the gated optimizers and a conservative
+    upper bound for the two configurable ones — safe for memory planning.
+
+    Per-shard state structure (all buffers float32):
+
+        Optimizer              momentum1   momentum2
+        ---------              ---------   ---------
+        SGD / None             —           —
+        Adam / LAMB            full        full
+        RowWiseAdagrad         rowwise     —
+        PartialRowWiseAdam     full        rowwise
+        PartialRowWiseLAMB     full        rowwise
+        Adagrad / LarsSGD      full        —          (catch-all)
+
+    where  full    = prod(shard_size) elements,
+           rowwise = shard_size[0] elements (one per embedding row).
+    """
+    STATE_DTYPE_BYTES = 4  # float32; see docstring
+
+    if not optimizer_class or optimizer_class in [
+        torch.optim.SGD,
+        trec_optim.SGD,
+    ]:
+        return [0] * len(shard_sizes)
+
+    if optimizer_class in [
+        torch.optim.Adam,
+        trec_optim.Adam,
+        trec_optim.LAMB,
+    ]:
+        return [prod(size) * STATE_DTYPE_BYTES * 2 for size in shard_sizes]
+
+    if optimizer_class == trec_optim.RowWiseAdagrad:
+        return [size[0] * STATE_DTYPE_BYTES for size in shard_sizes]
+
+    if optimizer_class in [
+        trec_optim.PartialRowWiseAdam,
+        trec_optim.PartialRowWiseLAMB,
+    ]:
+        return [
+            prod(size) * STATE_DTYPE_BYTES + size[0] * STATE_DTYPE_BYTES
+            for size in shard_sizes
+        ]
+
+    return [prod(size) * STATE_DTYPE_BYTES for size in shard_sizes]
 
 
 def _get_optimizer_multipler(
     optimizer_class: Optional[Type[torch.optim.Optimizer]],
     shape: torch.Size,
 ) -> float:
+    """Deprecated: use _calculate_optimizer_sizes instead.
+
+    Kept for backward compatibility with external callers."""
     if not optimizer_class:
         return 0.0
     if optimizer_class in [torch.optim.SGD, trec_optim.SGD]:

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -42,7 +42,7 @@ from torchrec.distributed.types import (
     PipelineType,
     ShardingType,
 )
-from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
+from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS, DataType
 
 try:
     # This is a safety measure against torch package issues for when
@@ -203,10 +203,13 @@ class EmbeddingStorageEstimator(ShardEstimator):
             # input indices can be of int32, but in TBE they get converted to int64 anyway
             input_data_type_size = BIGINT_DTYPE
 
+            # When output_dtype is not explicitly set, default to FP32 (4 bytes)
+            # because the embedding kernel outputs FP32 by default
+            # (SparseType.FP32), regardless of the weight storage precision.
             output_data_type_size: float = (
                 DATA_TYPE_NUM_BITS[sharding_option.output_dtype] / 8
-                if sharding_option.output_dtype
-                else sharding_option.tensor.element_size()
+                if isinstance(sharding_option.output_dtype, DataType)
+                else 4.0  # FP32 default, matching embedding kernel output dtype
             )
 
             mpp_conf = (

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -1636,6 +1636,68 @@ class TestEmbeddingStorageEstimator(unittest.TestCase):
 
         self.assertEqual(hbms[0], hbms[1])
 
+    def test_output_data_type_size_uses_fp32_default(self) -> None:
+        """Output size estimation should use FP32 (4 bytes) when output_dtype is
+        not explicitly set, since the embedding kernel defaults to FP32 output
+        (SparseType.FP32) regardless of weight storage precision."""
+        topology = Topology(world_size=2, compute_device="cuda")
+        estimator = EmbeddingStorageEstimator(topology=topology)
+
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=10,
+                name="table_bf16",
+                feature_names=["feature_0"],
+                data_type=DataType.BF16,
+            )
+        ]
+        model = TestSparseNN(tables=tables, weighted_tables=[])
+        ebc_module = model.sparse.ebc
+        assert isinstance(ebc_module, torch.nn.Module)
+
+        bf16_tensor = torch.zeros(100, 10, dtype=torch.bfloat16, device="meta")
+        self.assertEqual(bf16_tensor.element_size(), 2)
+
+        sharding_option = ShardingOption(
+            name="table_bf16",
+            tensor=bf16_tensor,
+            module=("sparse.ebc", ebc_module),
+            input_lengths=[1.0],
+            batch_size=BATCH_SIZE,
+            sharding_type=ShardingType.TABLE_WISE.value,
+            partition_by="host",
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[Shard(size=[100, 10], offset=[0, 0])],
+        )
+
+        sharder_data_map = {
+            sharding_option.module_type_key: SharderData(
+                fused_params={},
+                qcomm_dtype_sizes={},
+                storage_usage_type=StorageUsageType.DEFAULT,
+            ),
+        }
+
+        estimator.estimate([sharding_option], sharder_data_map=sharder_data_map)
+
+        shard = sharding_option.shards[0]
+        self.assertIsNotNone(shard.storage)
+
+        # See batched_embedding_kernel.py:2865 for FP32 default:
+        #   output_dtype = fused_params.get("output_dtype", SparseType.FP32)
+        bf16_tensor_size = 100 * 10 * 2  # weight storage
+        input_size = math.ceil(1.0 * BATCH_SIZE * 2 * 8)  # BIGINT_DTYPE
+        expected_output_fp32 = BATCH_SIZE * 2 * 10 * 4  # FP32 output
+        expected_hbm = bf16_tensor_size + input_size + expected_output_fp32
+
+        self.assertEqual(
+            shard.storage.hbm,
+            expected_hbm,
+            f"Output sizing should use FP32 (4 bytes) not weight dtype "
+            f"(BF16 = 2 bytes). Expected HBM={expected_hbm}, got {shard.storage.hbm}.",
+        )
+
     def test_zero_dimension_tensor_raises_value_error(self) -> None:
         topology = Topology(world_size=2, compute_device="cuda")
         estimator = EmbeddingStorageEstimator(topology=topology)

--- a/torchrec/distributed/planner/tests/test_shard_estimators.py
+++ b/torchrec/distributed/planner/tests/test_shard_estimators.py
@@ -31,6 +31,7 @@ from torchrec.distributed.planner.constants import (
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.estimator import EmbeddingPerfEstimatorFactory
 from torchrec.distributed.planner.shard_estimators import (
+    _calculate_optimizer_sizes,
     _calculate_storage_specific_sizes,
     EmbeddingOffloadStats,
     EmbeddingStorageEstimator,
@@ -1056,6 +1057,11 @@ class TestEmbeddingPerfEstimator(unittest.TestCase):
 
 
 def calculate_storage_specific_size_data_provider():
+    # Test setup: shape=(10,5,3), shard_sizes=[[5,5,3],[5,5,3]], storage=100.
+    # weight_bytes per shard = 50 (non-DP) or 100 (DP, replicated).
+    # Optimizer state is float32 (4 bytes), computed from shard dimensions:
+    #   Adam:           prod([5,5,3]) * 4 * 2 = 600 per shard
+    #   RowWiseAdagrad: shard_rows(5)  * 4    =  20 per shard
     return (
         {
             "sharding_type": ShardingType.TABLE_ROW_WISE,
@@ -1067,8 +1073,8 @@ def calculate_storage_specific_size_data_provider():
             "sharding_type": ShardingType.COLUMN_WISE,
             "optimizer_class": torch.optim.Adam,
             "expected_storage": [
-                150 + math.ceil(5 * (4 + 0.5 * 16)),
-                150 + math.ceil(5 * (4 + 0.5 * 16)),
+                650 + math.ceil(5 * (4 + 0.5 * 16)),
+                650 + math.ceil(5 * (4 + 0.5 * 16)),
             ],
             "clf": 0.5,
         },
@@ -1085,8 +1091,8 @@ def calculate_storage_specific_size_data_provider():
             "sharding_type": ShardingType.DATA_PARALLEL,
             "optimizer_class": trec_optim.RowWiseAdagrad,
             "expected_storage": [
-                134 + math.ceil(5 * (4 + 1.0 * 16)),
-                134 + math.ceil(5 * (4 + 1.0 * 16)),
+                120 + math.ceil(5 * (4 + 1.0 * 16)),
+                120 + math.ceil(5 * (4 + 1.0 * 16)),
             ],
             "clf": 1.0,
         },
@@ -1697,6 +1703,33 @@ class TestEmbeddingStorageEstimator(unittest.TestCase):
             f"Output sizing should use FP32 (4 bytes) not weight dtype "
             f"(BF16 = 2 bytes). Expected HBM={expected_hbm}, got {shard.storage.hbm}.",
         )
+
+    def test_calculate_optimizer_sizes(self) -> None:
+        # FBGEMM optimizer states are always float32, regardless of weight
+        # dtype. See construct_split_state in
+        # split_table_batched_embeddings_ops_training.py.
+        shard_sizes = [[100, 10], [100, 10]]
+        full = 100 * 10 * 4  # full float32 state per shard
+        rowwise = 100 * 4  # rowwise float32 state per shard
+
+        cases = [
+            (None, [0, 0]),
+            (torch.optim.SGD, [0, 0]),
+            (trec_optim.SGD, [0, 0]),
+            (torch.optim.Adam, [full * 2, full * 2]),
+            (trec_optim.Adam, [full * 2, full * 2]),
+            (trec_optim.LAMB, [full * 2, full * 2]),
+            (trec_optim.RowWiseAdagrad, [rowwise, rowwise]),
+            (trec_optim.PartialRowWiseAdam, [full + rowwise, full + rowwise]),
+            (trec_optim.PartialRowWiseLAMB, [full + rowwise, full + rowwise]),
+            (trec_optim.Adagrad, [full, full]),  # catch-all: 1 full state
+        ]
+        for optimizer_class, expected in cases:
+            with self.subTest(optimizer_class=optimizer_class):
+                self.assertEqual(
+                    _calculate_optimizer_sizes(shard_sizes, optimizer_class),
+                    expected,
+                )
 
     def test_zero_dimension_tensor_raises_value_error(self) -> None:
         topology = Topology(world_size=2, compute_device="cuda")


### PR DESCRIPTION
Summary:
The planner sized FBGEMM optimizer state by scaling weight bytes by a per-class multiplier, which conflated state dtype with weight dtype. FBGEMM allocates momentum buffers in float32 independent of weight dtype (`momentum{1,2}_dtype` defaults in `SplitTableBatchedEmbeddingBagsCodegen.__init__`), so BF16 weights were undersized 2x. The catch-all multiplier also misclassified LAMB (counted 1 buffer instead of 2) and PartialRowWise{Adam,LAMB} (counted 1 full buffer instead of 1 full + 1 rowwise).

Fix: compute optimizer bytes from shard dimensions × 4 (float32) directly, with explicit branches per optimizer schema. PartialRowWiseLAMB is now handled alongside PartialRowWiseAdam (same state structure).

| Optimizer                     | momentum1 | momentum2 |
|-------------------------------|-----------|-----------|
| SGD / None                    | —         | —         |
| Adam / LAMB                   | full      | full      |
| RowWiseAdagrad                | rowwise   | —         |
| PartialRowWiseAdam / LAMB     | full      | rowwise   |
| Adagrad / LarsSGD (catch-all) | full      | —         |

where `full = prod(shard_shape) * 4` bytes, `rowwise = shard_rows * 4` bytes.

Decomposition: optimizer class fixes the state schema (which buffers, full vs rowwise per element), sharding fixes how the schema is partitioned per rank, FBGEMM fixes the dtype (float32). The old planner conflated the third with the weight dtype.

For Adam-family optimizers FBGEMM enforces float32 via `assert`; for PartialRowWiseAdam float32 is the default and `optimizer_state_dtypes` can override — sizing as float32 is a conservative upper bound, safe for memory planning.

Differential Revision: D99700089


