### PR TITLE
Add sharded relay tests and benchmarks (#4209)

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -10,6 +10,7 @@
 import abc
 import copy
 import logging as logger
+import os
 from collections import defaultdict, OrderedDict
 from functools import wraps
 from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Set, Tuple, Type
@@ -47,6 +48,11 @@ from torchrec.distributed.model_tracker.types import (
     Trackers,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.sharded_relay_utils import (
+    allreduce_tensors_with_sharded_relay,
+    setup_sharded_relay,
+    ShardedRelayState,
+)
 from torchrec.distributed.sharding_plan import get_default_sharders
 from torchrec.distributed.types import (
     DMPCollectionConfig,
@@ -1115,6 +1121,7 @@ class DMPCollection(DistributedModelParallel):
         custom_all_reduce: Optional[Callable[[List[torch.Tensor]], None]] = None,
         submodule_configs: Optional[List[DMPCollectionConfig]] = None,
         rs_awaitable_hook_module: Optional[str] = None,
+        use_sharded_relay: bool = False,
     ) -> None:
         assert (
             device.type == "cuda" or device.type == "mtia"
@@ -1228,6 +1235,73 @@ class DMPCollection(DistributedModelParallel):
         ):
             self._register_sparse_arch_forward_hook(rs_awaitable_hook_module)
 
+        # Initialize FusedShardedRelayMultiGroup for 2D sparse parallelism if enabled.
+        # Creates a single FusedShardedRelayMultiGroup that executes all sparse groups
+        # in lockstep phases to eliminate XGMI link contention.
+        #
+        # NOTE: Sharded relay can be enabled via:
+        # 1. The use_sharded_relay parameter (explicit)
+        # 2. The NCCL_SHARDED_RELAY_MODE_ENABLE=1 environment variable (implicit)
+        #
+        # Active ranks are passed to the C++ ncclShardedRelayAllReduce API via
+        # function arguments.
+        #
+        # When RCCLX sharded relay is available, we create RCCLX comm to enable
+        # native ncclShardedRelayAllReduce. Otherwise, falls back to dist.all_reduce.
+        sharded_relay_env = os.environ.get("NCCL_SHARDED_RELAY_MODE_ENABLE", "0")
+        self._use_sharded_relay: bool = use_sharded_relay or sharded_relay_env == "1"
+        self._sharded_relay_state: ShardedRelayState | None = None
+
+        if self._use_sharded_relay:
+            if sharded_relay_env == "1" and not use_sharded_relay:
+                logger.info(
+                    "[TorchRec 2D Parallel] Sharded relay auto-enabled via "
+                    "NCCL_SHARDED_RELAY_MODE_ENABLE=1 environment variable."
+                )
+            self._setup_sharded_relay_per_context(
+                world_size=world_size,
+                use_inter_host_allreduce=use_inter_host_allreduce,
+                model_parallel_group_size=sharding_group_size,
+            )
+
+    def _setup_sharded_relay_per_context(
+        self,
+        world_size: int,
+        use_inter_host_allreduce: bool,
+        model_parallel_group_size: int = 32,
+    ) -> None:
+        """Set up fused sharded relay; delegates to sharded_relay_utils.
+
+        Args:
+            world_size: Total number of ranks across all nodes.
+            use_inter_host_allreduce: If True, sharded relay is not supported.
+            model_parallel_group_size: Number of GPUs in the model-parallel
+                (sharding) dimension of the 2D topology. This is the DMPCollection
+                ``sharding_group_size`` parameter (e.g., 32 for a 64-GPU job with
+                ``num_parallel_worlds=2``).
+
+                The sharded relay algorithm operates on *replica groups* — pairs
+                of ranks that hold the same model shard. The replica group size is:
+
+                    replica_group_size = world_size // model_parallel_group_size
+
+                For a 64-GPU job with ``num_parallel_worlds=2``:
+                    model_parallel_group_size = 32
+                    replica_group_size        =  2  ← passed to setup_sharded_relay
+        """
+        # Convert from model-parallel group size to replica group size.
+        # setup_sharded_relay expects the number of active ranks per sparse group,
+        # which equals the number of data-parallel replicas (num_parallel_worlds),
+        # not the number of model-parallel ranks per shard.
+        replica_group_size = world_size // model_parallel_group_size
+        self._sharded_relay_state = setup_sharded_relay(
+            global_rank=self._global_rank,
+            world_size=world_size,
+            use_inter_host_allreduce=use_inter_host_allreduce,
+            sharding_group_size=replica_group_size,
+        )
+        self._use_sharded_relay = self._sharded_relay_state is not None
+
     def _shard_modules_impl(
         self,
         module: nn.Module,
@@ -1304,12 +1378,14 @@ class DMPCollection(DistributedModelParallel):
         It uses the `dist.AllreduceCoalescedOptions` to perform an all-reduce operation on the weights,
         which averages the weights across all processes in the inter-process group.
 
-        The default CUDA stream is used for the all-reduce operation, and the method does not return any value.
+        For sharded relay mode, the FusedShardedRelayMultiGroup executes all groups in lockstep
+        phases with a blocking call, so no async work handling is needed.
 
         Args:
             include_optimizer_state (bool): Flag to include optimizer state syncing upon call
         """
-        # we sync per context to use the right all reduce process group
+        # We sync per context to use the right all reduce process group.
+        # For sharded relay mode, _allreduce_tensors uses blocking fused calls internally.
         for ctx in self._ctxs:
             if len(ctx.hash_zch_modules) > 0:
                 # Do syncing of managed collision modules.
@@ -1363,7 +1439,7 @@ class DMPCollection(DistributedModelParallel):
                 survived,
                 include_optimizer_state,
                 allreduce_fn=lambda dict_tensors, annotation, opts: self._allreduce_tensors(
-                    ctx.replica_pg, dict_tensors, annotation, opts
+                    ctx, dict_tensors, annotation, opts
                 ),
                 indices_slots=reserved_indices,
             )
@@ -1388,16 +1464,11 @@ class DMPCollection(DistributedModelParallel):
             opts = dist.AllreduceCoalescedOptions()
             opts.reduceOp = dist.ReduceOp.AVG
 
-        self._allreduce_tensors(
-            ctx.replica_pg,
-            ctx.weights_by_dtype,
-            "## 2d_weight_sync ##",
-            opts,
-        )
+        self._allreduce_tensors(ctx, ctx.weights_by_dtype, "## 2d_weight_sync ##", opts)
 
         if include_optimizer_state and ctx.optimizer_tensors_by_dtype:
             self._allreduce_tensors(
-                ctx.replica_pg,
+                ctx,
                 ctx.optimizer_tensors_by_dtype,
                 "## 2d_optimizer_sync ##",
                 opts,
@@ -1405,7 +1476,7 @@ class DMPCollection(DistributedModelParallel):
 
     def _allreduce_tensors(
         self,
-        pg: dist.ProcessGroup,
+        ctx: DMPCollectionContext,
         tensors_dict: Dict[torch.dtype, List[torch.Tensor]],
         annotation: str,
         opts: Optional[dist.AllreduceCoalescedOptions] = None,
@@ -1416,20 +1487,43 @@ class DMPCollection(DistributedModelParallel):
 
         Collective Communication:
             - allreduce_coalesced on the provided process group (pg)
+
+        For sharded relay mode with 2D sparse parallelism:
+        - Uses FusedShardedRelayMultiGroup for phase-synchronized execution
+        - ALL groups execute in lockstep phases to eliminate XGMI link contention
+        - Single fused blocking call handles all groups in parallel
+
+        Args:
+            ctx: The DMPCollectionContext containing the process group
+            tensors_dict: Dictionary of tensors grouped by dtype
+            annotation: Annotation string for profiling
+            opts: Optional allreduce coalesced options
         """
+        if self._use_sharded_relay and self._sharded_relay_state is not None:
+            # Propagate the reduce op from opts so callers (e.g.
+            # sync_hash_zch_weights) that pass ReduceOp.SUM are honored
+            # instead of being silently averaged.
+            op = opts.reduceOp if opts is not None else dist.ReduceOp.AVG
+            allreduce_tensors_with_sharded_relay(
+                self._sharded_relay_state,
+                tensors_dict,
+                annotation,
+                op=op,
+            )
+            return
 
         custom_all_reduce = self._custom_all_reduce
         if custom_all_reduce is not None:
-
+            # Custom all reduce hook
             def _all_reduce(tensors: List[torch.Tensor]) -> None:
                 with record_function(f"{annotation}_custom_hook"):
                     custom_all_reduce(tensors)
 
         else:
-
+            # Default allreduce_coalesced path (blocking)
             def _all_reduce(tensors: List[torch.Tensor]) -> None:
                 with record_function(annotation):
-                    pg.allreduce_coalesced(tensors, opts=opts).wait()
+                    ctx.replica_pg.allreduce_coalesced(tensors, opts=opts).wait()
 
         for tensor_list in tensors_dict.values():
             _all_reduce(tensor_list)

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -10,6 +10,7 @@
 import abc
 import copy
 import logging as logger
+import os
 from collections import defaultdict, OrderedDict
 from functools import wraps
 from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Set, Tuple, Type
@@ -51,6 +52,11 @@ from torchrec.distributed.model_tracker.types import (
     Trackers,
 )
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
+from torchrec.distributed.sharded_relay_utils import (
+    allreduce_tensors_with_sharded_relay,
+    setup_sharded_relay,
+    ShardedRelayState,
+)
 from torchrec.distributed.sharding_plan import get_default_sharders
 from torchrec.distributed.types import (
     DMPCollectionConfig,
@@ -1128,6 +1134,7 @@ class DMPCollection(DistributedModelParallel):
         custom_all_reduce: Optional[Callable[[List[torch.Tensor]], None]] = None,
         submodule_configs: Optional[List[DMPCollectionConfig]] = None,
         rs_awaitable_hook_module: Optional[str] = None,
+        use_sharded_relay: bool = False,
     ) -> None:
         assert (
             device.type == "cuda" or device.type == "mtia"
@@ -1255,6 +1262,73 @@ class DMPCollection(DistributedModelParallel):
         ):
             self._register_sparse_arch_forward_hook(rs_awaitable_hook_module)
 
+        # Initialize FusedShardedRelayMultiGroup for 2D sparse parallelism if enabled.
+        # Creates a single FusedShardedRelayMultiGroup that executes all sparse groups
+        # in lockstep phases to eliminate XGMI link contention.
+        #
+        # NOTE: Sharded relay can be enabled via:
+        # 1. The use_sharded_relay parameter (explicit)
+        # 2. The NCCL_SHARDED_RELAY_MODE_ENABLE=1 environment variable (implicit)
+        #
+        # Active ranks are passed to the C++ ncclShardedRelayAllReduce API via
+        # function arguments.
+        #
+        # When RCCLX sharded relay is available, we create RCCLX comm to enable
+        # native ncclShardedRelayAllReduce. Otherwise, falls back to dist.all_reduce.
+        sharded_relay_env = os.environ.get("NCCL_SHARDED_RELAY_MODE_ENABLE", "0")
+        self._use_sharded_relay: bool = use_sharded_relay or sharded_relay_env == "1"
+        self._sharded_relay_state: ShardedRelayState | None = None
+
+        if self._use_sharded_relay:
+            if sharded_relay_env == "1" and not use_sharded_relay:
+                logger.info(
+                    "[TorchRec 2D Parallel] Sharded relay auto-enabled via "
+                    "NCCL_SHARDED_RELAY_MODE_ENABLE=1 environment variable."
+                )
+            self._setup_sharded_relay_per_context(
+                world_size=world_size,
+                use_inter_host_allreduce=use_inter_host_allreduce,
+                model_parallel_group_size=sharding_group_size,
+            )
+
+    def _setup_sharded_relay_per_context(
+        self,
+        world_size: int,
+        use_inter_host_allreduce: bool,
+        model_parallel_group_size: int = 32,
+    ) -> None:
+        """Set up fused sharded relay; delegates to sharded_relay_utils.
+
+        Args:
+            world_size: Total number of ranks across all nodes.
+            use_inter_host_allreduce: If True, sharded relay is not supported.
+            model_parallel_group_size: Number of GPUs in the model-parallel
+                (sharding) dimension of the 2D topology. This is the DMPCollection
+                ``sharding_group_size`` parameter (e.g., 32 for a 64-GPU job with
+                ``num_parallel_worlds=2``).
+
+                The sharded relay algorithm operates on *replica groups* — pairs
+                of ranks that hold the same model shard. The replica group size is:
+
+                    replica_group_size = world_size // model_parallel_group_size
+
+                For a 64-GPU job with ``num_parallel_worlds=2``:
+                    model_parallel_group_size = 32
+                    replica_group_size        =  2  ← passed to setup_sharded_relay
+        """
+        # Convert from model-parallel group size to replica group size.
+        # setup_sharded_relay expects the number of active ranks per sparse group,
+        # which equals the number of data-parallel replicas (num_parallel_worlds),
+        # not the number of model-parallel ranks per shard.
+        replica_group_size = world_size // model_parallel_group_size
+        self._sharded_relay_state = setup_sharded_relay(
+            global_rank=self._global_rank,
+            world_size=world_size,
+            use_inter_host_allreduce=use_inter_host_allreduce,
+            sharding_group_size=replica_group_size,
+        )
+        self._use_sharded_relay = self._sharded_relay_state is not None
+
     def _shard_modules_impl(
         self,
         module: nn.Module,
@@ -1331,12 +1405,14 @@ class DMPCollection(DistributedModelParallel):
         It uses the `dist.AllreduceCoalescedOptions` to perform an all-reduce operation on the weights,
         which averages the weights across all processes in the inter-process group.
 
-        The default CUDA stream is used for the all-reduce operation, and the method does not return any value.
+        For sharded relay mode, the FusedShardedRelayMultiGroup executes all groups in lockstep
+        phases with a blocking call, so no async work handling is needed.
 
         Args:
             include_optimizer_state (bool): Flag to include optimizer state syncing upon call
         """
-        # we sync per context to use the right all reduce process group
+        # We sync per context to use the right all reduce process group.
+        # For sharded relay mode, _allreduce_tensors uses blocking fused calls internally.
         for ctx in self._ctxs:
             if len(ctx.hash_zch_modules) > 0:
                 # Do syncing of managed collision modules.
@@ -1390,7 +1466,7 @@ class DMPCollection(DistributedModelParallel):
                 survived,
                 include_optimizer_state,
                 allreduce_fn=lambda dict_tensors, annotation, opts: self._allreduce_tensors(
-                    ctx.replica_pg, dict_tensors, annotation, opts
+                    ctx, dict_tensors, annotation, opts
                 ),
                 indices_slots=reserved_indices,
             )
@@ -1415,16 +1491,11 @@ class DMPCollection(DistributedModelParallel):
             opts = dist.AllreduceCoalescedOptions()
             opts.reduceOp = dist.ReduceOp.AVG
 
-        self._allreduce_tensors(
-            ctx.replica_pg,
-            ctx.weights_by_dtype,
-            "## 2d_weight_sync ##",
-            opts,
-        )
+        self._allreduce_tensors(ctx, ctx.weights_by_dtype, "## 2d_weight_sync ##", opts)
 
         if include_optimizer_state and ctx.optimizer_tensors_by_dtype:
             self._allreduce_tensors(
-                ctx.replica_pg,
+                ctx,
                 ctx.optimizer_tensors_by_dtype,
                 "## 2d_optimizer_sync ##",
                 opts,
@@ -1432,7 +1503,7 @@ class DMPCollection(DistributedModelParallel):
 
     def _allreduce_tensors(
         self,
-        pg: dist.ProcessGroup,
+        ctx: DMPCollectionContext,
         tensors_dict: Dict[torch.dtype, List[torch.Tensor]],
         annotation: str,
         opts: Optional[dist.AllreduceCoalescedOptions] = None,
@@ -1443,20 +1514,43 @@ class DMPCollection(DistributedModelParallel):
 
         Collective Communication:
             - allreduce_coalesced on the provided process group (pg)
+
+        For sharded relay mode with 2D sparse parallelism:
+        - Uses FusedShardedRelayMultiGroup for phase-synchronized execution
+        - ALL groups execute in lockstep phases to eliminate XGMI link contention
+        - Single fused blocking call handles all groups in parallel
+
+        Args:
+            ctx: The DMPCollectionContext containing the process group
+            tensors_dict: Dictionary of tensors grouped by dtype
+            annotation: Annotation string for profiling
+            opts: Optional allreduce coalesced options
         """
+        if self._use_sharded_relay and self._sharded_relay_state is not None:
+            # Propagate the reduce op from opts so callers (e.g.
+            # sync_hash_zch_weights) that pass ReduceOp.SUM are honored
+            # instead of being silently averaged.
+            op = opts.reduceOp if opts is not None else dist.ReduceOp.AVG
+            allreduce_tensors_with_sharded_relay(
+                self._sharded_relay_state,
+                tensors_dict,
+                annotation,
+                op=op,
+            )
+            return
 
         custom_all_reduce = self._custom_all_reduce
         if custom_all_reduce is not None:
-
+            # Custom all reduce hook
             def _all_reduce(tensors: List[torch.Tensor]) -> None:
                 with record_function(f"{annotation}_custom_hook"):
                     custom_all_reduce(tensors)
 
         else:
-
+            # Default allreduce_coalesced path (blocking)
             def _all_reduce(tensors: List[torch.Tensor]) -> None:
                 with record_function(annotation):
-                    pg.allreduce_coalesced(tensors, opts=opts).wait()
+                    ctx.replica_pg.allreduce_coalesced(tensors, opts=opts).wait()
 
         for tensor_list in tensors_dict.values():
             _all_reduce(tensor_list)

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.autograd.profiler import record_function
+from torchrec.distributed.comm import get_local_size
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# NOTE: Do NOT add static `import torchcomms` / `from torchcomms import ...` here
+# (or `from caffe2.torch.distributed.fb.sharded_relay_process_group import ...`).
+# This module is reachable from `torchrec.distributed.model_parallel`, which the
+# Module Factory packager pulls into a torch.package. torch.package's static
+# dependency analyzer follows ALL `import` / `from ... import` statements
+# (even when wrapped in try/except), and `torchcomms._comms` /
+# `torchcomms._comms_rcclx` are compiled C-extensions with no `__file__`,
+# which causes packaging to fail with "Module had no __file__ defined".
+# Routing the imports through `importlib.import_module(<string>)` keeps these
+# names out of the AST, so the static analyzer never sees them.
+
+
+def _try_dynamic_import(module_path: str, attr: str) -> Any:
+    """Dynamic import that is invisible to torch.package's static analyzer."""
+    try:
+        return getattr(importlib.import_module(module_path), attr, None)
+    except ImportError:
+        return None
+
+
+def _get_fused_sharded_relay_multi_group_cls() -> Any:
+    return _try_dynamic_import(
+        "caffe2.torch.distributed.fb.sharded_relay_process_group",
+        "FusedShardedRelayMultiGroup",
+    )
+
+
+def _get_torchcomms_new_comm() -> Any:
+    return _try_dynamic_import("torchcomms", "new_comm")
+
+
+@dataclass
+class ShardedRelayState:
+    """
+    Runtime state for fused sharded relay multi-group allreduce.
+
+    Holds all configuration and communicator handles needed to perform
+    phase-synchronized sharded relay allreduce calls. Created once during
+    setup and reused across allreduce calls.
+
+    A single RCCLX communicator is shared across all sparse groups. The
+    phase-synchronized batched API handles all groups in one call.
+
+    Flat-concat allreduce design
+    ----------------------------
+    Instead of making N serial allreduce_multi_group calls (one per embedding
+    table), all tensors for the active group are packed into a single flat
+    buffer, ONE fused call is made for all 4 groups simultaneously, and results
+    are unpacked back into the original tensors. This matches the intended
+    usage of the C++ ncclShardedRelayMultiGroupAllReduceImpl kernel.
+
+    Buffer aliasing for helper groups
+    ---------------------------------
+    With phase-synchronized execution, all groups are processed simultaneously,
+    so each helper group MUST have its own buffer (no aliasing across groups).
+    Helper buffers are sized to nActiveRanks × chunkSize (two-slot passthrough),
+    which is much smaller than the full per-group total.  Across the 3 helper
+    groups per rank (in a 4-group topology), the total helper memory is
+    6 × chunkSize per rank.
+
+    Caches
+    ------
+    _active_flat_cache : per-dtype grow-only flat buffer for the active group.
+        Used as the pack/allreduce/unpack buffer. Keyed by dtype so weights
+        (bf16) and optimizer states (fp32) each have their own buffer.
+
+    _helper_flat_cache : per-(group_idx, dtype) grow-only flat scratch buffer
+        for helper groups. Sized to the passthrough minimum
+        (nActiveRanks × chunkSize) for each group. Each helper group has its
+        own buffer because all groups are processed simultaneously under
+        phase-sync.
+
+    _flat_metadata_cache : per-(annotation+dtype) cached allgather results.
+        Stores per_group_total_counts (total elements per group). Populated
+        on the first call and reused forever — embedding table dimensions are
+        fixed for the entire training run, so the allgather never needs to
+        repeat.
+    """
+
+    # Single FusedShardedRelayMultiGroup for all sparse groups at once.
+    fused: Any
+    intra_node_pytorch_pg: dist.ProcessGroup | None
+    local_rank: int
+    sparse_group_size: int
+    my_sparse_group: int
+    num_sparse_groups: int
+    local_size: int
+    precomputed_active_ranks: list[list[int]]
+    # Single RCCLX comm — held for cleanup via finalize().
+    _rcclx_comm: Any = field(default=None)
+    # Grow-only flat buffer for the active group: dtype → tensor.
+    # Packed before allreduce, unpacked after.
+    _active_flat_cache: dict[torch.dtype, torch.Tensor] = field(default_factory=dict)
+    # Grow-only flat scratch buffer for helper groups: (group_idx, dtype) → tensor.
+    # Each helper group has its own buffer (no aliasing) because phase-sync
+    # processes all groups simultaneously.
+    _helper_flat_cache: dict[tuple[int, torch.dtype], torch.Tensor] = field(
+        default_factory=dict
+    )
+    # Cached allgather metadata: (annotation + str(dtype)) → per_group_total_counts.
+    # Never invalidated — embedding table sizes are fixed throughout training.
+    _flat_metadata_cache: dict[str, list[int]] = field(default_factory=dict)
+
+
+def _validate_sharded_relay_preconditions(
+    use_inter_host_allreduce: bool,
+    sharding_group_size: int,
+    local_size: int,
+) -> bool:
+    """Return True if all preconditions for sharded relay are met.
+
+    Logs a warning and returns False otherwise. This factoring keeps
+    setup_sharded_relay below the C901 complexity threshold by moving the
+    chain of guard returns into a single linear validation step.
+    """
+    if use_inter_host_allreduce:
+        logger.warning(
+            "[TorchRec 2D Parallel] Sharded relay is NOT supported with "
+            "use_inter_host_allreduce=True (replica_pg spans multiple nodes). "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    # The RCCLX C++ kernel (buildShardedRelayRankConfig) requires exactly 2
+    # active ranks per group.  Any other sharding_group_size is unsupported.
+    if sharding_group_size != 2:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Sharded relay requires sharding_group_size=2, "
+            f"but got sharding_group_size={sharding_group_size}. "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    if local_size < 4:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Sharded relay requires at least 4 GPUs "
+            f"per node, but local_size={local_size}. "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    if local_size // sharding_group_size == 0:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Invalid configuration: "
+            f"num_sparse_groups=0 (local_size={local_size}, "
+            f"sparse_group_size={sharding_group_size}). "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    return True
+
+
+def _create_intra_node_rcclx_comm(
+    global_rank: int,
+    local_rank: int,
+    local_size: int,
+    my_node_idx: int,
+) -> Any | None:
+    """Create the shared 8-rank intra-node RCCLX comm.
+
+    Returns the comm object or None on failure. Wraps the env-var override
+    needed to make ``new_comm`` create an intra-node (not world-size) comm.
+    """
+    import os
+
+    torchcomms_new_comm = _get_torchcomms_new_comm()
+    if torchcomms_new_comm is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] Intra-node RCCLX comm not available. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    global_store = dist.distributed_c10d._get_default_store()
+    if global_store is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] No default store available for RCCLX "
+            "comm creation. Disabling sharded relay mode."
+        )
+        return None
+
+    device = torch.device(f"cuda:{local_rank}")
+    comm_name_base = f"sharded_relay_node{my_node_idx}"
+
+    orig_tc_rank = os.environ.get("TORCHCOMM_RANK")
+    orig_tc_size = os.environ.get("TORCHCOMM_SIZE")
+    try:
+        # Override rank/size so new_comm creates an 8-rank comm (not 64-rank).
+        os.environ["TORCHCOMM_RANK"] = str(local_rank)
+        os.environ["TORCHCOMM_SIZE"] = str(local_size)
+        group_store = dist.PrefixStore(f"rcclx_intra_{my_node_idx}", global_store)
+        rcclx_comm = torchcomms_new_comm(
+            backend="rcclx",
+            device=device,
+            name=comm_name_base,
+            store=group_store,
+        )
+    finally:
+        if orig_tc_rank is None:
+            os.environ.pop("TORCHCOMM_RANK", None)
+        else:
+            os.environ["TORCHCOMM_RANK"] = orig_tc_rank
+        if orig_tc_size is None:
+            os.environ.pop("TORCHCOMM_SIZE", None)
+        else:
+            os.environ["TORCHCOMM_SIZE"] = orig_tc_size
+
+    if rcclx_comm is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] new_comm() returned None for "
+            "intra-node RCCLX comm. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    logger.info(
+        f"[TorchRec 2D Parallel] Intra-node RCCLX comm created "
+        f"(single shared comm for all groups): "
+        f"global_rank={global_rank}, "
+        f"node_idx={my_node_idx}, "
+        f"local_rank_in_comm={rcclx_comm.get_rank()}, "
+        f"comm_size={rcclx_comm.get_size()}"
+    )
+    return rcclx_comm
+
+
+def _create_intra_node_pytorch_pg(
+    global_rank: int,
+    local_size: int,
+    num_nodes: int,
+    my_node_idx: int,
+) -> dist.ProcessGroup | None:
+    """Create intra-node PyTorch ProcessGroups for allgather metadata.
+
+    IMPORTANT: ``dist.new_group()`` is COLLECTIVE — every rank must call it
+    for every node's group, even if only one node ends up using its own.
+    Returns this rank's intra-node PG, or None if creation failed.
+    """
+    intra_node_pytorch_pg: dist.ProcessGroup | None = None
+    try:
+        for node_idx in range(num_nodes):
+            node_ranks = list(range(node_idx * local_size, (node_idx + 1) * local_size))
+            pg = dist.new_group(ranks=node_ranks)
+            if node_idx == my_node_idx:
+                intra_node_pytorch_pg = pg
+        if intra_node_pytorch_pg is not None:
+            logger.info(
+                f"[TorchRec 2D Parallel] Created intra-node ProcessGroup: "
+                f"global_rank={global_rank}, node_idx={my_node_idx}, "
+                f"pg_size={local_size}"
+            )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create intra-node ProcessGroup: {e}. "
+            "Will fall back to local tensor sizes only."
+        )
+        return None
+    return intra_node_pytorch_pg
+
+
+def setup_sharded_relay(
+    global_rank: int,
+    world_size: int,
+    use_inter_host_allreduce: bool,
+    sharding_group_size: int = 2,
+) -> ShardedRelayState | None:
+    """
+    Set up fused sharded relay for 2D sparse parallelism.
+
+    Creates the RCCLX communicators and FusedShardedRelayMultiGroup needed
+    for phase-synchronized multi-group allreduce. Returns None if any
+    precondition fails (disabling sharded relay).
+
+    Args:
+        global_rank: Global rank of this process across all nodes.
+        world_size: Total number of ranks (all nodes combined).
+        use_inter_host_allreduce: If True, sharded relay is not supported.
+        sharding_group_size: Number of active ranks per sparse group. The
+            underlying C++ kernel requires exactly 2; any other value disables
+            sharded relay.
+
+    Returns:
+        ShardedRelayState on success, None to disable sharded relay.
+    """
+    fused_cls = _get_fused_sharded_relay_multi_group_cls()
+    if fused_cls is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] FusedShardedRelayMultiGroup not available. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    local_size = get_local_size(world_size)
+    local_rank = global_rank % local_size
+
+    if not _validate_sharded_relay_preconditions(
+        use_inter_host_allreduce, sharding_group_size, local_size
+    ):
+        return None
+
+    sparse_group_size = sharding_group_size
+    num_sparse_groups = local_size // sparse_group_size
+
+    logger.info(
+        f"[TorchRec 2D Parallel] sparse_group_size={sparse_group_size}, "
+        f"num_sparse_groups={num_sparse_groups}, local_size={local_size}"
+    )
+
+    my_node_idx = global_rank // local_size
+    num_nodes = world_size // local_size
+
+    logger.info(
+        f"[TorchRec 2D Parallel] Setting up fused sharded relay: "
+        f"global_rank={global_rank}, num_sparse_groups={num_sparse_groups}, "
+        f"num_nodes={num_nodes}"
+    )
+
+    try:
+        rcclx_comm = _create_intra_node_rcclx_comm(
+            global_rank, local_rank, local_size, my_node_idx
+        )
+        if rcclx_comm is None:
+            return None
+        intra_node_pytorch_pg = _create_intra_node_pytorch_pg(
+            global_rank, local_size, num_nodes, my_node_idx
+        )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create RCCLX comm: {e}. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    # Build per-group active ranks list using LOCAL ranks
+    all_active_ranks_list: list[list[int]] = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+
+    # Create ONE FusedShardedRelayMultiGroup for ALL sparse groups at once.
+    try:
+        fused = fused_cls(
+            rcclx_comm=rcclx_comm,
+            world_size=local_size,
+            rank=local_rank,
+            all_active_ranks=all_active_ranks_list,
+        )
+        logger.info(
+            f"[TorchRec 2D Parallel] Created FusedShardedRelayMultiGroup "
+            f"(single instance for all {num_sparse_groups} groups): "
+            f"global_rank={global_rank}, local_rank={local_rank}, "
+            f"all_active_ranks={all_active_ranks_list}"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create FusedShardedRelayMultiGroup: {e}. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    return ShardedRelayState(
+        fused=fused,
+        intra_node_pytorch_pg=intra_node_pytorch_pg,
+        local_rank=local_rank,
+        sparse_group_size=sparse_group_size,
+        my_sparse_group=local_rank // sparse_group_size,
+        num_sparse_groups=num_sparse_groups,
+        local_size=local_size,
+        precomputed_active_ranks=all_active_ranks_list,
+        _rcclx_comm=rcclx_comm,
+    )
+
+
+def cleanup_sharded_relay(state: ShardedRelayState) -> None:
+    """
+    Properly finalize RCCLX communicators to avoid thread cleanup issues.
+
+    Cleanup order:
+    1. Clear the FusedShardedRelayMultiGroup instance (it holds a comm reference)
+    2. Finalize the shared intra-node RCCLX comm
+    """
+    state.fused = None
+
+    if state._rcclx_comm is not None:
+        try:
+            state._rcclx_comm.finalize()
+        except Exception as e:
+            logger.warning(f"[TorchRec 2D Parallel] Error finalizing RCCLX comm: {e}")
+    state._rcclx_comm = None
+
+
+def _get_active_flat_buf(
+    state: ShardedRelayState,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat buffer for the active group.
+
+    Reuses the cached buffer if it is large enough; reallocates (and caches
+    the new larger buffer) only when the total element count has grown.
+    """
+    existing = state._active_flat_cache.get(dtype)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._active_flat_cache[dtype] = torch.empty(total, dtype=dtype, device=device)
+    buf = state._active_flat_cache[dtype]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _get_helper_flat_buf(
+    state: ShardedRelayState,
+    group_idx: int,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat scratch buffer for a specific helper group.
+
+    Keyed by (group_idx, dtype) because phase-sync processes all groups
+    simultaneously — each helper group needs its own buffer.  Weights (bf16)
+    and optimizer states (fp32) have separate buffers and do not evict each
+    other across training steps.
+
+    The buffer is sized to ``total``, which should be
+    _passthrough_helper_size(per_group_total_counts[g], ...).
+    """
+    key = (group_idx, dtype)
+    existing = state._helper_flat_cache.get(key)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._helper_flat_cache[key] = torch.empty(total, dtype=dtype, device=device)
+    buf = state._helper_flat_cache[key]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _passthrough_helper_size(
+    total_g: int,
+    sparse_group_size: int,
+    num_chunks: int,
+) -> int:
+    """Compute the passthrough helper buffer size for one group.
+
+    Returns the allocation size (in elements) for the two-slot passthrough
+    helper buffer:
+
+        min(total_g, sparse_group_size × chunk_aligned)
+
+    where chunk_aligned = (total_g // num_chunks) rounded down to
+    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to total_g when
+    total_g < num_chunks × 128.
+
+    This is the canonical Python-side mirror of the C++ ``minRequired``
+    formula in TorchCommRCCLX.cpp.
+    """
+    CHUNK_ALIGN_ELEMENTS = 128
+    chunk = total_g // num_chunks
+    chunk_aligned = (chunk // CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS
+    if chunk_aligned == 0:
+        chunk_aligned = total_g
+    return min(total_g, sparse_group_size * chunk_aligned)
+
+
+def allreduce_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+    op: dist.ReduceOp = dist.ReduceOp.AVG,
+) -> None:
+    """
+    Perform allreduce using the fused sharded relay algorithm.
+
+    Flat-concat approach — one fused call per dtype
+    ------------------------------------------------
+    For each dtype present in ``tensors_dict``:
+
+    1. **Pack**: copy all of the active group's tensors for this dtype into a
+       single contiguous flat buffer (device-to-device HBM copy).
+
+    2. **Metadata** (first call only): run one ``dist.all_gather`` to learn
+       the total flat size for each group, then cache the result permanently.
+       Embedding table dimensions are fixed throughout training, so this
+       allgather never needs to repeat.
+
+    3. **Build group tensors**: active group → flat pack buffer; each helper
+       group → grow-only flat scratch buffer sized to that group's total.
+
+    4. **One fused call**: ``allreduce_multi_group`` with 4 big flat buffers,
+       one per sparse group.  All groups execute in lockstep phases
+       (phase-synchronized), eliminating XGMI link contention.
+
+    5. **Unpack**: copy allreduced values from the flat buffer back into each
+       original tensor (device-to-device HBM copy).
+
+    The two HBM copies (pack + unpack) add ~0.3 ms for ~200 MB of data at
+    1.3 TB/s — negligible compared to eliminating ~100 serial kernel launches.
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        tensors_dict: Tensors to allreduce, grouped by dtype.
+        annotation: Profiling annotation string for record_function.
+        op: Reduction op to apply. Only ``ReduceOp.AVG`` and ``ReduceOp.SUM``
+            are supported by the underlying RCCLX kernel; other values will
+            be rejected by the backend.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    with record_function(f"{annotation}_fused_sharded_relay"):
+        for dtype, my_tensor_list in tensors_dict.items():
+            if not my_tensor_list:
+                continue
+
+            my_total = sum(t.numel() for t in my_tensor_list)
+            if my_total == 0:
+                continue
+
+            device = my_tensor_list[0].device
+
+            # --- Step 1: Pack ---
+            # torch.cat(out=) writes all tensors into the pre-allocated flat
+            # buffer in a single fused CUDA kernel, replacing N individual
+            # copy_() calls (N = number of embedding tables, typically 101 for
+            # BM-FM).  Each copy_() incurs a separate kernel launch (~1-5μs on
+            # AMD); fusing them into one eliminates ~100 launches for pack.
+            active_flat = _get_active_flat_buf(state, my_total, dtype, device)
+            torch.cat(
+                [t.flatten() for t in my_tensor_list],
+                out=active_flat,
+            )
+
+            # --- Step 2: Metadata (allgather once, cache forever) ---
+            meta_key = annotation + str(dtype)
+            per_group_total_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_total_tensor = torch.tensor(
+                        [my_total], dtype=torch.int64, device=device
+                    )
+                    all_totals_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_totals_list,
+                        my_total_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_total_counts = [
+                        int(all_totals_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same total element count."
+                    )
+                    per_group_total_counts = [my_total] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_total_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat allreduce metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_total_counts={per_group_total_counts}"
+                )
+            else:
+                per_group_total_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build group tensor list ---
+            group_tensors: list[torch.Tensor] = []
+            group_sizes: list[int] = []
+
+            # Compute num_chunks for passthrough helper size (mirrors C++).
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    group_tensors.append(active_flat)
+                    group_sizes.append(my_total)
+                else:
+                    total_g = per_group_total_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        total_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    group_tensors.append(helper_buf)
+                    group_sizes.append(total_g)  # full count goes to the kernel
+
+            # --- Step 4: ONE fused call — all groups, all data, phase-synchronized ---
+            state.fused.allreduce_multi_group(
+                tensors=group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_sizes=group_sizes,
+                all_active_ranks=precomputed_active_ranks,
+                op=op,
+                skip_validation=True,
+            )
+
+            # --- Step 5: Unpack ---
+            # torch._foreach_copy_ dispatches all N copies as a single batched
+            # operation, replacing N individual copy_() calls.  The split()
+            # produces views (no allocation), so this is still a pure HBM copy
+            # but with a single kernel launch instead of N.
+            slices = active_flat.split([t.numel() for t in my_tensor_list])
+            torch._foreach_copy_(
+                my_tensor_list,
+                [s.view(t.shape) for s, t in zip(slices, my_tensor_list)],
+            )

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# NOTE: Do NOT add `from __future__ import annotations` here.
+# This module is loaded inside a torch.package at model-publish time. Combining
+# PEP 563 (string annotations) with @dataclass on Python 3.12 hits
+# https://github.com/python/cpython/issues/115258 — `dataclass._is_type` does
+# `sys.modules.get(cls.__module__).__dict__`, which returns None for
+# torch.package-synthetic module names ("<torch_package_N>.…") and crashes with
+# AttributeError. Keeping annotations as runtime objects avoids that path.
+
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.autograd.profiler import record_function
+from torchrec.distributed.comm import get_local_size
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# NOTE: Do NOT add static `import torchcomms` / `from torchcomms import ...` here
+# (or `from caffe2.torch.distributed.fb.sharded_relay_process_group import ...`).
+# This module is reachable from `torchrec.distributed.model_parallel`, which the
+# Module Factory packager pulls into a torch.package. torch.package's static
+# dependency analyzer follows ALL `import` / `from ... import` statements
+# (even when wrapped in try/except), and `torchcomms._comms` /
+# `torchcomms._comms_rcclx` are compiled C-extensions with no `__file__`,
+# which causes packaging to fail with "Module had no __file__ defined".
+# Routing the imports through `importlib.import_module(<string>)` keeps these
+# names out of the AST, so the static analyzer never sees them.
+
+
+def _try_dynamic_import(module_path: str, attr: str) -> Any:
+    """Dynamic import that is invisible to torch.package's static analyzer."""
+    try:
+        return getattr(importlib.import_module(module_path), attr, None)
+    except ImportError:
+        return None
+
+
+def _get_fused_sharded_relay_multi_group_cls() -> Any:
+    return _try_dynamic_import(
+        "caffe2.torch.distributed.fb.sharded_relay_process_group",
+        "FusedShardedRelayMultiGroup",
+    )
+
+
+def _get_torchcomms_new_comm() -> Any:
+    return _try_dynamic_import("torchcomms", "new_comm")
+
+
+@dataclass
+class ShardedRelayState:
+    """
+    Runtime state for fused sharded relay multi-group allreduce.
+
+    Holds all configuration and communicator handles needed to perform
+    phase-synchronized sharded relay allreduce calls. Created once during
+    setup and reused across allreduce calls.
+
+    A single RCCLX communicator is shared across all sparse groups. The
+    phase-synchronized batched API handles all groups in one call.
+
+    Flat-concat allreduce design
+    ----------------------------
+    Instead of making N serial allreduce_multi_group calls (one per embedding
+    table), all tensors for the active group are packed into a single flat
+    buffer, ONE fused call is made for all 4 groups simultaneously, and results
+    are unpacked back into the original tensors. This matches the intended
+    usage of the C++ ncclShardedRelayMultiGroupAllReduceImpl kernel.
+
+    Buffer aliasing for helper groups
+    ---------------------------------
+    With phase-synchronized execution, all groups are processed simultaneously,
+    so each helper group MUST have its own buffer (no aliasing across groups).
+    Helper buffers are sized to nActiveRanks × chunkSize (two-slot passthrough),
+    which is much smaller than the full per-group total.  Across the 3 helper
+    groups per rank (in a 4-group topology), the total helper memory is
+    6 × chunkSize per rank.
+
+    Caches
+    ------
+    _active_flat_cache : per-dtype grow-only flat buffer for the active group.
+        Used as the pack/allreduce/unpack buffer. Keyed by dtype so weights
+        (bf16) and optimizer states (fp32) each have their own buffer.
+
+    _helper_flat_cache : per-(group_idx, dtype) grow-only flat scratch buffer
+        for helper groups. Sized to the passthrough minimum
+        (nActiveRanks × chunkSize) for each group. Each helper group has its
+        own buffer because all groups are processed simultaneously under
+        phase-sync.
+
+    _flat_metadata_cache : per-(annotation+dtype) cached allgather results.
+        Stores per_group_total_counts (total elements per group). Populated
+        on the first call and reused forever — embedding table dimensions are
+        fixed for the entire training run, so the allgather never needs to
+        repeat.
+    """
+
+    # Single FusedShardedRelayMultiGroup for all sparse groups at once.
+    fused: Any
+    intra_node_pytorch_pg: dist.ProcessGroup | None
+    local_rank: int
+    sparse_group_size: int
+    my_sparse_group: int
+    num_sparse_groups: int
+    local_size: int
+    precomputed_active_ranks: list[list[int]]
+    # Single RCCLX comm — held for cleanup via finalize().
+    _rcclx_comm: Any = field(default=None)
+    # Grow-only flat buffer for the active group: dtype → tensor.
+    # Packed before allreduce, unpacked after.
+    _active_flat_cache: dict[torch.dtype, torch.Tensor] = field(default_factory=dict)
+    # Grow-only flat scratch buffer for helper groups: (group_idx, dtype) → tensor.
+    # Each helper group has its own buffer (no aliasing) because phase-sync
+    # processes all groups simultaneously.
+    _helper_flat_cache: dict[tuple[int, torch.dtype], torch.Tensor] = field(
+        default_factory=dict
+    )
+    # Cached allgather metadata: (annotation + str(dtype)) → per_group_total_counts.
+    # Never invalidated — embedding table sizes are fixed throughout training.
+    _flat_metadata_cache: dict[str, list[int]] = field(default_factory=dict)
+
+
+def _validate_sharded_relay_preconditions(
+    use_inter_host_allreduce: bool,
+    sharding_group_size: int,
+    local_size: int,
+) -> bool:
+    """Return True if all preconditions for sharded relay are met.
+
+    Logs a warning and returns False otherwise. This factoring keeps
+    setup_sharded_relay below the C901 complexity threshold by moving the
+    chain of guard returns into a single linear validation step.
+    """
+    if use_inter_host_allreduce:
+        logger.warning(
+            "[TorchRec 2D Parallel] Sharded relay is NOT supported with "
+            "use_inter_host_allreduce=True (replica_pg spans multiple nodes). "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    # The RCCLX C++ kernel (buildShardedRelayRankConfig) requires exactly 2
+    # active ranks per group.  Any other sharding_group_size is unsupported.
+    if sharding_group_size != 2:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Sharded relay requires sharding_group_size=2, "
+            f"but got sharding_group_size={sharding_group_size}. "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    if local_size < 4:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Sharded relay requires at least 4 GPUs "
+            f"per node, but local_size={local_size}. "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    if local_size // sharding_group_size == 0:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Invalid configuration: "
+            f"num_sparse_groups=0 (local_size={local_size}, "
+            f"sparse_group_size={sharding_group_size}). "
+            "Disabling sharded relay mode."
+        )
+        return False
+
+    return True
+
+
+def _create_intra_node_rcclx_comm(
+    global_rank: int,
+    local_rank: int,
+    local_size: int,
+    my_node_idx: int,
+) -> Any | None:
+    """Create the shared 8-rank intra-node RCCLX comm.
+
+    Returns the comm object or None on failure. Wraps the env-var override
+    needed to make ``new_comm`` create an intra-node (not world-size) comm.
+    """
+    import os
+
+    torchcomms_new_comm = _get_torchcomms_new_comm()
+    if torchcomms_new_comm is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] Intra-node RCCLX comm not available. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    global_store = dist.distributed_c10d._get_default_store()
+    if global_store is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] No default store available for RCCLX "
+            "comm creation. Disabling sharded relay mode."
+        )
+        return None
+
+    device = torch.device(f"cuda:{local_rank}")
+    comm_name_base = f"sharded_relay_node{my_node_idx}"
+
+    orig_tc_rank = os.environ.get("TORCHCOMM_RANK")
+    orig_tc_size = os.environ.get("TORCHCOMM_SIZE")
+    try:
+        # Override rank/size so new_comm creates an 8-rank comm (not 64-rank).
+        os.environ["TORCHCOMM_RANK"] = str(local_rank)
+        os.environ["TORCHCOMM_SIZE"] = str(local_size)
+        group_store = dist.PrefixStore(f"rcclx_intra_{my_node_idx}", global_store)
+        rcclx_comm = torchcomms_new_comm(
+            backend="rcclx",
+            device=device,
+            name=comm_name_base,
+            store=group_store,
+        )
+    finally:
+        if orig_tc_rank is None:
+            os.environ.pop("TORCHCOMM_RANK", None)
+        else:
+            os.environ["TORCHCOMM_RANK"] = orig_tc_rank
+        if orig_tc_size is None:
+            os.environ.pop("TORCHCOMM_SIZE", None)
+        else:
+            os.environ["TORCHCOMM_SIZE"] = orig_tc_size
+
+    if rcclx_comm is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] new_comm() returned None for "
+            "intra-node RCCLX comm. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    logger.info(
+        f"[TorchRec 2D Parallel] Intra-node RCCLX comm created "
+        f"(single shared comm for all groups): "
+        f"global_rank={global_rank}, "
+        f"node_idx={my_node_idx}, "
+        f"local_rank_in_comm={rcclx_comm.get_rank()}, "
+        f"comm_size={rcclx_comm.get_size()}"
+    )
+    return rcclx_comm
+
+
+def _create_intra_node_pytorch_pg(
+    global_rank: int,
+    local_size: int,
+    num_nodes: int,
+    my_node_idx: int,
+) -> dist.ProcessGroup | None:
+    """Create intra-node PyTorch ProcessGroups for allgather metadata.
+
+    IMPORTANT: ``dist.new_group()`` is COLLECTIVE — every rank must call it
+    for every node's group, even if only one node ends up using its own.
+    Returns this rank's intra-node PG, or None if creation failed.
+    """
+    intra_node_pytorch_pg: dist.ProcessGroup | None = None
+    try:
+        for node_idx in range(num_nodes):
+            node_ranks = list(range(node_idx * local_size, (node_idx + 1) * local_size))
+            pg = dist.new_group(ranks=node_ranks)
+            if node_idx == my_node_idx and isinstance(pg, dist.ProcessGroup):
+                intra_node_pytorch_pg = pg
+        if intra_node_pytorch_pg is not None:
+            logger.info(
+                f"[TorchRec 2D Parallel] Created intra-node ProcessGroup: "
+                f"global_rank={global_rank}, node_idx={my_node_idx}, "
+                f"pg_size={local_size}"
+            )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create intra-node ProcessGroup: {e}. "
+            "Will fall back to local tensor sizes only."
+        )
+        return None
+    return intra_node_pytorch_pg
+
+
+def setup_sharded_relay(
+    global_rank: int,
+    world_size: int,
+    use_inter_host_allreduce: bool,
+    sharding_group_size: int = 2,
+) -> ShardedRelayState | None:
+    """
+    Set up fused sharded relay for 2D sparse parallelism.
+
+    Creates the RCCLX communicators and FusedShardedRelayMultiGroup needed
+    for phase-synchronized multi-group allreduce. Returns None if any
+    precondition fails (disabling sharded relay).
+
+    Args:
+        global_rank: Global rank of this process across all nodes.
+        world_size: Total number of ranks (all nodes combined).
+        use_inter_host_allreduce: If True, sharded relay is not supported.
+        sharding_group_size: Number of active ranks per sparse group. The
+            underlying C++ kernel requires exactly 2; any other value disables
+            sharded relay.
+
+    Returns:
+        ShardedRelayState on success, None to disable sharded relay.
+    """
+    fused_cls = _get_fused_sharded_relay_multi_group_cls()
+    if fused_cls is None:
+        logger.warning(
+            "[TorchRec 2D Parallel] FusedShardedRelayMultiGroup not available. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    local_size = get_local_size(world_size)
+    local_rank = global_rank % local_size
+
+    if not _validate_sharded_relay_preconditions(
+        use_inter_host_allreduce, sharding_group_size, local_size
+    ):
+        return None
+
+    sparse_group_size = sharding_group_size
+    num_sparse_groups = local_size // sparse_group_size
+
+    logger.info(
+        f"[TorchRec 2D Parallel] sparse_group_size={sparse_group_size}, "
+        f"num_sparse_groups={num_sparse_groups}, local_size={local_size}"
+    )
+
+    my_node_idx = global_rank // local_size
+    num_nodes = world_size // local_size
+
+    logger.info(
+        f"[TorchRec 2D Parallel] Setting up fused sharded relay: "
+        f"global_rank={global_rank}, num_sparse_groups={num_sparse_groups}, "
+        f"num_nodes={num_nodes}"
+    )
+
+    try:
+        rcclx_comm = _create_intra_node_rcclx_comm(
+            global_rank, local_rank, local_size, my_node_idx
+        )
+        if rcclx_comm is None:
+            return None
+        intra_node_pytorch_pg = _create_intra_node_pytorch_pg(
+            global_rank, local_size, num_nodes, my_node_idx
+        )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create RCCLX comm: {e}. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    # Build per-group active ranks list using LOCAL ranks
+    all_active_ranks_list: list[list[int]] = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+
+    # Create ONE FusedShardedRelayMultiGroup for ALL sparse groups at once.
+    try:
+        fused = fused_cls(
+            rcclx_comm=rcclx_comm,
+            world_size=local_size,
+            rank=local_rank,
+            all_active_ranks=all_active_ranks_list,
+        )
+        logger.info(
+            f"[TorchRec 2D Parallel] Created FusedShardedRelayMultiGroup "
+            f"(single instance for all {num_sparse_groups} groups): "
+            f"global_rank={global_rank}, local_rank={local_rank}, "
+            f"all_active_ranks={all_active_ranks_list}"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[TorchRec 2D Parallel] Failed to create FusedShardedRelayMultiGroup: {e}. "
+            "Disabling sharded relay mode."
+        )
+        return None
+
+    return ShardedRelayState(
+        fused=fused,
+        intra_node_pytorch_pg=intra_node_pytorch_pg,
+        local_rank=local_rank,
+        sparse_group_size=sparse_group_size,
+        my_sparse_group=local_rank // sparse_group_size,
+        num_sparse_groups=num_sparse_groups,
+        local_size=local_size,
+        precomputed_active_ranks=all_active_ranks_list,
+        _rcclx_comm=rcclx_comm,
+    )
+
+
+def cleanup_sharded_relay(state: ShardedRelayState) -> None:
+    """
+    Properly finalize RCCLX communicators to avoid thread cleanup issues.
+
+    Cleanup order:
+    1. Clear the FusedShardedRelayMultiGroup instance (it holds a comm reference)
+    2. Finalize the shared intra-node RCCLX comm
+    """
+    state.fused = None
+
+    if state._rcclx_comm is not None:
+        try:
+            state._rcclx_comm.finalize()
+        except Exception as e:
+            logger.warning(f"[TorchRec 2D Parallel] Error finalizing RCCLX comm: {e}")
+    state._rcclx_comm = None
+
+
+def _get_active_flat_buf(
+    state: ShardedRelayState,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat buffer for the active group.
+
+    Reuses the cached buffer if it is large enough; reallocates (and caches
+    the new larger buffer) only when the total element count has grown.
+    """
+    existing = state._active_flat_cache.get(dtype)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._active_flat_cache[dtype] = torch.empty(total, dtype=dtype, device=device)
+    buf = state._active_flat_cache[dtype]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _get_helper_flat_buf(
+    state: ShardedRelayState,
+    group_idx: int,
+    total: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a grow-only flat scratch buffer for a specific helper group.
+
+    Keyed by (group_idx, dtype) because phase-sync processes all groups
+    simultaneously — each helper group needs its own buffer.  Weights (bf16)
+    and optimizer states (fp32) have separate buffers and do not evict each
+    other across training steps.
+
+    The buffer is sized to ``total``, which should be
+    _passthrough_helper_size(per_group_total_counts[g], ...).
+    """
+    key = (group_idx, dtype)
+    existing = state._helper_flat_cache.get(key)
+    if existing is None or existing.numel() < total or existing.device != device:
+        state._helper_flat_cache[key] = torch.empty(total, dtype=dtype, device=device)
+    buf = state._helper_flat_cache[key]
+    return buf if buf.numel() == total else buf.narrow(0, 0, total)
+
+
+def _passthrough_helper_size(
+    total_g: int,
+    sparse_group_size: int,
+    num_chunks: int,
+) -> int:
+    """Compute the passthrough helper buffer size for one group.
+
+    Returns the allocation size (in elements) for the two-slot passthrough
+    helper buffer:
+
+        min(total_g, sparse_group_size × chunk_aligned)
+
+    where chunk_aligned = (total_g // num_chunks) rounded down to
+    CHUNK_ALIGN_ELEMENTS = 128 elements, falling back to total_g when
+    total_g < num_chunks × 128.
+
+    This is the canonical Python-side mirror of the C++ ``minRequired``
+    formula in TorchCommRCCLX.cpp.
+    """
+    CHUNK_ALIGN_ELEMENTS = 128
+    chunk = total_g // num_chunks
+    chunk_aligned = (chunk // CHUNK_ALIGN_ELEMENTS) * CHUNK_ALIGN_ELEMENTS
+    if chunk_aligned == 0:
+        chunk_aligned = total_g
+    return min(total_g, sparse_group_size * chunk_aligned)
+
+
+def allreduce_tensors_with_sharded_relay(
+    state: ShardedRelayState,
+    tensors_dict: dict[torch.dtype, list[torch.Tensor]],
+    annotation: str,
+    op: dist.ReduceOp = dist.ReduceOp.AVG,
+) -> None:
+    """
+    Perform allreduce using the fused sharded relay algorithm.
+
+    Flat-concat approach — one fused call per dtype
+    ------------------------------------------------
+    For each dtype present in ``tensors_dict``:
+
+    1. **Pack**: copy all of the active group's tensors for this dtype into a
+       single contiguous flat buffer (device-to-device HBM copy).
+
+    2. **Metadata** (first call only): run one ``dist.all_gather`` to learn
+       the total flat size for each group, then cache the result permanently.
+       Embedding table dimensions are fixed throughout training, so this
+       allgather never needs to repeat.
+
+    3. **Build group tensors**: active group → flat pack buffer; each helper
+       group → grow-only flat scratch buffer sized to that group's total.
+
+    4. **One fused call**: ``allreduce_multi_group`` with 4 big flat buffers,
+       one per sparse group.  All groups execute in lockstep phases
+       (phase-synchronized), eliminating XGMI link contention.
+
+    5. **Unpack**: copy allreduced values from the flat buffer back into each
+       original tensor (device-to-device HBM copy).
+
+    The two HBM copies (pack + unpack) add ~0.3 ms for ~200 MB of data at
+    1.3 TB/s — negligible compared to eliminating ~100 serial kernel launches.
+
+    Args:
+        state: Sharded relay runtime state (pre-computed invariants + comms).
+        tensors_dict: Tensors to allreduce, grouped by dtype.
+        annotation: Profiling annotation string for record_function.
+        op: Reduction op to apply. Only ``ReduceOp.AVG`` and ``ReduceOp.SUM``
+            are supported by the underlying RCCLX kernel; other values will
+            be rejected by the backend.
+    """
+    sparse_group_size = state.sparse_group_size
+    my_sparse_group = state.my_sparse_group
+    num_sparse_groups = state.num_sparse_groups
+    local_size = state.local_size
+    precomputed_active_ranks = state.precomputed_active_ranks
+
+    with record_function(f"{annotation}_fused_sharded_relay"):
+        for dtype, my_tensor_list in tensors_dict.items():
+            if not my_tensor_list:
+                continue
+
+            my_total = sum(t.numel() for t in my_tensor_list)
+            if my_total == 0:
+                continue
+
+            device = my_tensor_list[0].device
+
+            # --- Step 1: Pack ---
+            # torch.cat(out=) writes all tensors into the pre-allocated flat
+            # buffer in a single fused CUDA kernel, replacing N individual
+            # copy_() calls (N = number of embedding tables, typically 101 for
+            # BM-FM).  Each copy_() incurs a separate kernel launch (~1-5μs on
+            # AMD); fusing them into one eliminates ~100 launches for pack.
+            active_flat = _get_active_flat_buf(state, my_total, dtype, device)
+            torch.cat(
+                [t.flatten() for t in my_tensor_list],
+                out=active_flat,
+            )
+
+            # --- Step 2: Metadata (allgather once, cache forever) ---
+            meta_key = annotation + str(dtype)
+            per_group_total_counts: list[int]
+
+            if meta_key not in state._flat_metadata_cache:
+                if state.intra_node_pytorch_pg is not None:
+                    my_total_tensor = torch.tensor(
+                        [my_total], dtype=torch.int64, device=device
+                    )
+                    all_totals_list = [
+                        torch.zeros(1, dtype=torch.int64, device=device)
+                        for _ in range(local_size)
+                    ]
+                    dist.all_gather(
+                        all_totals_list,
+                        my_total_tensor,
+                        group=state.intra_node_pytorch_pg,
+                    )
+                    per_group_total_counts = [
+                        int(all_totals_list[g * sparse_group_size].item())
+                        for g in range(num_sparse_groups)
+                    ]
+                else:
+                    logger.warning(
+                        "[TorchRec 2D Parallel] no intra_node_pytorch_pg! "
+                        "Assuming all groups have the same total element count."
+                    )
+                    per_group_total_counts = [my_total] * num_sparse_groups
+
+                state._flat_metadata_cache[meta_key] = per_group_total_counts
+                logger.info(
+                    f"[TorchRec 2D Parallel] flat allreduce metadata cached: "
+                    f"annotation={annotation!r}, dtype={dtype}, "
+                    f"per_group_total_counts={per_group_total_counts}"
+                )
+            else:
+                per_group_total_counts = state._flat_metadata_cache[meta_key]
+
+            # --- Step 3: Build group tensor list ---
+            group_tensors: list[torch.Tensor] = []
+            group_sizes: list[int] = []
+
+            # Compute num_chunks for passthrough helper size (mirrors C++).
+            num_chunks = (local_size - sparse_group_size) + 1
+
+            for g in range(num_sparse_groups):
+                if g == my_sparse_group:
+                    group_tensors.append(active_flat)
+                    group_sizes.append(my_total)
+                else:
+                    total_g = per_group_total_counts[g]
+                    helper_size_g = _passthrough_helper_size(
+                        total_g, sparse_group_size, num_chunks
+                    )
+                    helper_buf = _get_helper_flat_buf(
+                        state, g, helper_size_g, dtype, device
+                    )
+                    group_tensors.append(helper_buf)
+                    group_sizes.append(total_g)  # full count goes to the kernel
+
+            # --- Step 4: ONE fused call — all groups, all data, phase-synchronized ---
+            state.fused.allreduce_multi_group(
+                tensors=group_tensors,
+                num_groups=num_sparse_groups,
+                per_group_sizes=group_sizes,
+                all_active_ranks=precomputed_active_ranks,
+                op=op,
+                skip_validation=True,
+            )
+
+            # --- Step 5: Unpack ---
+            # torch._foreach_copy_ dispatches all N copies as a single batched
+            # operation, replacing N individual copy_() calls.  The split()
+            # produces views (no allocation), so this is still a pure HBM copy
+            # but with a single kernel launch instead of N.
+            slices = active_flat.split([t.numel() for t in my_tensor_list])
+            torch._foreach_copy_(
+                my_tensor_list,
+                [s.view(t.shape) for s, t in zip(slices, my_tensor_list)],
+            )

--- a/torchrec/distributed/tests/bench_sharded_relay_perf.py
+++ b/torchrec/distributed/tests/bench_sharded_relay_perf.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Performance benchmark for sharded relay allreduce on MI350X.
+
+Measures and compares four approaches:
+
+  A) COALESCED — allreduce_coalesced on 2-rank sub-group PGs (legacy baseline)
+  B) FUSED     — 1 call with flat-concat buffers + per-group passthrough helpers
+                 (phase-sync kernel: all groups in lockstep, passthrough-at-helper)
+  C) KERNEL    — 1 direct call, one large tensor per group (kernel BW validation)
+  NCCL         — 4 parallel 2-rank dist.all_reduce calls (pre-sharded-relay baseline)
+
+Memory model (phase-sync kernel, passthrough-at-helper, batched forward):
+  Each rank holds:
+    - 1 active flat buffer (= per-group total for its active group)
+    - 3 helper buffers (= nActiveRanks × chunkSize each, passthrough minimum)
+    - 1 relay scratch (= numHelpers × chunkSize, batched recv from all helpers)
+    - 1 direct-exchange scratch (= 1 × directChunkSize)
+  Each helper group has its own buffer (no aliasing) because phase-sync
+  processes all groups simultaneously.
+
+  | Approach                          | Active | Helper          | Scratch         | Total  |
+  |:----------------------------------|-------:|----------------:|----------------:|-------:|
+  | Pre-OOM-fix (phase-sync, reduce)  | 24 GiB | 3×24 = 72 GiB  | ~3.2 GiB        | ~99 GiB|
+  | **Passthrough (batched forward)** | 24 GiB | 3×6.8= 20.6 GiB| ~24 GiB         | ~69 GiB|
+
+BM-FM production numbers (from aps-bm_fm_amd_srinathb_20260420_200640-ea51247ebd):
+  - 64 trainers (8 nodes × 8 GPUs per MI350X node)
+  - 2d_weight_sync (fp16) per_group_total_counts:
+      [12_002_982_488, 12_245_126_152, 12_014_370_640, 12_057_805_952]
+      ≈ 22.4 GiB per group (fp16)
+  - 2d_optimizer_sync (fp32) per_group_total_counts:
+      [479_250_475, 553_440_942, 634_386_550, 560_128_334]
+      ≈ 1.8–2.4 GiB per group (fp32)
+
+The production per-group totals above are the defaults.  Run with no extra flags:
+    buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+        //torchrec/distributed/tests:bench_sharded_relay_perf
+
+Optimizer-sync scale (fp32):
+    BENCH_DTYPE=fp32 buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+        //torchrec/distributed/tests:bench_sharded_relay_perf
+
+Small-scale smoke run (101 tables × 1M elements ≈ 100M per group):
+    BENCH_NUM_TABLES=101 BENCH_TABLE_SIZE=1048576 \\
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+        //torchrec/distributed/tests:bench_sharded_relay_perf
+
+Environment variables (all optional):
+    BENCH_DTYPE          bf16|fp16|fp32   (default: fp16)
+    BENCH_NUM_TABLES     int              (default: 1)
+    BENCH_TABLE_SIZE     int              (default: production total for active group)
+    BENCH_KERNEL_SIZE_GB float            (default: production total for active group)
+    BENCH_WARMUP_ITERS   int              (default: 5)
+    BENCH_BENCH_ITERS    int              (default: 20)
+    BENCH_LOG_SIZES      1                (print sizes and exit; for calibration)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+try:
+    from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+        FusedShardedRelayMultiGroup,
+    )
+
+    FUSED_AVAILABLE: bool = True
+except ImportError:
+    FusedShardedRelayMultiGroup = None  # type: ignore[misc, assignment]
+    FUSED_AVAILABLE = False
+
+try:
+    from torchcomms import new_comm as _torchcomms_new_comm  # type: ignore[import]
+
+    RCCLX_AVAILABLE: bool = True
+except ImportError:
+    _torchcomms_new_comm = None  # type: ignore[misc, assignment]
+    RCCLX_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _env_int(key: str, default: int) -> int:
+    return int(os.environ.get(key, str(default)))
+
+
+def _env_float(key: str, default: float) -> float:
+    return float(os.environ.get(key, str(default)))
+
+
+def _env_str(key: str, default: str) -> str:
+    return os.environ.get(key, default)
+
+
+def _get_dtype() -> torch.dtype:
+    name = _env_str("BENCH_DTYPE", "fp16")
+    return {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[name]
+
+
+# ---------------------------------------------------------------------------
+# Production numbers (defaults)
+# ---------------------------------------------------------------------------
+
+# fp16 weight sync — one total per sparse group (local ranks 0-1, 2-3, 4-5, 6-7)
+_PROD_TOTALS_FP16: list[int] = [
+    12_002_982_488,  # group 0
+    12_245_126_152,  # group 1
+    12_014_370_640,  # group 2
+    12_057_805_952,  # group 3
+]
+
+# fp32 optimizer sync — one total per sparse group
+_PROD_TOTALS_FP32: list[int] = [
+    479_250_475,  # group 0
+    553_440_942,  # group 1
+    634_386_550,  # group 2
+    560_128_334,  # group 3
+]
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_rcclx_comm(
+    local_rank: int, local_size: int, node_idx: int, store: Any
+) -> Any | None:
+    """Create a single 8-rank intra-node RCCLX communicator using the provided store."""
+    if not RCCLX_AVAILABLE or _torchcomms_new_comm is None:
+        return None
+    device = torch.device(f"cuda:{local_rank}")
+
+    orig_rank = os.environ.get("TORCHCOMM_RANK")
+    orig_size = os.environ.get("TORCHCOMM_SIZE")
+    try:
+        os.environ["TORCHCOMM_RANK"] = str(local_rank)
+        os.environ["TORCHCOMM_SIZE"] = str(local_size)
+        group_store = dist.PrefixStore(f"bench_rcclx_node{node_idx}", store)
+        comm = _torchcomms_new_comm(
+            backend="rcclx",
+            device=device,
+            name=f"bench_node{node_idx}",
+            store=group_store,
+        )
+        return comm
+    finally:
+        if orig_rank is None:
+            os.environ.pop("TORCHCOMM_RANK", None)
+        else:
+            os.environ["TORCHCOMM_RANK"] = orig_rank
+        if orig_size is None:
+            os.environ.pop("TORCHCOMM_SIZE", None)
+        else:
+            os.environ["TORCHCOMM_SIZE"] = orig_size
+
+
+def _make_fused(rcclx_comm: Any, local_rank: int, local_size: int) -> Any | None:
+    if FusedShardedRelayMultiGroup is None or rcclx_comm is None:
+        return None
+    sparse_group_size = 2
+    num_sparse_groups = local_size // sparse_group_size
+    all_active_ranks = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+    return FusedShardedRelayMultiGroup(
+        rcclx_comm=rcclx_comm,
+        world_size=local_size,
+        rank=local_rank,
+        all_active_ranks=all_active_ranks,
+    )
+
+
+from torchrec.distributed.sharded_relay_utils import _passthrough_helper_size
+
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Benchmark B: fused flat approach (phase-sync kernel, passthrough helper)
+# ---------------------------------------------------------------------------
+
+
+def bench_fused_flat(
+    fused: Any,
+    my_tensors: list[torch.Tensor],
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    local_size: int,
+    intra_pg: dist.ProcessGroup | None,
+    sparse_group_size: int,
+    flat_bufs: list[torch.Tensor],
+    meta_cache: dict[str, list[int]],
+) -> None:
+    """ONE fused call with all tensors concatenated per group.
+
+    Uses per-group passthrough-sized helper buffers (nActiveRanks × chunkSize).
+    Each helper group has its own buffer — no aliasing — because the
+    phase-sync kernel processes all groups simultaneously.
+    """
+    device = my_tensors[0].device
+    dtype = my_tensors[0].dtype
+    my_total = sum(t.numel() for t in my_tensors)
+
+    # Pack: single fused CUDA kernel via torch.cat(out=) into pre-allocated buffer.
+    active_flat = flat_bufs[my_sparse_group]
+    if active_flat.numel() < my_total:
+        flat_bufs[my_sparse_group] = torch.empty(my_total, dtype=dtype, device=device)
+        active_flat = flat_bufs[my_sparse_group]
+    active_flat = active_flat.narrow(0, 0, my_total)
+    torch.cat([t.flatten() for t in my_tensors], out=active_flat)
+
+    meta_key = "bench" + str(dtype)
+    if meta_key not in meta_cache:
+        if intra_pg is not None:
+            # Use all_gather to learn per-group totals (heterogeneous groups).
+            count_tensor = torch.tensor([my_total], dtype=torch.int64, device=device)
+            all_counts = [
+                torch.zeros(1, dtype=torch.int64, device=device)
+                for _ in range(local_size)
+            ]
+            dist.all_gather(all_counts, count_tensor, group=intra_pg)
+            meta_cache[meta_key] = [
+                int(all_counts[g * sparse_group_size].item())
+                for g in range(num_sparse_groups)
+            ]
+        else:
+            # Bench controls table count: all groups have the same total.
+            meta_cache[meta_key] = [my_total] * num_sparse_groups
+    per_group_totals = meta_cache[meta_key]
+
+    # Compute per-group passthrough helper sizes.
+    num_chunks = (local_size - sparse_group_size) + 1
+
+    group_tensors: list[torch.Tensor] = []
+    group_sizes: list[int] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            group_tensors.append(active_flat)
+            group_sizes.append(my_total)
+        else:
+            total_g = per_group_totals[g]
+            helper_size_g = _passthrough_helper_size(
+                total_g, sparse_group_size, num_chunks
+            )
+            # Ensure the per-group helper buffer in flat_bufs is large enough.
+            if flat_bufs[g].numel() < helper_size_g:
+                flat_bufs[g] = torch.empty(helper_size_g, dtype=dtype, device=device)
+            helper_buf = flat_bufs[g]
+            group_tensors.append(
+                helper_buf
+                if helper_buf.numel() == helper_size_g
+                else helper_buf.narrow(0, 0, helper_size_g)
+            )
+            group_sizes.append(total_g)  # full count goes to the kernel
+
+    fused.allreduce_multi_group(
+        tensors=group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_sizes=group_sizes,
+        all_active_ranks=all_active_ranks,
+        op=dist.ReduceOp.AVG,
+        skip_validation=True,
+    )
+
+    # Unpack: single batched operation via _foreach_copy_.
+    slices = active_flat.split([t.numel() for t in my_tensors])
+    torch._foreach_copy_(
+        my_tensors,
+        [s.view(t.shape) for s, t in zip(slices, my_tensors)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark C: kernel-level direct call
+# ---------------------------------------------------------------------------
+
+
+def bench_kernel_direct(
+    fused: Any,
+    tensor: torch.Tensor,
+    num_sparse_groups: int,
+    my_sparse_group: int,
+    all_active_ranks: list[list[int]],
+    scratch_tensors: list[torch.Tensor],
+    per_group_declared_sizes: list[int] | None = None,
+) -> None:
+    """Direct kernel call with one large tensor per group — kernel BW validation.
+
+    per_group_declared_sizes: the declared element count for each group passed
+    to allreduce_multi_group().  All ranks MUST agree on these values so that
+    the RCCLX kernel computes the same chunkSize on every rank.  When None,
+    falls back to tensor.numel() for all groups (safe only when all groups have
+    the same active tensor size, e.g. the tiny warmup).
+    """
+    group_tensors: list[torch.Tensor] = []
+    group_sizes: list[int] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            group_tensors.append(tensor)
+            group_sizes.append(tensor.numel())
+        else:
+            group_tensors.append(scratch_tensors[g])
+            # Use the caller-supplied declared size for this helper group so
+            # that every rank computes the same chunkSize.  If not provided,
+            # fall back to this rank's tensor size (only correct when all
+            # groups share the same element count).
+            declared = (
+                per_group_declared_sizes[g]
+                if per_group_declared_sizes is not None
+                else tensor.numel()
+            )
+            group_sizes.append(declared)
+
+    fused.allreduce_multi_group(
+        tensors=group_tensors,
+        num_groups=num_sparse_groups,
+        per_group_sizes=group_sizes,
+        all_active_ranks=all_active_ranks,
+        op=dist.ReduceOp.AVG,
+        skip_validation=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NCCL baseline: 4 parallel 2-rank dist.all_reduce calls
+# ---------------------------------------------------------------------------
+
+
+def bench_nccl_baseline(
+    tensor: torch.Tensor,
+    my_pg: dist.ProcessGroup,
+) -> None:
+    """Standard NCCL 2-rank allreduce — pre-sharded-relay baseline."""
+    dist.all_reduce(tensor, group=my_pg, op=dist.ReduceOp.SUM)
+
+
+# ---------------------------------------------------------------------------
+# Timer helper
+# ---------------------------------------------------------------------------
+
+
+def _measure_ms(fn: Any, warmup: int, iters: int) -> tuple[float, float]:
+    """Return (mean_ms, std_ms) over 'iters' calls after 'warmup' warmup runs."""
+    torch.cuda.synchronize()
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times: list[float] = []
+    for _ in range(iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        times.append((time.perf_counter() - t0) * 1000.0)
+
+    mean = sum(times) / len(times)
+    std = (sum((x - mean) ** 2 for x in times) / len(times)) ** 0.5
+    return mean, std
+
+
+# ---------------------------------------------------------------------------
+# Per-rank benchmark worker — mimics _benchmark_worker from the old
+# test_sharded_relay_2d_integration.py pattern:
+#   - receives an explicit TCPStore instead of using _get_default_store()
+#   - sets RANK/WORLD_SIZE/MASTER_ADDR/MASTER_PORT itself
+# ---------------------------------------------------------------------------
+
+NUM_GPUS: int = 8
+_NCCL_PORT: int = 29500
+_TCPSTORE_PORT: int = 29502
+
+
+def _bench_a_worker(rank: int, world_size: int, results_dict: Any) -> None:
+    """Worker for bench A: serial all_reduce on isolated 2-rank sub-group PGs.
+
+    Runs in its own mp.spawn with its own dist.init_process_group/destroy cycle
+    (on different ports) so that NCCL sub-group communicators are fully isolated
+    from bench B/C's RCCLX communicators.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT + 10)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    local_rank = rank
+    is_master = rank == 0
+
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=_TCPSTORE_PORT + 10,
+        world_size=world_size,
+        is_master=is_master,
+        wait_for_workers=True,
+    )
+
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        store=store,
+    )
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    dtype = _get_dtype()
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 5))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 20))
+
+    sparse_group_size = 2
+    num_sparse_groups = world_size // sparse_group_size
+    my_sparse_group = local_rank // sparse_group_size
+    all_active_ranks = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+
+    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+
+    num_tables = _env_int("BENCH_NUM_TABLES", 1)
+    table_sizes_all = [
+        _env_int("BENCH_TABLE_SIZE", prod_totals[g]) for g in range(num_sparse_groups)
+    ]
+    all_tensors_sizes = [
+        [max(1024, ts // (1 + (i % 5))) for i in range(num_tables)]
+        for ts in table_sizes_all
+    ]
+    sizes = all_tensors_sizes[my_sparse_group]
+    my_tensors = [torch.randn(sz, dtype=dtype, device=device) for sz in sizes]
+
+    # Create one sub-group PG per pair (0/1, 2/3, 4/5, 6/7).
+    sub_pgs = [
+        dist.new_group(ranks=all_active_ranks[g]) for g in range(num_sparse_groups)
+    ]
+    my_pg = sub_pgs[my_sparse_group]
+
+    # CPU-only barrier via TCPStore (no GPU/NCCL).
+    _barrier_cnt: list[int] = [0]
+
+    def _store_barrier() -> None:
+        _barrier_cnt[0] += 1
+        tag = f"_bench_a_barrier_{_barrier_cnt[0]}"
+        store.set(f"{tag}_{rank}", "1")
+        for r in range(world_size):
+            store.wait([f"{tag}_{r}"])
+
+    # Warmup the sub-group communicator.
+    _warmup_t = torch.ones(1, dtype=dtype, device=device)
+    dist.all_reduce(_warmup_t, op=dist.ReduceOp.SUM, group=my_pg)
+    torch.cuda.synchronize()
+    del _warmup_t
+    _store_barrier()
+
+    # Match the legacy weight-sync path: one allreduce_coalesced call with
+    # all tensors batched. Use SUM + manual divide instead of AVG because
+    # RCCL on MI350X lacks the compiled kernel for AVG + fp16 (ncclDevFuncId
+    # not found → GPU memory access fault).
+    _ar_opts = dist.AllreduceCoalescedOptions()
+    _ar_opts.reduceOp = dist.ReduceOp.SUM
+
+    def run_coalesced() -> None:
+        for t in my_tensors:
+            t.fill_(1.0)
+        my_pg.allreduce_coalesced(my_tensors, opts=_ar_opts).wait()
+        for t in my_tensors:
+            t.div_(sparse_group_size)
+
+    mean_serial, std_serial = _measure_ms(run_coalesced, warmup, bench_iters)
+    _store_barrier()
+
+    if rank == 0:
+        results_dict["A"] = (mean_serial, std_serial)
+
+    dist.destroy_process_group()
+
+
+def _benchmark_worker(rank: int, world_size: int, results_dict: Any) -> None:
+    """
+    Worker for bench B (fused flat) and C (kernel direct).
+
+    Uses an explicit TCPStore (same pattern as the deleted
+    test_sharded_relay_2d_integration.py) so that RCCLX comm creation does
+    not depend on dist._get_default_store(), which can hang when called from
+    spawned child processes in the Meta environment.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(_NCCL_PORT)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    local_rank = rank
+    is_master = rank == 0
+
+    # Explicit TCPStore — same as the integration test pattern.
+    store = dist.TCPStore(
+        host_name="localhost",
+        port=_TCPSTORE_PORT,
+        world_size=world_size,
+        is_master=is_master,
+        wait_for_workers=True,
+    )
+
+    dist.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+        store=store,
+    )
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    # Config
+    dtype = _get_dtype()
+    # Enforce minimum 1 warmup: on AMD GPUs the first RCCLX kernel call triggers
+    # JIT compilation which takes several minutes.  Without warmup the timed run
+    # shows compilation time, not runtime.
+    warmup = max(1, _env_int("BENCH_WARMUP_ITERS", 5))
+    bench_iters = max(1, _env_int("BENCH_BENCH_ITERS", 20))
+    log_sizes = _env_str("BENCH_LOG_SIZES", "0") == "1"
+
+    sparse_group_size = 2
+    num_sparse_groups = world_size // sparse_group_size
+    my_sparse_group = local_rank // sparse_group_size
+    all_active_ranks = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+
+    # Production per-group totals: groups have heterogeneous sizes matching BM-FM.
+    prod_totals = _PROD_TOTALS_FP16 if dtype != torch.float32 else _PROD_TOTALS_FP32
+
+    # Tensors for Benchmark B.
+    # Default: one flat tensor per group at the production total for this rank's
+    # active group.  Groups are heterogeneous as in real BM-FM training.
+    # Override with BENCH_NUM_TABLES + BENCH_TABLE_SIZE for smaller-scale runs.
+    num_tables = _env_int("BENCH_NUM_TABLES", 1)
+    table_sizes_all = [
+        _env_int("BENCH_TABLE_SIZE", prod_totals[g]) for g in range(num_sparse_groups)
+    ]
+    all_tensors_sizes = [
+        [max(1024, ts // (1 + (i % 5))) for i in range(num_tables)]
+        for ts in table_sizes_all
+    ]
+
+    table_size = table_sizes_all[my_sparse_group]
+    sizes = all_tensors_sizes[my_sparse_group]
+    my_tensors = [torch.randn(sz, dtype=dtype, device=device) for sz in sizes]
+
+    if log_sizes:
+        if rank == 0:
+            total = sum(sizes)
+            print(f"[BENCH_LOG_SIZES] num_tables={num_tables}, dtype={dtype}")
+            print(f"  sizes (first 10): {sizes[:10]}")
+            print(f"  total_elements_per_group: {total}")
+            print(
+                f"  total_bytes_per_group: {total * dtype.itemsize / 1024 / 1024:.1f} MB"
+            )
+        dist.destroy_process_group()
+        return
+
+    # -------------------------------------------------------------------------
+    # Benchmark B: 1 fused call with flat-concat buffers (proposed fix).
+    # -------------------------------------------------------------------------
+
+    # RCCLX comm — pass the explicit store directly (no _get_default_store())
+    rcclx_comm = _setup_rcclx_comm(local_rank, world_size, 0, store)
+    fused = _make_fused(rcclx_comm, local_rank, world_size)
+    if fused is None:
+        if rank == 0:
+            print("[bench] FusedShardedRelayMultiGroup not available. Exiting.")
+        dist.destroy_process_group()
+        return
+
+    # Helper sizes for Bench B and C
+    total_my = sum(sizes)
+    # With the passthrough kernel, each helper group gets its own buffer
+    # sized to nActiveRanks × chunkSize (passthrough minimum).
+    num_chunks = (world_size - sparse_group_size) + 1
+
+    # Benchmark B flat buffers: active = total_my, each helper = passthrough size.
+    flat_bufs: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            flat_bufs.append(torch.zeros(total_my, dtype=dtype, device=device))
+        else:
+            helper_total_g = sum(all_tensors_sizes[g])
+            helper_size_g = _passthrough_helper_size(
+                helper_total_g, sparse_group_size, num_chunks
+            )
+            flat_bufs.append(torch.zeros(helper_size_g, dtype=dtype, device=device))
+    meta_cache_b: dict[str, list[int]] = {
+        "bench"
+        + str(dtype): [sum(all_tensors_sizes[g]) for g in range(num_sparse_groups)]
+    }
+
+    # Tensors for Benchmark C: one large tensor per group at production scale.
+    # Override with BENCH_KERNEL_SIZE_GB for a different size.
+    # All ranks must pass the same per_group_sizes vector for every group index.
+    kernel_gb = _env_float("BENCH_KERNEL_SIZE_GB", 0.0)
+    kernel_elements = (
+        int(kernel_gb * 1024**3 / dtype.itemsize)
+        if kernel_gb > 0
+        else prod_totals[my_sparse_group]
+    )
+    kernel_declared_sizes: list[int] = (
+        [kernel_elements] * num_sparse_groups if kernel_gb > 0 else list(prod_totals)
+    )
+    kernel_tensor = torch.ones(kernel_elements, dtype=dtype, device=device)
+    # For kernel bench, each helper group gets its own passthrough-sized buffer.
+    kernel_scratch: list[torch.Tensor] = []
+    for g in range(num_sparse_groups):
+        if g == my_sparse_group:
+            kernel_scratch.append(kernel_tensor)
+        else:
+            declared_g = kernel_declared_sizes[g]
+            helper_size_g = _passthrough_helper_size(
+                declared_g, sparse_group_size, num_chunks
+            )
+            kernel_scratch.append(
+                torch.empty(helper_size_g, dtype=dtype, device=device)
+            )
+
+    # One barrier + kernel warmup to trigger HIP JIT compilation before timing.
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    # Warmup with 1024 elements: must be >= numChunks * CACHE_LINE_SIZE = 7 * 64 = 448
+    # so chunkSize > 0 after alignment, avoiding the degenerate chunkSize==count fallback.
+    _tiny = torch.ones(1024, dtype=dtype, device=device)
+    _tiny_scratch = [
+        torch.ones(1024, dtype=dtype, device=device) for _ in range(num_sparse_groups)
+    ]
+    for _ in range(3):
+        bench_kernel_direct(
+            fused=fused,
+            tensor=_tiny,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            scratch_tensors=_tiny_scratch,
+        )
+    torch.cuda.synchronize()
+    del _tiny, _tiny_scratch
+
+    def run_fused() -> None:
+        for t in my_tensors:
+            t.fill_(1.0)
+        bench_fused_flat(
+            fused=fused,
+            my_tensors=my_tensors,
+            num_sparse_groups=num_sparse_groups,
+            my_sparse_group=my_sparse_group,
+            all_active_ranks=all_active_ranks,
+            local_size=world_size,
+            intra_pg=None,
+            sparse_group_size=sparse_group_size,
+            flat_bufs=flat_bufs,
+            meta_cache=meta_cache_b,
+        )
+
+    mean_fused, std_fused = _measure_ms(run_fused, warmup, bench_iters)
+
+    # -------------------------------------------------------------------------
+    # Benchmark C: direct kernel call with one large tensor per group.
+    # -------------------------------------------------------------------------
+    def run_kernel() -> None:
+        kernel_tensor.fill_(1.0)
+        fused.allreduce_multi_group(
+            tensors=kernel_scratch,
+            num_groups=num_sparse_groups,
+            per_group_sizes=kernel_declared_sizes,
+            all_active_ranks=all_active_ranks,
+            op=dist.ReduceOp.AVG,
+            skip_validation=True,
+        )
+
+    mean_kernel, std_kernel = _measure_ms(run_kernel, warmup, bench_iters)
+
+    # Measure peak HBM usage — the whole point of this work.
+    torch.cuda.reset_peak_memory_stats()
+    run_fused()
+    torch.cuda.synchronize()
+    peak_hbm_bytes = torch.cuda.max_memory_allocated()
+
+    if rank == 0:
+        total_bytes = sum(sz * dtype.itemsize for sz in sizes)
+        kernel_bytes = kernel_elements * dtype.itemsize
+
+        def bw(nbytes: int, ms: float) -> float:
+            return 2 * nbytes / (ms / 1000) / 1e9
+
+        bench_a_mean = float(results_dict["A"][0]) if "A" in results_dict else 0.0
+        bench_a_std = float(results_dict["A"][1]) if "A" in results_dict else 0.0
+
+        print("\n" + "=" * 72)
+        print(f"Sharded Relay Allreduce Benchmark — MI350X ({world_size} GPUs)")
+        print("=" * 72)
+        print(f"  dtype:          {dtype}")
+        print(f"  num_tables:     {num_tables}")
+        print(
+            f"  avg table size: {table_size:,} elements "
+            f"({table_size * dtype.itemsize / 1024 / 1024:.1f} MB)"
+        )
+        print(f"  total data/grp: {total_bytes / 1024 / 1024:.1f} MB")
+        print()
+        if bench_a_mean > 0:
+            print(f"  [A] COALESCED ({num_tables} tensors, allreduce_coalesced):")
+            print(
+                f"       {bench_a_mean:.2f} ms  ±  {bench_a_std:.2f} ms  |  "
+                f"{bw(total_bytes, bench_a_mean):.1f} GB/s"
+            )
+        else:
+            print("  [A] COALESCED: N/A")
+        print()
+        print("  [B] FUSED FLAT (1 call, passthrough helpers, phase-sync kernel):")
+        print(
+            f"       {mean_fused:.2f} ms  ±  {std_fused:.2f} ms  |  "
+            f"{bw(total_bytes, mean_fused):.1f} GB/s"
+        )
+        print(f"       Peak HBM: {peak_hbm_bytes / 1024 / 1024 / 1024:.2f} GiB")
+        print()
+        print(
+            f"  [C] KERNEL DIRECT (1 large tensor, {kernel_bytes / 1024 / 1024:.0f} MB):"
+        )
+        print(
+            f"       {mean_kernel:.2f} ms  ±  {std_kernel:.2f} ms  |  "
+            f"{bw(kernel_bytes, mean_kernel):.1f} GB/s"
+        )
+        print()
+        if bench_a_mean > 0:
+            speedup_ab = bench_a_mean / mean_fused if mean_fused > 0 else float("inf")
+            print(f"  A→B speedup (coalesced → fused flat):  {speedup_ab:.2f}x")
+        print("=" * 72)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# TestCase — works with both "buck2 test" and "buck2 run" (same as the old
+# test_sharded_relay_2d_integration.py pattern).
+# ---------------------------------------------------------------------------
+
+
+class BenchShardedRelayPerfTest(unittest.TestCase):
+    """
+    Runs the sharded relay benchmark via mp.spawn inside a single TestCase.
+
+    Bench A (NCCL allreduce_coalesced) runs in its own mp.spawn with its own
+    dist.init/destroy cycle so that its NCCL sub-group communicators are fully
+    isolated from bench B/C's RCCLX communicators.  Results are passed to the
+    bench B/C worker via mp.Manager dict for a unified printout.
+
+    Both of these work:
+        buck2 test @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+            //torchrec/distributed/tests:bench_sharded_relay_perf
+
+        buck2 run @mode/opt-amd-gpu -m rocm70 -m rcclx_dev \\
+            //torchrec/distributed/tests:bench_sharded_relay_perf
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm not available")
+        if torch.cuda.device_count() < NUM_GPUS:
+            self.skipTest(
+                f"Benchmark requires {NUM_GPUS} GPUs, "
+                f"found {torch.cuda.device_count()}"
+            )
+        if not (FUSED_AVAILABLE and RCCLX_AVAILABLE):
+            self.skipTest("FusedShardedRelayMultiGroup or RCCLX not available")
+
+    def test_benchmark(self) -> None:
+        manager = mp.Manager()
+        results: Any = manager.dict()
+
+        # Phase 1: bench A — allreduce_coalesced on 2-rank NCCL sub-group PGs.
+        mp.spawn(
+            _bench_a_worker,
+            args=(NUM_GPUS, results),
+            nprocs=NUM_GPUS,
+            join=True,
+        )
+
+        # Phase 2: bench B (fused flat) and C (kernel direct) via RCCLX.
+        mp.spawn(
+            _benchmark_worker,
+            args=(NUM_GPUS, results),
+            nprocs=NUM_GPUS,
+            join=True,
+        )
+
+        manager.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchrec/distributed/tests/test_sharded_relay_utils.py
+++ b/torchrec/distributed/tests/test_sharded_relay_utils.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Unit tests for sharded_relay_utils.py.
+
+These tests run on CPU with no real GPU, NCCL, or RCCLX stack.  All
+distributed calls and the FusedShardedRelayMultiGroup are replaced with
+unittest.mock objects so tests are fast and hermetic.
+
+Test classes
+============
+FlatCacheTest
+    Tests for the grow-only flat buffer caches (_active_flat_cache and
+    _helper_flat_cache) that replaced the old per-tensor scratch scheme.
+
+FlatAllreduceTest
+    Tests for allreduce_tensors_with_sharded_relay with the flat-concat
+    approach: N tensors → pack into flat buf → ONE call → unpack.
+
+FusedShardedRelayValidationTest
+    Tests for FusedShardedRelayMultiGroup.allreduce_multi_group validation
+    logic (tensor size mismatch, count=0 skipping).  These test the kernel
+    API directly and are unchanged by the flat-concat rewrite.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.distributed as dist
+from torchrec.distributed.sharded_relay_utils import (
+    _get_active_flat_buf,
+    _get_helper_flat_buf,
+    _passthrough_helper_size,
+    allreduce_tensors_with_sharded_relay,
+    ShardedRelayState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DEVICE = torch.device("cpu")
+
+
+def _make_state(
+    rank: int = 0,
+    sparse_group_size: int = 2,
+    local_size: int = 8,
+) -> ShardedRelayState:
+    """
+    Build a ShardedRelayState suitable for CPU-only unit tests.
+
+    - intra_node_pytorch_pg=None triggers the fallback path in
+      allreduce_tensors_with_sharded_relay (no dist.all_gather calls).
+    - fused is a MagicMock; allreduce_multi_group records every call.
+    """
+    num_sparse_groups = local_size // sparse_group_size
+    active_ranks = [
+        list(range(g * sparse_group_size, (g + 1) * sparse_group_size))
+        for g in range(num_sparse_groups)
+    ]
+    mock_fused = MagicMock()
+    mock_fused.allreduce_multi_group = MagicMock()
+    return ShardedRelayState(
+        fused=mock_fused,
+        intra_node_pytorch_pg=None,
+        local_rank=rank,
+        sparse_group_size=sparse_group_size,
+        my_sparse_group=rank // sparse_group_size,
+        num_sparse_groups=num_sparse_groups,
+        local_size=local_size,
+        precomputed_active_ranks=active_ranks,
+        _rcclx_comm=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for the flat buffer caches
+# ---------------------------------------------------------------------------
+
+
+class FlatCacheTest(unittest.TestCase):
+    """Tests for _get_active_flat_buf and _get_helper_flat_buf."""
+
+    # --- _get_active_flat_buf ---
+
+    def test_active_flat_buf_exact_size_on_first_call(self) -> None:
+        state = _make_state()
+        buf = _get_active_flat_buf(state, 100, torch.float32, _DEVICE)
+        self.assertEqual(buf.numel(), 100)
+        self.assertEqual(buf.dtype, torch.float32)
+
+    def test_active_flat_buf_reused_when_same_size(self) -> None:
+        state = _make_state()
+        buf1 = _get_active_flat_buf(state, 100, torch.float32, _DEVICE)
+        buf2 = _get_active_flat_buf(state, 100, torch.float32, _DEVICE)
+        self.assertEqual(buf1.data_ptr(), buf2.data_ptr())
+
+    def test_active_flat_buf_narrowed_view_when_size_shrinks(self) -> None:
+        state = _make_state()
+        big = _get_active_flat_buf(state, 1000, torch.float32, _DEVICE)
+        small = _get_active_flat_buf(state, 500, torch.float32, _DEVICE)
+        self.assertEqual(small.numel(), 500)
+        # narrow() shares storage with the cached buffer
+        self.assertEqual(big.data_ptr(), small.data_ptr())
+
+    def test_active_flat_buf_reallocates_when_size_grows(self) -> None:
+        state = _make_state()
+        _get_active_flat_buf(state, 100, torch.float32, _DEVICE)
+        big = _get_active_flat_buf(state, 200, torch.float32, _DEVICE)
+        self.assertEqual(big.numel(), 200)
+
+    def test_active_flat_buf_separate_per_dtype(self) -> None:
+        """bf16 (weights) and fp32 (optimizer states) must have separate buffers."""
+        state = _make_state()
+        bf16 = _get_active_flat_buf(state, 100, torch.bfloat16, _DEVICE)
+        fp32 = _get_active_flat_buf(state, 100, torch.float32, _DEVICE)
+        # Re-fetching bf16 must return the same buffer (not reallocated).
+        bf16_again = _get_active_flat_buf(state, 100, torch.bfloat16, _DEVICE)
+        self.assertEqual(bf16.data_ptr(), bf16_again.data_ptr())
+        self.assertNotEqual(bf16.data_ptr(), fp32.data_ptr())
+
+    # --- _get_helper_flat_buf ---
+
+    def test_helper_flat_buf_exact_size_on_first_call(self) -> None:
+        state = _make_state()
+        buf = _get_helper_flat_buf(state, 1, 100, torch.float32, _DEVICE)
+        self.assertEqual(buf.numel(), 100)
+        self.assertEqual(buf.dtype, torch.float32)
+
+    def test_helper_flat_buf_reused_across_training_steps(self) -> None:
+        state = _make_state()
+        buf1 = _get_helper_flat_buf(state, 1, 200, torch.float32, _DEVICE)
+        buf2 = _get_helper_flat_buf(state, 1, 200, torch.float32, _DEVICE)
+        self.assertEqual(buf1.data_ptr(), buf2.data_ptr())
+
+    def test_helper_flat_buf_separate_per_group(self) -> None:
+        """With per-(group, dtype) keying, different group_idx values get separate buffers."""
+        state = _make_state()
+        buf0 = _get_helper_flat_buf(state, 1, 100, torch.float32, _DEVICE)
+        buf1 = _get_helper_flat_buf(state, 2, 100, torch.float32, _DEVICE)
+        self.assertNotEqual(buf0.data_ptr(), buf1.data_ptr())
+
+    def test_helper_flat_buf_separate_per_dtype(self) -> None:
+        """fp16 (weights) and fp32 (optimizer states) must not evict each other."""
+        state = _make_state()
+        fp16 = _get_helper_flat_buf(state, 1, 100, torch.float16, _DEVICE)
+        fp32 = _get_helper_flat_buf(state, 1, 100, torch.float32, _DEVICE)
+        fp16_again = _get_helper_flat_buf(state, 1, 100, torch.float16, _DEVICE)
+        self.assertEqual(fp16.data_ptr(), fp16_again.data_ptr())
+        self.assertNotEqual(fp16.data_ptr(), fp32.data_ptr())
+
+
+# ---------------------------------------------------------------------------
+# Tests for allreduce_tensors_with_sharded_relay (flat-concat approach)
+# ---------------------------------------------------------------------------
+
+
+class FlatAllreduceTest(unittest.TestCase):
+    def _call_count(self, state: ShardedRelayState) -> int:
+        return state.fused.allreduce_multi_group.call_count
+
+    def _all_calls(self, state: ShardedRelayState):
+        return state.fused.allreduce_multi_group.call_args_list
+
+    # ------------------------------------------------------------------
+    # Basic call-count correctness
+    # ------------------------------------------------------------------
+
+    def test_returns_immediately_when_no_tensors(self) -> None:
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(state, {}, "test")
+        self.assertEqual(self._call_count(state), 0)
+
+    def test_single_call_for_one_tensor(self) -> None:
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100)]}, "test"
+        )
+        self.assertEqual(self._call_count(state), 1)
+
+    def test_single_call_for_many_tables(self) -> None:
+        """101 tensors → exactly ONE allreduce_multi_group call (not 101)."""
+        state = _make_state(rank=0)
+        tensors = [torch.zeros(100) for _ in range(101)]
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "test")
+        self.assertEqual(self._call_count(state), 1)
+
+    def test_single_call_per_dtype_for_mixed_dicts(self) -> None:
+        """Two dtypes in tensors_dict → two calls (one per dtype)."""
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state,
+            {
+                torch.float16: [torch.zeros(50, dtype=torch.float16)],
+                torch.float32: [torch.zeros(50, dtype=torch.float32)],
+            },
+            "test",
+        )
+        self.assertEqual(self._call_count(state), 2)
+
+    def test_bm_fm_counts_still_one_call(self) -> None:
+        """BM-FM has [94,101,88,99] tensors per group; rank 0 (group 0) has 94."""
+        state = _make_state(rank=0)
+        tensors = [torch.zeros(100) for _ in range(94)]
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "test")
+        self.assertEqual(self._call_count(state), 1)
+
+    # ------------------------------------------------------------------
+    # Flat buffer sizing passed to allreduce_multi_group
+    # ------------------------------------------------------------------
+
+    def test_active_group_total_numel_matches_sum_of_tensor_sizes(self) -> None:
+        """The active group's per_group_sizes entry must equal sum(t.numel())."""
+        state = _make_state(rank=0)  # active for group 0
+        sizes = [100, 500, 750]
+        tensors = [torch.zeros(s) for s in sizes]
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "test")
+
+        call_kwargs = self._all_calls(state)[0].kwargs
+        active_size = call_kwargs["per_group_sizes"][state.my_sparse_group]
+        self.assertEqual(active_size, sum(sizes))
+
+    def test_helper_flat_buffer_total_numel_matches_passthrough_size(self) -> None:
+        """
+        With the passthrough kernel, helper buffers are sized to
+        nActiveRanks × chunkSize (much smaller than the full per-group total).
+        Each helper group has its own buffer (no aliasing).
+        """
+        state = _make_state(rank=0)
+        sizes = [100, 500, 750]
+        tensors = [torch.zeros(s) for s in sizes]
+        expected_total = sum(sizes)  # 1350
+
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "test")
+
+        call_kwargs = self._all_calls(state)[0].kwargs
+        iter_tensors = call_kwargs["tensors"]
+        iter_sizes = call_kwargs["per_group_sizes"]
+
+        # Active group should have full total.
+        self.assertEqual(
+            iter_sizes[state.my_sparse_group],
+            expected_total,
+        )
+        self.assertEqual(
+            iter_tensors[state.my_sparse_group].numel(),
+            expected_total,
+        )
+
+        # Helper groups: per_group_sizes has the full total_g, but tensor
+        # numel is the passthrough size (nActiveRanks × chunkSize).
+        # All helper groups have the same total_g (fallback: all equal my_total).
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+        expected_helper_numel = _passthrough_helper_size(
+            expected_total, state.sparse_group_size, num_chunks
+        )
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            self.assertEqual(
+                iter_sizes[g],
+                expected_total,
+                f"group={g}: per_group_sizes should be full total",
+            )
+            self.assertEqual(
+                iter_tensors[g].numel(),
+                expected_helper_numel,
+                f"group={g}: helper tensor numel should be passthrough size",
+            )
+            helper_ptrs.add(iter_tensors[g].data_ptr())
+
+        # Each helper group has its OWN buffer (no aliasing under phase-sync).
+        self.assertEqual(
+            len(helper_ptrs),
+            state.num_sparse_groups - 1,
+            f"Expected {state.num_sparse_groups - 1} distinct helper buffers, "
+            f"got {len(helper_ptrs)}",
+        )
+
+    # ------------------------------------------------------------------
+    # Values written back to original tensors
+    # ------------------------------------------------------------------
+
+    def test_values_written_back_to_original_tensors(self) -> None:
+        """
+        After allreduce, each original tensor must contain the values that
+        the allreduce produced (written from the flat buffer back via unpack).
+        We simulate this by having the mock fill active_flat with a sentinel.
+        """
+        state = _make_state(rank=0)
+        my_tensor = torch.zeros(300)
+
+        sentinel = 42.0
+
+        def _fill_active_flat(*args, **kwargs) -> None:
+            # Simulate the allreduce result: write sentinel into the active flat buf.
+            tensors = kwargs.get("tensors", args[0] if args else [])
+            my_g = state.my_sparse_group
+            tensors[my_g].fill_(sentinel)
+
+        state.fused.allreduce_multi_group.side_effect = _fill_active_flat
+
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [my_tensor]}, "test"
+        )
+
+        # The unpack step must have copied sentinel back into my_tensor.
+        self.assertTrue(
+            torch.all(my_tensor == sentinel),
+            f"Expected all values to be {sentinel}, got {my_tensor[:5]}",
+        )
+
+    def test_unpack_handles_multiple_tensors_correctly(self) -> None:
+        """
+        With multiple tensors of different sizes, the unpack step must write
+        each tensor's slice of the flat buffer back to the correct original tensor.
+        """
+        state = _make_state(rank=0)
+        t0 = torch.zeros(100)
+        t1 = torch.zeros(200)
+        t2 = torch.zeros(50)
+
+        fill_values = [1.0, 2.0, 3.0]
+
+        def _fill_by_slice(*args, **kwargs) -> None:
+            tensors = kwargs.get("tensors", args[0] if args else [])
+            my_g = state.my_sparse_group
+            flat = tensors[my_g]
+            flat[:100].fill_(fill_values[0])
+            flat[100:300].fill_(fill_values[1])
+            flat[300:350].fill_(fill_values[2])
+
+        state.fused.allreduce_multi_group.side_effect = _fill_by_slice
+
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [t0, t1, t2]}, "test"
+        )
+
+        self.assertTrue(torch.all(t0 == fill_values[0]))
+        self.assertTrue(torch.all(t1 == fill_values[1]))
+        self.assertTrue(torch.all(t2 == fill_values[2]))
+
+    # ------------------------------------------------------------------
+    # Metadata cache skips allgather on subsequent calls
+    # ------------------------------------------------------------------
+
+    @patch("torchrec.distributed.sharded_relay_utils.dist")
+    def test_metadata_cache_skips_allgather_after_first_call(
+        self, mock_dist: MagicMock
+    ) -> None:
+        """
+        allgather must be called exactly once per (annotation, dtype) pair,
+        regardless of how many training steps have passed.
+        """
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        # Set up the mock allgather to return a count of 200 for all ranks.
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for t in tensor_list:
+                t.fill_(200)
+
+        mock_dist.all_gather.side_effect = _allgather_side_effect
+        mock_dist.ReduceOp = dist.ReduceOp
+
+        tensors = [torch.zeros(200, dtype=torch.float32)]
+
+        # First call — should trigger allgather.
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        # Second call — must use cached metadata, no new allgather.
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "step")
+        self.assertEqual(mock_dist.all_gather.call_count, 1)
+
+        # Different annotation → new cache entry → one more allgather.
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: tensors}, "other_annotation"
+        )
+        self.assertEqual(mock_dist.all_gather.call_count, 2)
+
+    # ------------------------------------------------------------------
+    # Scratch buffers reused across training steps
+    # ------------------------------------------------------------------
+
+    def test_helper_flat_buf_reused_across_training_steps(self) -> None:
+        """The helper flat buffer must not be reallocated on subsequent steps."""
+        state = _make_state(rank=0)
+        tensors = [torch.zeros(100)]
+
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "step1")
+        call1 = self._all_calls(state)[0].kwargs["tensors"]
+        helper_g = 1
+        ptr_step1 = call1[helper_g].data_ptr()
+
+        allreduce_tensors_with_sharded_relay(state, {torch.float32: tensors}, "step1")
+        call2 = self._all_calls(state)[1].kwargs["tensors"]
+        ptr_step2 = call2[helper_g].data_ptr()
+
+        self.assertEqual(
+            ptr_step1,
+            ptr_step2,
+            "Helper flat buffer was reallocated between training steps (should be reused)",
+        )
+
+    def test_separate_flat_bufs_for_weights_and_optimizer(self) -> None:
+        """
+        Alternating between bf16 (weights sync) and fp32 (optimizer sync)
+        must not trigger reallocation and must use separate buffers.
+        The helper buffer is keyed by (group_idx, dtype), so each (group, dtype)
+        pair has its own buffer.
+        """
+        state = _make_state(rank=0)
+        helper_g = 1
+
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float16: [torch.zeros(100, dtype=torch.float16)]}, "weights"
+        )
+        ptr_fp16_1 = self._all_calls(state)[0].kwargs["tensors"][helper_g].data_ptr()
+
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100, dtype=torch.float32)]}, "opt"
+        )
+        ptr_fp32_1 = self._all_calls(state)[1].kwargs["tensors"][helper_g].data_ptr()
+
+        # fp16 again — must reuse the fp16 buffer.
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float16: [torch.zeros(100, dtype=torch.float16)]}, "weights"
+        )
+        ptr_fp16_2 = self._all_calls(state)[2].kwargs["tensors"][helper_g].data_ptr()
+
+        self.assertEqual(
+            ptr_fp16_1, ptr_fp16_2, "fp16 buffer reallocated on second call"
+        )
+        self.assertNotEqual(
+            ptr_fp16_1, ptr_fp32_1, "fp16 and fp32 share the same buffer"
+        )
+
+    # ------------------------------------------------------------------
+    # Passthrough helper buffer tests (per-group keying, no aliasing)
+    # ------------------------------------------------------------------
+
+    def test_one_fused_call_per_dtype(self) -> None:
+        """Drive with one fp32 tensor; assert exactly 1 fused call with num_groups."""
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(100)]}, "test"
+        )
+        self.assertEqual(self._call_count(state), 1)
+        call_kwargs = self._all_calls(state)[0].kwargs
+        self.assertEqual(call_kwargs["num_groups"], state.num_sparse_groups)
+
+    def test_helper_buffers_separate_per_group(self) -> None:
+        """Each helper-group slot has its own data_ptr; active does NOT alias helpers."""
+        state = _make_state(rank=0)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [torch.zeros(200)]}, "test"
+        )
+        call_kwargs = self._all_calls(state)[0].kwargs
+        iter_tensors = call_kwargs["tensors"]
+
+        active_ptr = iter_tensors[state.my_sparse_group].data_ptr()
+        helper_ptrs = set()
+        for g in range(state.num_sparse_groups):
+            if g != state.my_sparse_group:
+                helper_ptrs.add(iter_tensors[g].data_ptr())
+
+        self.assertEqual(
+            len(helper_ptrs),
+            state.num_sparse_groups - 1,
+            "Each helper group should have its own buffer",
+        )
+        self.assertNotIn(
+            active_ptr, helper_ptrs, "Active buffer must not alias helpers"
+        )
+
+    def test_helper_buffer_sized_to_passthrough_minimum(self) -> None:
+        """
+        Drive an allreduce with heterogeneous per-group totals via mocked
+        allgather; assert each helper buffer is passthrough-sized.
+        """
+        state = _make_state(rank=0)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        # Group totals: [100, 300, 200, 150].  Rank 0 is active for group 0.
+        group_totals = [100, 300, 200, 150]
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for r, t in enumerate(tensor_list):
+                t.fill_(group_totals[r // state.sparse_group_size])
+
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        with patch("torchrec.distributed.sharded_relay_utils.dist") as mock_dist:
+            mock_dist.all_gather.side_effect = _allgather_side_effect
+            mock_dist.ReduceOp = dist.ReduceOp
+            allreduce_tensors_with_sharded_relay(
+                state, {torch.float32: [torch.zeros(100)]}, "hetero"
+            )
+
+        call_kwargs = self._all_calls(state)[0].kwargs
+        iter_tensors = call_kwargs["tensors"]
+        for g in range(state.num_sparse_groups):
+            if g == state.my_sparse_group:
+                continue
+            expected_size = _passthrough_helper_size(
+                group_totals[g], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(
+                iter_tensors[g].numel(),
+                expected_size,
+                f"group={g}: helper should be passthrough-sized",
+            )
+
+    def test_active_buffer_unchanged(self) -> None:
+        """Active flat buffer is still sized to my_total, reused, and distinct."""
+        state = _make_state(rank=0)
+        t1 = torch.zeros(300)
+        allreduce_tensors_with_sharded_relay(
+            state, {torch.float32: [t1]}, "active_test"
+        )
+        call_kwargs = self._all_calls(state)[0].kwargs
+        active_tensor = call_kwargs["tensors"][state.my_sparse_group]
+        self.assertEqual(active_tensor.numel(), 300)
+
+    def test_bm_fm_real_totals_per_group_helper_buffers(self) -> None:
+        """
+        Using real BM-FM per-group totals, assert that each helper group has
+        its own passthrough-sized buffer.
+        """
+        state = _make_state(rank=0, sparse_group_size=2, local_size=8)
+        state = dataclasses.replace(state, intra_node_pytorch_pg=MagicMock())
+
+        bm_fm_fp16_totals = [
+            12_002_982_488,
+            12_245_126_152,
+            12_014_370_640,
+            12_057_805_952,
+        ]
+
+        def _allgather_side_effect(tensor_list, _tensor, **_kwargs) -> None:
+            for r, t in enumerate(tensor_list):
+                t.fill_(bm_fm_fp16_totals[r // state.sparse_group_size])
+
+        num_chunks = (state.local_size - state.sparse_group_size) + 1
+
+        captured_helper_calls: list[tuple[int, int]] = []
+
+        def _fake_helper(_state, group_idx, total, _dtype, _device):
+            captured_helper_calls.append((group_idx, total))
+            return torch.empty(total, dtype=_dtype, device="meta")
+
+        def _fake_active(_state, total, _dtype, _device):
+            return torch.zeros(1, dtype=_dtype)
+
+        with patch(
+            "torchrec.distributed.sharded_relay_utils._get_active_flat_buf",
+            side_effect=_fake_active,
+        ), patch(
+            "torchrec.distributed.sharded_relay_utils._get_helper_flat_buf",
+            side_effect=_fake_helper,
+        ), patch(
+            "torchrec.distributed.sharded_relay_utils.dist"
+        ) as mock_dist:
+            mock_dist.all_gather.side_effect = _allgather_side_effect
+            mock_dist.ReduceOp = dist.ReduceOp
+            tensors = [torch.zeros(1, dtype=torch.float16)]
+            allreduce_tensors_with_sharded_relay(
+                state, {torch.float16: tensors}, "bm_fm_2d_weight_sync"
+            )
+
+        # 3 calls to _get_helper_flat_buf (one per helper group, no aliasing)
+        self.assertEqual(
+            len(captured_helper_calls),
+            3,
+            f"Expected 3 helper buffer allocations, got {len(captured_helper_calls)}",
+        )
+        # Each helper buffer should be passthrough-sized
+        for group_idx, total in captured_helper_calls:
+            expected = _passthrough_helper_size(
+                bm_fm_fp16_totals[group_idx], state.sparse_group_size, num_chunks
+            )
+            self.assertEqual(
+                total,
+                expected,
+                f"group={group_idx}: helper buffer should be passthrough-sized",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests for FusedShardedRelayMultiGroup.allreduce_multi_group validation
+# (kernel API — unchanged by the flat-concat rewrite)
+# ---------------------------------------------------------------------------
+
+
+class FusedShardedRelayValidationTest(unittest.TestCase):
+    def _make_fused(self, rank: int = 0):
+        try:
+            from caffe2.torch.distributed.fb.sharded_relay_process_group import (  # type: ignore[import]
+                FusedShardedRelayMultiGroup,
+            )
+        except ImportError:
+            self.skipTest("FusedShardedRelayMultiGroup not available")
+
+        all_active_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        # rcclx_comm=None → _use_native=False; validation still runs.
+        return FusedShardedRelayMultiGroup(
+            rcclx_comm=None,
+            world_size=8,
+            rank=rank,
+            all_active_ranks=all_active_ranks,
+        )
+
+    def test_raises_value_error_on_tensor_size_mismatch(self) -> None:
+        """
+        allreduce_multi_group must raise ValueError when tensor.numel() does
+        not match per_group_sizes[g].  This is the validation that catches the
+        bug where a 640M-element scratch buffer was passed with count=10M.
+        """
+        fused = self._make_fused(rank=0)
+        tensors = [
+            torch.zeros(1000),  # group 0 — matches
+            torch.zeros(640),  # group 1 — will mismatch (expected 500)
+            torch.zeros(750),  # group 2 — matches
+            torch.zeros(600),  # group 3 — matches
+        ]
+        per_group_sizes = [1000, 500, 750, 600]  # group 1: 640 vs 500
+
+        with self.assertRaises(ValueError) as cm:
+            fused.allreduce_multi_group(
+                tensors=tensors,
+                num_groups=4,
+                per_group_sizes=per_group_sizes,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+
+        err = str(cm.exception)
+        self.assertIn("640", err)  # actual numel
+        self.assertIn("500", err)  # expected size
+
+    def test_count_zero_group_skips_size_validation(self) -> None:
+        """
+        Regression for BM-FM failure (Python layer):
+          ValueError: Tensor 3 has 1 elements, but per_group_sizes[3]=0
+
+        The Python allreduce_multi_group must skip count=0 groups in its
+        size validation — they carry a 1-element placeholder the kernel ignores.
+        """
+        fused = self._make_fused(rank=0)
+        # Groups 0,1,2 have data; group 3 ran out — count=0, placeholder=1 elem.
+        tensors = [torch.zeros(100), torch.zeros(100), torch.zeros(100), torch.zeros(1)]
+        per_group_sizes = [100, 100, 100, 0]
+
+        # Must NOT raise ValueError.  RuntimeError (no native API) is expected.
+        with self.assertRaises(RuntimeError) as cm:
+            fused.allreduce_multi_group(
+                tensors=tensors,
+                num_groups=4,
+                per_group_sizes=per_group_sizes,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+    def test_my_active_group_count_zero_skips_validation(self) -> None:
+        """
+        Same scenario from my own group's perspective: when this rank has run
+        out of tensors (iter_idx >= my_tensor_count), my group slot gets
+        count=0 and a 1-element placeholder.  Validation must skip it.
+        """
+        fused = self._make_fused(rank=0)
+        # Group 0 (this rank's active group) has count=0 at this iteration.
+        tensors = [torch.zeros(1), torch.zeros(200), torch.zeros(200), torch.zeros(200)]
+        per_group_sizes = [0, 200, 200, 200]
+
+        with self.assertRaises(RuntimeError) as cm:
+            fused.allreduce_multi_group(
+                tensors=tensors,
+                num_groups=4,
+                per_group_sizes=per_group_sizes,
+                all_active_ranks=[[0, 1], [2, 3], [4, 5], [6, 7]],
+                op=dist.ReduceOp.SUM,
+            )
+        self.assertNotIsInstance(cm.exception, ValueError)
+
+
+class _PassthroughHelperSizePolicyTest(unittest.TestCase):
+    """Tests for _passthrough_helper_size — Python ↔ C++ formula parity."""
+
+    def test_passthrough_size_matches_2x_chunkSize_for_realistic_totals(self) -> None:
+        """BM-FM fp16: ~12B elements per group, 8 ranks, 2 active → numChunks=7."""
+        total_g = 12_002_982_488
+        sparse_group_size = 2
+        num_chunks = 7  # (8 - 2) + 1
+        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
+        chunk = total_g // num_chunks
+        chunk_aligned = (chunk // 128) * 128
+        expected = sparse_group_size * chunk_aligned
+        self.assertEqual(result, expected)
+        # Sanity: result should be ~2/7 of total, much less than total
+        self.assertLess(result, total_g)
+        self.assertGreater(result, 0)
+
+    def test_passthrough_size_falls_back_to_total_for_tiny_counts(self) -> None:
+        """When total_g < num_chunks * CACHE_LINE_SIZE, chunkSize falls back to total_g."""
+        total_g = 100
+        sparse_group_size = 2
+        num_chunks = 7
+        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
+        # chunk = 100 // 7 = 14, chunk_aligned = (14 // 128) * 128 = 0
+        # fallback: chunk_aligned = total_g = 100
+        # result = min(100, 2 * 100) = 100
+        self.assertEqual(result, total_g)
+
+    def test_passthrough_size_capped_at_total_g(self) -> None:
+        """Result must never exceed total_g."""
+        total_g = 128
+        sparse_group_size = 2
+        num_chunks = 7
+        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
+        self.assertLessEqual(result, total_g)
+
+    def test_python_meets_cpp_min_required_at_alignment_boundary(self) -> None:
+        """At exact alignment boundaries, Python and C++ formulas agree."""
+        # total_g = 7 * 128 * k for some k → exact alignment, no remainder
+        total_g = 7 * 128 * 1000  # 896_000
+        sparse_group_size = 2
+        num_chunks = 7
+        result = _passthrough_helper_size(total_g, sparse_group_size, num_chunks)
+        chunk = total_g // num_chunks  # 128_000
+        chunk_aligned = (chunk // 128) * 128  # 128_000
+        expected = min(total_g, sparse_group_size * chunk_aligned)
+        self.assertEqual(result, expected)
+        self.assertEqual(result, 256_000)
+
+    def test_total_per_rank_helper_memory_is_6x_chunkSize(self) -> None:
+        """
+        For 4 groups / 2 active per group: each rank helps 3 groups.
+        Total helper memory = 3 × 2 × chunkSize = 6 × chunkSize.
+        """
+        total_g = 12_002_982_488  # BM-FM fp16 group 0
+        sparse_group_size = 2
+        num_chunks = 7
+        helper_per_group = _passthrough_helper_size(
+            total_g, sparse_group_size, num_chunks
+        )
+        chunk = total_g // num_chunks
+        chunk_aligned = (chunk // 128) * 128
+        self.assertEqual(helper_per_group, sparse_group_size * chunk_aligned)
+        # 3 helper groups per rank
+        total_helper = 3 * helper_per_group
+        self.assertEqual(total_helper, 6 * chunk_aligned)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Add tests and benchmarks for the sharded relay distributed utilities:
- Unit tests for sharded_relay_utils covering correctness validation
- Performance benchmark (bench_sharded_relay_perf) for measuring
  relay allreduce throughput and latency
- MI350 benchmark runner script for AMD GPU testing

Reviewed By: kausv

Differential Revision: D103262938


