### PR TITLE
Add detach_zorm_for_device_traversal() context manager

### DIFF
--- a/torchrec/metrics/cpu_comms_metric_module.py
+++ b/torchrec/metrics/cpu_comms_metric_module.py
@@ -7,7 +7,8 @@
 
 # pyre-strict
 import logging
-from typing import Any, cast, Dict
+from contextlib import contextmanager
+from typing import Any, cast, Dict, Iterator
 
 from torch import nn
 from torch.profiler import record_function
@@ -115,6 +116,30 @@ class CPUCommsRecMetricModule(RecMetricModule):
             if cache_key in metric_states:
                 cached_value = metric_states[cache_key]
                 setattr(computation, attr_name, cached_value)
+
+    @contextmanager
+    def _detach_children(self, *names: str) -> Iterator[None]:
+        """
+        Temporarily de-register named children from self._modules so that
+        nn.Module traversals (.to, _apply, ...) skip them. Restored on exit.
+        """
+        detached = {n: self._modules.pop(n) for n in names if n in self._modules}
+        try:
+            yield
+        finally:
+            self._modules.update(detached)
+
+    @contextmanager
+    def pause_for_external_mutation(self) -> Iterator[None]:
+        """
+        Defensive counterpart to ``CPUOffloadedRecMetricModule.pause_for_external_mutation``
+        in case this module is ever held outside the offloaded module's
+        ``_modules`` (so the offloaded module's pop would not protect it).
+        Pops ``rec_metrics`` and ``throughput_metric`` for the duration of an
+        external traversal that mutates module state.
+        """
+        with self._detach_children("rec_metrics", "throughput_metric"):
+            yield
 
     def _clone_rec_metrics(self) -> RecMetricList:
         """

--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -13,10 +13,11 @@ import queue
 import threading
 import time
 import traceback
-from typing import Any, Dict, Mapping, Optional, Union
+from contextlib import contextmanager, ExitStack
+from typing import Any, Dict, Iterator, Mapping, Optional, Union
 
 import torch
-from torch import distributed as dist
+from torch import distributed as dist, nn
 from torch.profiler import record_function
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
 from torchrec.distributed.logging_utils import EventType
@@ -254,6 +255,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             if required_inputs:
                 metric_update_job.kwargs["required_inputs"] = required_inputs
 
+            _assert_buffers_on_cpu(self.rec_metrics, "rec_metrics")
             self.rec_metrics.update(
                 predictions=predictions,
                 labels=labels,
@@ -262,6 +264,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             )
 
             if self.throughput_metric:
+                _assert_buffers_on_cpu(self.throughput_metric, "throughput_metric")
                 self.throughput_metric.update()
 
             elapsed_ms = (time.time() - start_time) * 1000
@@ -459,6 +462,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         with record_function("## CPUOffloadedRecMetricModule:compute ##"):
             start_ms = time.time()
+            _assert_buffers_on_cpu(self.comms_module, "comms_module")
             self.comms_module.load_local_metric_state_snapshot(
                 metric_compute_job.metric_state_snapshot
             )
@@ -721,16 +725,66 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         Args are identical to torch.nn.Module.load_state_dict().
         """
-        # Temporarily remove comms_module from _modules. Otherwise, it will try to traverse
-        # the submodule tree and load the state dict into the comms module.
-        comms_module = self._modules.pop("comms_module", None)
-
-        try:
+        # Without this, super().load_state_dict() would traverse into comms_module
+        # and load the state dict into both rec_metrics and comms_module.
+        with self._detach_children("comms_module"):
             super().load_state_dict(state_dict, strict=strict, assign=assign)
+
+    @contextmanager
+    def _detach_children(self, *names: str) -> Iterator[None]:
+        """
+        Temporarily de-register named children from self._modules so that
+        nn.Module traversals (.to, _apply, load_state_dict, ...) skip them.
+        Restored on exit.
+        """
+        detached = {n: self._modules.pop(n) for n in names if n in self._modules}
+        try:
+            yield
         finally:
