### PR TITLE
Add PG check before tensor data usage in dist_data.py (#4245)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -16,6 +16,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.autograd.profiler import record_function
+from torch.distributed.distributed_c10d import ProcessGroupNCCL
 from torchrec.distributed.comm_ops import (
     all_gather_base_pooled,
     alltoall_pooled,
@@ -93,6 +94,27 @@ except Exception:
 
 
 logger: logging.Logger = logging.getLogger()
+
+
+def check_pg_for_nccl_error(pg: dist.ProcessGroup) -> None:
+    """Raise if the ProcessGroup has been flagged with an NCCL timeout or error."""
+    try:
+        backend = pg._get_backend(torch.device("cuda"))
+    except (RuntimeError, AttributeError):
+        return
+    if not isinstance(backend, ProcessGroupNCCL):
+        return
+    error = backend.get_error()
+    if error != torch._C._distributed_c10d.ErrorType.SUCCESS:
+        pg_name = pg.group_name if hasattr(pg, "group_name") else "unknown"
+        pg_desc = pg.group_desc if hasattr(pg, "group_desc") else ""
+        raise RuntimeError(
+            f"NCCL error detected on ProcessGroup "
+            f"(name={pg_name}, desc={pg_desc}, error={error}). "
+            f"Aborting to prevent silent data corruption "
+            f"from collective failure."
+        )
+
 
 _INT32_MAX: int = 2_147_483_647
 _INT64_MAX: int = 9_223_372_036_854_775_807
@@ -436,6 +458,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         collective_tag_parts: Optional[Tuple[object, ...]] = None,
     ) -> None:
         super().__init__()
+        self._pg: dist.ProcessGroup = pg
         self.num_workers: int = pg.size()
         self._collective_tag = collective_tag
         self._collective_tag_parts = collective_tag_parts
@@ -600,6 +623,12 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
                     f"the underlying mismatch will still cause silent data "
                     f"corruption or an NCCL hang downstream."
                 )
+
+        # After .tolist() the CPU has blocked on the GPU.  If a prior
+        # collective timed out the watchdog will have flagged the PG by now.
+        # Check before the overflow validation below so we report "NCCL
+        # timeout" instead of a misleading "int32 overflow on garbage data".
+        check_pg_for_nccl_error(self._pg)
 
         # Check for int32 overflow in AllToAll input. If the input is already
         # corrupted, the corruption happened before the collective.

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -95,6 +95,32 @@ except Exception:
 
 logger: logging.Logger = logging.getLogger()
 
+
+def _check_pg_for_nccl_error(pg: dist.ProcessGroup) -> None:
+    """Raise if the ProcessGroup has been flagged with an NCCL timeout or error."""
+    try:
+        backend = pg._get_backend(torch.device("cuda"))
+    except RuntimeError:
+        # RuntimeError: cannot get cuda device for cpu machines
+        # Exit gracefully
+        torch._C._log_api_usage_once(
+            "_check_pg_for_nccl_error: could not get cuda backend"
+        )
+        return
+    if not hasattr(backend, "get_error"):
+        return
+    error = backend.get_error()
+    if error != torch._C._distributed_c10d.ErrorType.SUCCESS:
+        pg_name = pg.group_name
+        pg_desc = pg.group_desc
+        raise RuntimeError(
+            f"NCCL error detected on ProcessGroup "
+            f"(name={pg_name}, desc={pg_desc}, error={error}). "
+            f"Aborting to prevent silent data corruption "
+            f"from collective failure."
+        )
+
+
 _INT32_MAX: int = 2_147_483_647
 _INT64_MAX: int = 9_223_372_036_854_775_807
 
@@ -430,6 +456,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         collective_tag_parts: Optional[Tuple[object, ...]] = None,
     ) -> None:
         super().__init__()
+        self._pg: dist.ProcessGroup = pg
         self.num_workers: int = pg.size()
         self._collective_tag = collective_tag
         self._collective_tag_parts = collective_tag_parts
@@ -564,6 +591,12 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
             self._splits_awaitable.wait()
 
         ret = _safe_tolist_2d(self._output_tensor.view(self.num_workers, -1).T)
+
+        # After .tolist() the CPU has blocked on the GPU.  If a prior
+        # collective timed out the watchdog will have flagged the PG by now.
+        # Check before the overflow validation below so we report "NCCL
+        # timeout" instead of a misleading "int32 overflow on garbage data".
+        _check_pg_for_nccl_error(self._pg)
 
         # Validate collective tag if present. The validation block itself is
         # skipped under torch.compile: .tolist() returns unbacked symints, so

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -29,9 +29,11 @@ import torch
 import torch.distributed as dist
 from hypothesis import given, settings
 from pyre_extensions import none_throws
+from torch.distributed.distributed_c10d import ProcessGroupNCCL
 from torchrec.distributed.dist_data import (
     _collective_tag_from,
     _get_recat,
+    check_pg_for_nccl_error,
     JaggedTensorAllToAll,
     KJTAllToAll,
     KJTAllToAllSplitsAwaitable,
@@ -2416,3 +2418,29 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
             world_size=2,
             backend="gloo",
         )
