### PR TITLE
Fix the NaN issue due to the memory usage race condition over multiple streams

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -249,6 +249,13 @@ class MemoryStashingManager:
                             pin_memory=True,
                         )
                         cpu_buffer.copy_(tensor, non_blocking=True)
+                        # Tell the caching allocator this tensor is in use on
+                        # d2h_stream so the bytes are not reused by default-
+                        # stream allocations until the async D2H copy completes.
+                        # Without this, resize_(0) below would let the allocator
+                        # immediately reuse the HBM, corrupting the in-flight
+                        # copy and producing NaN after a few batches.
+                        tensor.record_stream(d2h_stream)
                         orig_storage_size = tensor.untyped_storage().size()
                         stash_data.append((tensor, cpu_buffer, orig_storage_size))
 
@@ -317,6 +324,11 @@ class MemoryStashingManager:
                     )
                     with torch.cuda.stream(h2d_stream):
                         tmp.copy_(cpu_buf, non_blocking=True)
+                    # Tell the caching allocator this storage is in use on
+                    # h2d_stream so the bytes cannot be reused by main-stream
+                    # allocations (e.g. a subsequent resize_(0) + realloc)
+                    # before the H2D copy completes.
+                    hbm_ref.record_stream(h2d_stream)
 
                 # only need to record the last event
                 restore_event = torch.cuda.Event()


### PR DESCRIPTION
Summary:
#### Overview

This diff addresses a "nan" (not a number) issue by introducing a synchronization mechanism to prevent the caching allocator from reusing HBM (Host-Bus Memory) memory while a D2H (Device-to-Host) copy operation is in flight.

Without the change, there is an issue resulting in a memory usage race condition:
1. weights_dev is allocated by FBGEMM TBE on the default stream.
2. In execute_stash:
- Loop 1 enqueues cpu_buffer.copy_(tensor, non_blocking=True) on d2h_stream.
- Loop 2 calls tensor.untyped_storage().resize_(0) on the host thread.
3. PyTorch's caching allocator only sees that the storage was last used on the default stream. Without tensor.record_stream(d2h_stream), the allocator considers the freed bytes immediately reusable for any new default-stream allocation — even though the D2H copy is still in flight on d2h_stream.
4. Subsequent default-stream allocations (dense forward intermediates, output_dist buffers, etc.) reuse the same HBM bytes and overwrite them mid-copy.
5. The pinned CPU buffer captures garbage (potentially NaN-producing values).
6. Next iteration's restore pulls that garbage back into weights_dev. Since the FBGEMM TBE backward + fused optimizer reads weights_dev, garbage → divergence → NaN propagates everywhere.

#### Key Change

The fix involves adding a line of code to the `memory_stashing.py` file to inform the caching allocator that a tensor is being used on the `d2h_stream`. This prevents the allocator from prematurely reusing the HBM memory, which could cause data corruption.

#### Impact

This change ensures that the tensor's memory is not reused by the allocator until the async D2H copy completes, thus preventing potential data corruption and resolving the "nan" issue.

#### Affected Files

*   `fbcode/torchrec/distributed/memory_stashing.py`

Note that this is a summary based on the provided prompt, if you need a proper code diff summary, you should include the actual diff in your codebase version control system (like GitHub etc), that will automatically generate a summary which can be used directly here.

Reviewed By: TroyGarden

Differential Revision: D102202725