-            # Restore comms_module
-            if comms_module is not None:
-                self._modules["comms_module"] = comms_module
+            self._modules.update(detached)
+
+    @contextmanager
+    def pause_for_external_mutation(self) -> Iterator[None]:
+        """
+        De-register every CPU-pinned child and own buffer for the duration of
+        an external traversal that mutates module state -- for example, a
+        parent module's ``.to(cuda)`` propagated by cudagraph wrap or Pyper
+        init.
+
+        ZORM keeps all metric state on CPU; without this guard, a parent's
+        ``.to(cuda)`` would migrate ``rec_metrics`` / ``comms_module`` /
+        ``throughput_metric`` buffers to GPU and the next worker-thread
+        ``state += state_value`` would raise a device mismatch. The compute
+        worker also reads/writes the inherited ``_compute_interval_steps``
+        buffer via ``_adjust_compute_interval``; that buffer must stay on CPU
+        too.
+
+        Pre-condition: both the update queue and the compute queue must be
+        empty. The workers access children via ``self.<name>`` attribute
+        lookup; if a worker tries to look up a popped name during the detach
+        window, it gets ``AttributeError``. Keeping the queues empty ensures
+        no worker is mid-job during the detach.
+        """
+        # Use raise rather than assert: this guard prevents a worker
+        # AttributeError race; assertions are stripped under `python -O`.
+        if not (self.update_queue.empty() and self.compute_queue.empty()):
+            raise RuntimeError(
+                "pause_for_external_mutation requires both queues to be empty. "
+                "Call sync() first or only use this during init / before any "
+                "update() call."
+            )
+        detached_buffers = {
+            n: self._buffers.pop(n)
+            for n in ("_compute_interval_steps",)
+            if n in self._buffers
+        }
+        try:
+            with self._detach_children(
+                "rec_metrics", "comms_module", "throughput_metric"
+            ):
+                yield
+        finally:
+            self._buffers.update(detached_buffers)
 
     @override
     def unsync(self) -> None:
@@ -740,3 +794,51 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         and is essentially "discarded" after compute().
         """
         pass
+
+
+def _assert_buffers_on_cpu(module: nn.Module, label: str) -> None:
+    """
+    Verify every buffer under ``module`` is on CPU. Called from ZORM worker
+    threads before they touch metric state -- if a parent's ``.to(cuda)`` was
+    not wrapped in ``detach_zorm_for_device_traversal()``, this surfaces the
+    misuse with an actionable message instead of a cryptic ``state += value``
+    device-mismatch deep in TorchMetrics.
+    """
+    for name, buf in module.named_buffers():
+        if buf.device.type != "cpu":
+            raise RuntimeError(
+                f"ZORM metric state buffer {label}.{name} is on {buf.device}, "
+                "expected CPU. A caller migrated ZORM state off CPU. Wrap any "
+                "model.to(cuda)/.cuda() call with detach_zorm_for_device_traversal() "
+                "from torchrec.metrics.cpu_offloaded_metric_module."
+            )
+
+
+@contextmanager
+def detach_zorm_for_device_traversal(model: nn.Module) -> Iterator[None]:
+    """
+    Wrap any caller-driven traversal that mutates module state (typically
+    ``model.to(cuda)`` from cudagraph wrap or Pyper init) so that ZORM's
+    CPU-pinned children are temporarily de-registered and skipped.
+
+    Usage::
+
+        with detach_zorm_for_device_traversal(model):
+            model.to(torch.cuda.current_device())
+
+    Walks ``model.modules()`` once up-front to collect ZORM instances so the
+    iterator is not invalidated by the subsequent ``_modules`` mutation.
+    """
+    # Local import to avoid an import cycle: cpu_comms_metric_module imports
+    # from cpu_offloaded_metric_module via its parent package wiring.
+    from torchrec.metrics.cpu_comms_metric_module import CPUCommsRecMetricModule
+
+    pinned_modules = [
+        m
+        for m in model.modules()
+        if isinstance(m, (CPUOffloadedRecMetricModule, CPUCommsRecMetricModule))
+    ]
+    with ExitStack() as stack:
+        for m in pinned_modules:
+            stack.enter_context(m.pause_for_external_mutation())
+        yield

--- a/torchrec/metrics/tests/test_cpu_comms_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_comms_metric_module.py
@@ -87,6 +87,36 @@ class CPUCommsRecMetricModuleTest(unittest.TestCase):
             # unwanted distributed syncs. All syncs will be called via cpu_comms_module.
             self.assertTrue(cloned_metric.verify_sync_disabled())
 
+    def test_pause_for_external_mutation_keeps_state_on_cpu(self) -> None:
+        """
+        Defensive: pause_for_external_mutation on the comms module pops
+        rec_metrics from _modules so a parent's .to(...) traversal does not
+        migrate the comms-side state buffers off CPU.
+        """
+        mock_metric = MockRecMetric(
+            world_size=self.world_size,
+            my_rank=self.my_rank,
+            batch_size=self.batch_size,
+            tasks=self.tasks,
+            initial_states={"state_1": torch.tensor([1.0])},
+        )
+        cpu_comms_module = CPUCommsRecMetricModule(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            rec_tasks=self.tasks,
+            rec_metrics=RecMetricList([mock_metric]),
+        )
+
+        # Inside the context, rec_metrics is not visible via _modules.
+        with cpu_comms_module.pause_for_external_mutation():
+            self.assertNotIn("rec_metrics", cpu_comms_module._modules)
+
+        # Restored on exit.
+        self.assertIn("rec_metrics", cpu_comms_module._modules)
+        self.assertIs(
+            cpu_comms_module._modules["rec_metrics"], cpu_comms_module.rec_metrics
+        )
+
     def test_load_metric_states(self) -> None:
         """
         Test loading metric states into a single metric computation.

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -21,6 +21,7 @@ from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.metrics.cpu_offloaded_metric_module import (
     CPUOffloadedRecMetricModule,
+    detach_zorm_for_device_traversal,
     MetricUpdateJob,
 )
 from torchrec.metrics.deferrable_metrics import transfer_tensors_to_cpu
