### PR TITLE
Add SHAMPOO_V3_MRS to OptimType enum

### DIFF
--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -70,6 +70,7 @@ class OptimType(Enum):
     SHAMPOO_V2_MRS = "SHAMPOO_V2_MRS"
     SHAMPOO_MRS = "SHAMPOO_MRS"
     MUON = "MUON"
+    SHAMPOO_V3_MRS = "SHAMPOO_V3_MRS"
 
 
 @unique


### PR DESCRIPTION
Summary:
Adds a single new enum value `SHAMPOO_V3_MRS = "SHAMPOO_V3_MRS"` to `torchrec.distributed.embedding_types.OptimType`. This is the routing key the upcoming MVAI optimizer factory will use to dispatch to the V3 wrapper (`V3MRSDistributedShampoo`, added in the next diff in this stack); landing it on its own keeps the BASE → APP layering clean and avoids the `AttributeError` failure mode flagged in S621061.

No behavior change on its own — the new value is unused by any existing call site.

Reviewed By: renyiryry

Differential Revision: D102646479