+
+
+class CheckPgForNcclErrorTest(unittest.TestCase):
+    """Unit tests for the check_pg_for_nccl_error helper."""
+
+    def test_returns_on_success(self) -> None:
+        """NCCL backend with SUCCESS error status should be a no-op."""
+        pg = unittest.mock.MagicMock(spec=dist.ProcessGroup)
+        backend = unittest.mock.MagicMock(spec=ProcessGroupNCCL)
+        backend.get_error.return_value = torch._C._distributed_c10d.ErrorType.SUCCESS
+        pg._get_backend.return_value = backend
+        self.assertIsNone(check_pg_for_nccl_error(pg))
+
+    def test_raises_on_nccl_error(self) -> None:
+        """NCCL backend with a non-SUCCESS error should raise RuntimeError."""
+        pg = unittest.mock.MagicMock(spec=dist.ProcessGroup)
+        pg.group_name = "test_pg"
+        pg.group_desc = "test_desc"
+        backend = unittest.mock.MagicMock(spec=ProcessGroupNCCL)
+        backend.get_error.return_value = torch._C._distributed_c10d.ErrorType.TIMEOUT
+        pg._get_backend.return_value = backend
+        with self.assertRaises(RuntimeError) as ctx:
+            check_pg_for_nccl_error(pg)
+        self.assertIn("NCCL error detected", str(ctx.exception))
+        self.assertIn("test_pg", str(ctx.exception))
+        self.assertIn("test_desc", str(ctx.exception))

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -22,6 +22,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from unittest.mock import MagicMock
 
 import hypothesis.strategies as st
 import torch
@@ -30,6 +31,7 @@ import torchrec.distributed.collective_utils as cu
 from hypothesis import given, settings
 from pyre_extensions import none_throws
 from torchrec.distributed.dist_data import (
+    _check_pg_for_nccl_error,
     _collective_tag_from,
     _get_recat,
     JaggedTensorAllToAll,
@@ -2426,3 +2428,84 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
             world_size=2,
             backend="gloo",
         )
+
+
+# Convenience alias for the c10d ErrorType enum used by the NCCL guard.
+_ErrorType = torch._C._distributed_c10d.ErrorType
+
+
+def _make_mock_pg(
+    backend: object,
+    *,
+    backend_raises: bool = False,
+    group_name: str = "splits_a2a_pg",
+    group_desc: str = "kjt_splits_collective",
+) -> MagicMock:
+    """Build a mock ProcessGroup for _check_pg_for_nccl_error.
+
+    No real ProcessGroup / NCCL / GPU is involved. ``pg._get_backend`` returns
+    ``backend`` (or raises RuntimeError when ``backend_raises`` is set, mimicking
+    a CPU-only host that cannot resolve a cuda backend).
+    """
+    pg = MagicMock(spec=dist.ProcessGroup)
+    pg.group_name = group_name
+    pg.group_desc = group_desc
+    if backend_raises:
+        pg._get_backend.side_effect = RuntimeError(
+            "cannot get cuda device for cpu machines"
+        )
+    else:
+        pg._get_backend.return_value = backend
+    return pg
+
+
+class CheckPgForNcclErrorTest(unittest.TestCase):
+    """Deterministic fault-injection tests for the ``_check_pg_for_nccl_error``
+    guard added to ``dist_data.py``. These run with mocks only -- no real
+    ProcessGroup, NCCL, GPU, or distributed init."""
+
+    def test_raises_on_non_success_error(self) -> None:
+        """backend.get_error() returns a non-SUCCESS ErrorType -> RuntimeError
+        is raised, and the message carries the pg name, desc, and error."""
+        backend = MagicMock()
+        backend.get_error.return_value = _ErrorType.TIMEOUT
+        pg = _make_mock_pg(backend, group_name="my_pg_name", group_desc="my_pg_desc")
+
+        with self.assertRaisesRegex(
+            RuntimeError, "NCCL error detected on ProcessGroup"
+        ) as cm:
+            _check_pg_for_nccl_error(pg)
+
+        message = str(cm.exception)
+        self.assertIn("my_pg_name", message)
+        self.assertIn("my_pg_desc", message)
+        self.assertIn("TIMEOUT", message)
+        self.assertIn("silent data corruption", message)
+        backend.get_error.assert_called_once()
+
+    def test_no_raise_on_success(self) -> None:
+        """backend.get_error() returns SUCCESS -> the guard does NOT raise."""
+        backend = MagicMock()
+        backend.get_error.return_value = _ErrorType.SUCCESS
+        pg = _make_mock_pg(backend)
+
+        # Should return None without raising.
+        self.assertIsNone(_check_pg_for_nccl_error(pg))
+        backend.get_error.assert_called_once()
+
+    def test_no_raise_when_backend_has_no_get_error(self) -> None:
+        """Backend lacks a get_error attribute (e.g. gloo) -> graceful no-op.
+
+        ``object()`` has no ``get_error`` attribute, so ``hasattr`` is False."""
+        backend = object()
+        pg = _make_mock_pg(backend)
+
+        self.assertIsNone(_check_pg_for_nccl_error(pg))
+
+    def test_no_raise_when_get_backend_raises(self) -> None:
+        """pg._get_backend raises RuntimeError (cpu / no-cuda host) -> the guard
+        swallows it and returns gracefully."""
+        pg = _make_mock_pg(backend=None, backend_raises=True)
+
+        self.assertIsNone(_check_pg_for_nccl_error(pg))
+        pg._get_backend.assert_called_once()


### PR DESCRIPTION
Summary:

We have noticed that certain IG-ML jobs result in corrupted tensor data in tensors after an NCCL timeout that torchrec ends up using to show faulty data. This results in errors like int32 overflows, which can be misleading when investigating job failures.

These type of data corruption issues are usually transient for jobs with nccl timeouts because there is a race condition between whether the nccl job about kills the job before torchrec processes the corrupt data, which is why not every job with nccl timeout shows this issue

Reviewed By: kausv

Differential Revision: D102664109