@@ -530,6 +531,54 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 "state_3": torch.tensor([1.0]),
             },
         )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_detach_zorm_for_device_traversal_keeps_state_on_cpu(self) -> None:
+        """
+        Regression for ZORM + cudagraph compatibility (sijiaw MAST job
+        f1075434594 on 2026-05-01).
+
+        When a parent module containing a CPUOffloadedRecMetricModule has
+        .to(cuda) called on it -- e.g., the post-make_graphed_callables sweep
+        at caffe2/torch/fb/module_factory/sync_sgd/cuda_graph_wrapper.py:157
+        -- nn.Module recursion drags ZORM's metric state buffers onto the
+        GPU. The worker thread then crashes on `state += state_value` (state
+        on cuda, state_value on cpu via transfer_tensors_to_cpu).
+
+        Fix: detach_zorm_for_device_traversal(model) is a context manager
+        that temporarily de-registers ZORM's CPU-pinned children from
+        self._modules so the parent's .to(cuda) recursion skips them.
+        """
+        parent = torch.nn.Module()
+        # pyre-ignore[16]: dynamic submodule attribute on bare nn.Module
+        parent.metric_module = self.cpu_module
+
+        # Sanity: every buffer starts on CPU before the traversal.
+        named_buffers_before = list(self.cpu_module.named_buffers())
+        self.assertGreater(
+            len(named_buffers_before),
+            0,
+            "expected ZORM module to have at least one state buffer to validate",
+        )
+        for name, buf in named_buffers_before:
+            self.assertEqual(
+                buf.device.type,
+                "cpu",
+                f"{name} expected on CPU before traversal, found {buf.device}",
+            )
+
+        with detach_zorm_for_device_traversal(parent):
+            parent.to("cuda:0")
+
+        for name, buf in self.cpu_module.named_buffers():
+            self.assertEqual(
+                buf.device.type,
+                "cpu",
+                f"{name} expected on CPU after wrapped .to(cuda), found {buf.device}",
+            )
 
     @unittest.skipIf(
         torch.cuda.device_count() < 2,
@@ -1137,7 +1186,10 @@ def _compare_metric_results_worker(
         world_size=world_size,
         rec_tasks=tasks,
         rec_metrics=RecMetricList([offloaded_metric]),
-    ).to(device)
+    )
+    # ZORM keeps all metric state on CPU; .to(device) here would migrate state
+    # buffers to GPU and break the worker thread. model_out_device tells ZORM
+    # where the inputs come from, which is all it needs.
 
     # Generate same training data for both modules
     torch.manual_seed(42 + rank)  # Ensure deterministic but rank-specific data


### PR DESCRIPTION
Summary:
CPUOffloadedRecMetricModule pins metric state to CPU because its update/compute worker threads run there. When a parent module's `.to(cuda)` recursion walks into it, the rec_metrics / comms_module / throughput_metric buffers and the inherited `_compute_interval_steps` migrate to GPU, and the next worker-thread `state += state_value` raises a device mismatch.

Add `detach_zorm_for_device_traversal(model)` -- a context manager that callers wrap around `model.to(cuda)` so CPU-pinned children are temporarily de-registered from `_modules` and restored on exit. Generalizes the pop trick already used in `load_state_dict`. Add an always-on `_assert_buffers_on_cpu` check in both worker loops so future callers that bypass the wrap fail fast with an actionable message instead of a cryptic device error.

Differential Revision: D103754477


