### PR TITLE
Enable uneven buckets per rank (#4262)

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -7,7 +7,6 @@ RunOptions:
   num_batches: 20
   num_benchmarks: 5
   num_profiles: 1
-  sharding_type: row_wise        # MP-ZCH only works with row-wise sharding
   profile_dir: "."
   name: "sparse_data_dist_mpzch"
   num_float_features: 1000
@@ -33,7 +32,6 @@ EmbeddingTablesConfig:
   mc_config:
     mc_type: "mp-zch"           # Either "mp-zch" or "sort-zch"
     total_num_buckets: 10       # zch_size must be a multiple of total_num_buckets,
-                                #     and total_num_buckets must be a multiple of world size
     max_probe: 128              # Controls amount of time kernel searches for lookup or insertion
     input_hash_size: 0          # Maximum input hash size.
     disable_fallback: False     # If ID lookup fails, then the IDS are removed entirely from output.
@@ -50,7 +48,7 @@ EmbeddingTablesConfig:
         data_type: FP16
         mc_config:
           mc_type: "mp-zch"
-          total_num_buckets: 10
+          total_num_buckets: 5
           max_probe: 128
           input_hash_size: 0
           eviction_policy_name: "SINGLE_TTL_EVICTION"
@@ -58,6 +56,7 @@ EmbeddingTablesConfig:
             single_ttl: 1
           disable_fallback: False
 PlannerConfig:
+  sharding_type: row_wise
   pooling_factors: [30.0]  # Must match ModelInputConfig.feature_pooling_avg
   # MP-ZCH only works with row-wise sharding
   additional_constraints:

--- a/torchrec/distributed/mc_modules.py
+++ b/torchrec/distributed/mc_modules.py
@@ -508,6 +508,18 @@ class ShardedManagedCollisionCollection(
             self._sharding_features,
         ):
             assert isinstance(sharding, BaseRwEmbeddingSharding)
+
+            feature_to_sharded_table = {
+                feature: table
+                for group_config in sharding._grouped_embedding_configs_per_rank[0]
+                for table in group_config.embedding_tables
+                for feature in table.feature_names
+            }
+
+            embedding_table_sizes = [
+                feature_to_sharded_table[f].num_embeddings for f in sharding_features
+            ]
+
             feature_num_buckets: List[int] = [
                 # pyrefly: ignore[not-callable]
                 self._managed_collision_modules[self._feature_to_table[f]].buckets()
@@ -522,10 +534,7 @@ class ShardedManagedCollisionCollection(
 
             feature_hash_sizes: List[int] = []
             feature_total_num_buckets: List[int] = []
-            for input_size, num_buckets in zip(
-                input_sizes,
-                feature_num_buckets,
-            ):
+            for input_size, num_buckets in zip(input_sizes, feature_num_buckets):
                 feature_hash_sizes.append(input_size)
                 feature_total_num_buckets.append(num_buckets)
 
@@ -540,6 +549,7 @@ class ShardedManagedCollisionCollection(
                 has_feature_processor=sharding._has_feature_processor,
                 need_pos=False,
                 keep_original_indices=True,
+                zch_sizes=embedding_table_sizes,
             )
             self._input_dists.append(input_dist)
 
@@ -581,6 +591,18 @@ class ShardedManagedCollisionCollection(
             self._sharding_features,
         ):
             assert isinstance(sharding, BaseRwEmbeddingSharding)
+
+            feature_to_sharded_table = {
+                feature: table
+                for group_config in sharding._grouped_embedding_configs_per_rank[0]
+                for table in group_config.embedding_tables
+                for feature in table.feature_names
+            }
+
+            embedding_table_sizes = [
+                feature_to_sharded_table[f].num_embeddings for f in sharding_features
+            ]
+
             feature_num_buckets: List[int] = [
                 # pyrefly: ignore[not-callable]
                 self._managed_collision_modules[self._feature_to_table[f]].buckets()
@@ -608,6 +630,7 @@ class ShardedManagedCollisionCollection(
                 device=sharding._device,
                 is_sequence=True,
                 keep_original_indices=True,
+                zch_sizes=embedding_table_sizes,
             )
             self._write_input_dists.append(write_dist)
 

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -51,6 +51,9 @@ from torchrec.modules.embedding_modules import (
     EmbeddingCollection,
 )
 from torchrec.modules.embedding_tower import EmbeddingTower, EmbeddingTowerCollection
+from torchrec.modules.mc_embedding_modules import (
+    BaseManagedCollisionEmbeddingCollection,
+)
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -312,12 +315,15 @@ class EmbeddingEnumerator(Enumerator):
         Returns:
             Optional[int]: Number of buckets for the table, or None if module is not EmbeddingBagCollection or table not found.
         """
-        # If module is not of type EmbeddingBagCollection, return None
         if isinstance(module, EmbeddingBagCollection):
             embedding_configs = module.embedding_bag_configs()
         elif isinstance(module, EmbeddingCollection):
             embedding_configs = module.embedding_configs()
+        elif isinstance(module, BaseManagedCollisionEmbeddingCollection):
+            all_buckets = module._managed_collision_collection.table_to_number_buckets()
+            return all_buckets[parameter] if parameter in all_buckets else None
         else:
+            # Module does not utilize buckets
             return None
 
         # Find the embedding config for the table with the same name as parameter input

--- a/torchrec/distributed/sharding/rw_sequence_sharding.py
+++ b/torchrec/distributed/sharding/rw_sequence_sharding.py
@@ -134,7 +134,7 @@ class RwSequenceEmbeddingSharding(
     ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
         num_features = self._get_num_features()
         feature_hash_sizes = self._get_feature_hash_sizes()
-        virtual_table_feature_num_buckets, has_uneven_virtual_tables = (
+        virtual_table_feature_num_buckets = (
             self._get_virtual_table_feature_num_buckets()
         )
         return RwSparseFeaturesDist(
@@ -148,7 +148,6 @@ class RwSequenceEmbeddingSharding(
             has_feature_processor=self._has_feature_processor,
             need_pos=False,
             virtual_table_feature_num_buckets=virtual_table_feature_num_buckets,
-            has_uneven_virtual_tables=has_uneven_virtual_tables,
         )
 
     def create_lookup(

--- a/torchrec/distributed/sharding/rw_sharding.py
+++ b/torchrec/distributed/sharding/rw_sharding.py
@@ -107,6 +107,38 @@ def get_embedding_shard_metadata(
     return (embed_sharding, is_even_sharding)
 
 
+def _get_bucketize_row_pos(
+    world_size: int,
+    feature_num_buckets: Optional[List[int]],
+    feature_block_sizes: List[int],
+) -> Optional[List[torch.Tensor]]:
+    # Creates the bucketize row positions for input-id space with uneven sharding with buckets. If the number of
+    # buckets is greater than the world size, and world_size % num_buckets != 0, the buckets count will not be
+    # the same on each rank. Bucketize_row_pos object lays out the distribution of buckets in this scenario.
+    # For eg.
+    # Bucketize_row_pos
+    # [
+    #   Tensor([0, 4, 8, 12, 15, 18, 21]), Feature 1 has 4 buckets on ranks 0, 1, 2. 3 buckets on ranks 3, 4, 5
+    #   Tensor([0, 2, 4, 6, 7, 8, 9]), Feature 2 has 2 buckets on ranks 0, 1, 2. 1 bucket on ranks 3, 4, 5
+    # ]
+    if feature_num_buckets is None or len(feature_num_buckets) == 0:
+        return None
+    bucketize_row_pos = [[0] for _ in range(len(feature_num_buckets))]
+    bucketize_row_pos_tensors = []
+    for feature in range(len(feature_num_buckets)):
+        for rank in range(world_size):
+            bucketize_row_pos[feature].append(
+                bucketize_row_pos[feature][-1]
+                + (
+                    (feature_num_buckets[feature] // world_size)
+                    + int(rank < feature_num_buckets[feature] % world_size)
+                )
+                * feature_block_sizes[feature]
+            )
+        bucketize_row_pos_tensors.append(torch.tensor(bucketize_row_pos[feature]))
+    return bucketize_row_pos_tensors
+
+
 class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
     """
     Base class for row-wise sharding.
@@ -302,14 +334,13 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                 feature_hash_sizes.extend(group_config.feature_hash_sizes())
         return feature_hash_sizes
 
-    def _get_virtual_table_feature_num_buckets(self) -> Tuple[List[int], bool]:
+    def _get_virtual_table_feature_num_buckets(self) -> List[int]:
         """
         Returns the number of buckets for each KVZCH feature in the GroupedEmbeddingConfigs.
         If a feature is not a KVZCH feature, the list will have world_size for that feature's corresponding position.
         This is needed as KVZCH features have to be processed for input_dist with non-KVZCH features.
         """
         feature_num_buckets: List[int] = []
-        has_uneven_virtual_tables = False
         for group_config in self._grouped_embedding_configs:
             for embedding_table in group_config.embedding_tables:
                 if (
@@ -320,14 +351,11 @@ class BaseRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
                         [embedding_table.total_num_buckets]
                         * embedding_table.num_features()
                     )
-                    has_uneven_virtual_tables = has_uneven_virtual_tables or (
-                        embedding_table.total_num_buckets % self._world_size != 0
-                    )
                 else:
                     feature_num_buckets.extend(
                         [self._world_size] * embedding_table.num_features()
                     )
-        return feature_num_buckets, has_uneven_virtual_tables
+        return feature_num_buckets
 
 
 class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
@@ -361,46 +389,66 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         need_pos: bool = False,
         keep_original_indices: bool = False,
         virtual_table_feature_num_buckets: Optional[List[int]] = None,
-        has_uneven_virtual_tables: bool = False,
+        zch_sizes: Optional[List[int]] = None,
     ) -> None:
         super().__init__()
         self._world_size: int = pg.size()
         self._num_features = num_features
 
-        feature_block_sizes: List[int] = []
+        uneven_buckets_per_rank = False
+        if feature_total_num_buckets is not None:
+            uneven_buckets_per_rank = any(
+                num_buckets % self._world_size != 0
+                for num_buckets in feature_total_num_buckets
+            )
+        elif virtual_table_feature_num_buckets is not None:
+            uneven_buckets_per_rank = any(
+                num_buckets % self._world_size != 0
+                for num_buckets in virtual_table_feature_num_buckets
+            )
 
+        feature_block_sizes: List[int] = []
+        row_pos_block_sizes: List[int] = []
+        row_pos_num_buckets: List[int] = []
         for i, hash_size in enumerate(feature_hash_sizes):
             block_divisor = self._world_size
-            # Using different num_bucket lists for MPZCH and KVZCH allows us to process them with
-            # different code paths for now, enabling uneven sharding for KVZCH only. MPZCH can have
-            # uneven sharding enabled for it as well in the future but that will require additional testing
             if feature_total_num_buckets is not None:
                 # MPZCH sharding
-                assert (
-                    feature_total_num_buckets[i] % self._world_size == 0
-                ), f"Number of buckets: {feature_total_num_buckets[i]} should be divisible by world size: {self._world_size} for MPZCH"
-
                 block_divisor = feature_total_num_buckets[i]
             elif (
-                has_uneven_virtual_tables
+                uneven_buckets_per_rank
                 and virtual_table_feature_num_buckets is not None
                 and len(virtual_table_feature_num_buckets)
             ):
                 # KVZCH uneven sharding
-                assert (
-                    virtual_table_feature_num_buckets[i] >= self._world_size
-                ), f"Number of buckets: {virtual_table_feature_num_buckets[i]} for a table cannot be less than the word_size: {self._world_size}"
-
                 block_divisor = virtual_table_feature_num_buckets[i]
-            feature_block_sizes.append((hash_size + block_divisor - 1) // block_divisor)
 
-        self.kvzch_bucketize_row_pos: Optional[List[torch._tensor.Tensor]] = (
+            assert (
+                block_divisor >= self._world_size
+            ), f"Number of buckets: {block_divisor} for a table cannot be less than the word_size: {self._world_size}"
+
+            input_spc_block_size = (hash_size + block_divisor - 1) // block_divisor
+            feature_block_sizes.append(input_spc_block_size)
+
+            if uneven_buckets_per_rank:
+                row_pos_num_buckets.append(block_divisor)
+                if hash_size == 0:
+                    assert (
+                        zch_sizes is not None
+                    ), "When hash-size is infinite, then zch_sizes must be provided"
+                    row_pos_block_sizes.append(
+                        (zch_sizes[i] + block_divisor - 1) // block_divisor
+                    )
+                else:
+                    row_pos_block_sizes.append(input_spc_block_size)
+
+        self.zch_bucketize_row_pos: Optional[List[torch.Tensor]] = (
             (
-                self._get_bucketize_row_pos(
-                    virtual_table_feature_num_buckets, feature_block_sizes
+                _get_bucketize_row_pos(
+                    self._world_size, row_pos_num_buckets, row_pos_block_sizes
                 )
             )
-            if has_uneven_virtual_tables
+            if uneven_buckets_per_rank
             else None
         )
 
@@ -436,37 +484,6 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
         self._need_pos = need_pos
         self.unbucketize_permute_tensor: Optional[torch.Tensor] = None
         self._keep_original_indices = keep_original_indices
-
-    def _get_bucketize_row_pos(
-        self,
-        feature_num_buckets: Optional[List[int]],
-        feature_block_sizes: List[int],
-    ) -> Optional[List[torch.Tensor]]:
-        # Creates the bucketize row positions for uneven sharding with buckets. If the number of buckets
-        # is greater than the world size, and world_size % num_buckets != 0, the buckets count will not be
-        # the same on each rank. Bucketize_row_pos object lays out the distribution of buckets in this scenario.
-        # For eg.
-        # Bucketize_row_pos
-        # [
-        #   Tensor([0, 4, 8, 12, 15, 18, 21]), Feature 1 has 4 buckets on ranks 0, 1, 2. 3 buckets on ranks 3, 4, 5
-        #   Tensor([0, 2, 4, 6, 7, 8, 9]), Feature 2 has 2 buckets on ranks 0, 1, 2. 1 bucket on ranks 3, 4, 5
-        # ]
-        if feature_num_buckets is None or len(feature_num_buckets) == 0:
-            return None
-        bucketize_row_pos = [[0] for _ in range(len(feature_num_buckets))]
-        bucketize_row_pos_tensors = []
-        for feature in range(len(feature_num_buckets)):
-            for rank in range(self._world_size):
-                bucketize_row_pos[feature].append(
-                    bucketize_row_pos[feature][-1]
-                    + (
-                        (feature_num_buckets[feature] // self._world_size)
-                        + int(rank < feature_num_buckets[feature] % self._world_size)
-                    )
-                    * feature_block_sizes[feature]
-                )
-            bucketize_row_pos_tensors.append(torch.tensor(bucketize_row_pos[feature]))
-        return bucketize_row_pos_tensors
 
     @EventLoggingHandler.event_logger(
         TorchrecComponent.INPUT_DIST, n=1000, add_wait_counter=True
@@ -508,7 +525,7 @@ class RwSparseFeaturesDist(BaseSparseFeaturesDist[KeyedJaggedTensor]):
                 else self._need_pos
             ),
             keep_original_indices=self._keep_original_indices,
-            block_bucketize_row_pos=self.kvzch_bucketize_row_pos,
+            block_bucketize_row_pos=self.zch_bucketize_row_pos,
         )
 
         return self._dist(bucketized_features)
@@ -657,7 +674,7 @@ class RwPooledEmbeddingSharding(
     ) -> BaseSparseFeaturesDist[KeyedJaggedTensor]:
         num_features = self._get_num_features()
         feature_hash_sizes = self._get_feature_hash_sizes()
-        virtual_table_feature_num_buckets, has_uneven_virtual_tables = (
+        virtual_table_feature_num_buckets = (
             self._get_virtual_table_feature_num_buckets()
         )
         return RwSparseFeaturesDist(
@@ -671,7 +688,6 @@ class RwPooledEmbeddingSharding(
             has_feature_processor=self._has_feature_processor,
             virtual_table_feature_num_buckets=virtual_table_feature_num_buckets,
             need_pos=self._need_pos,
-            has_uneven_virtual_tables=has_uneven_virtual_tables,
         )
 
     def create_lookup(
@@ -728,19 +744,57 @@ class RwSparseFeaturesWriteDist(BaseSparseFeaturesWriteDist[KeyedJaggedTensor]):
         device: Optional[torch.device] = None,
         is_sequence: bool = False,
         keep_original_indices: bool = False,
+        zch_sizes: Optional[List[int]] = None,
     ) -> None:
         super().__init__()
         self._world_size: int = pg.size()
         self._num_features = num_features
 
-        feature_block_sizes: List[int] = []
+        # Checks if there are uneven buckets per rank based on if
+        # provided the number of buckets per feature.
+        uneven_buckets_per_rank: bool = False
+        if feature_total_num_buckets is not None:
+            uneven_buckets_per_rank = any(
+                num_buckets % self._world_size != 0
+                for num_buckets in feature_total_num_buckets
+            )
 
+        feature_block_sizes: List[int] = []
+        row_pos_block_sizes: List[int] = []
+        row_pos_num_buckets: List[int] = []
         for i, hash_size in enumerate(feature_hash_sizes):
             block_divisor = self._world_size
             if feature_total_num_buckets is not None:
-                assert feature_total_num_buckets[i] % self._world_size == 0
                 block_divisor = feature_total_num_buckets[i]
-            feature_block_sizes.append((hash_size + block_divisor - 1) // block_divisor)
+
+            assert (
+                block_divisor >= self._world_size
+            ), f"Number of buckets: {block_divisor} for a table cannot be less than the word_size: {self._world_size}"
+
+            input_block_size = (hash_size + block_divisor - 1) // block_divisor
+            feature_block_sizes.append(input_block_size)
+
+            if uneven_buckets_per_rank:
+                row_pos_num_buckets.append(block_divisor)
+                if hash_size == 0:
+                    assert (
+                        zch_sizes is not None
+                    ), "When hash-size is infinite, then zch_sizes must be provided"
+                    row_pos_block_sizes.append(
+                        (zch_sizes[i] + block_divisor - 1) // block_divisor
+                    )
+                else:
+                    row_pos_block_sizes.append(input_block_size)
+
+        self.zch_bucketize_row_pos: Optional[List[torch.Tensor]] = (
+            (
+                _get_bucketize_row_pos(
+                    self._world_size, row_pos_num_buckets, row_pos_block_sizes
+                )
+            )
+            if uneven_buckets_per_rank
+            else None
+        )
 
         self.register_buffer(
             "_feature_block_sizes_tensor",
@@ -788,7 +842,6 @@ class RwSparseFeaturesWriteDist(BaseSparseFeaturesWriteDist[KeyedJaggedTensor]):
         Returns:
             Awaitable[Awaitable[KeyedJaggedTensor]]: awaitable of awaitable of KeyedJaggedTensor.
         """
-
         (
             bucketized_features,
             self.unbucketize_permute_tensor,
@@ -806,6 +859,7 @@ class RwSparseFeaturesWriteDist(BaseSparseFeaturesWriteDist[KeyedJaggedTensor]):
             output_permute=self._is_sequence,
             bucketize_pos=False,
             keep_original_indices=self._keep_original_indices,
+            block_bucketize_row_pos=self.zch_bucketize_row_pos,
         )
 
         return self._dist(bucketized_features)

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -324,6 +324,7 @@ def _get_parameter_size_offsets(
     local_size: int,
     world_size: int,
     col_wise_shard_dim: Optional[int] = None,
+    num_buckets: Optional[int] = None,
 ) -> List[Tuple[List[int], List[int]]]:
     (
         shard_sizes,
@@ -334,6 +335,7 @@ def _get_parameter_size_offsets(
         local_world_size=local_size,
         sharding_type=sharding_type.value,
         col_wise_shard_dim=col_wise_shard_dim,
+        num_buckets=num_buckets,
     )
     return list(zip(shard_sizes, shard_offsets))
 
@@ -553,12 +555,15 @@ def table_wise(
 def row_wise(
     sizes_placement: Optional[Tuple[List[int], Union[str, List[str]]]] = None,
     compute_kernel: Optional[str] = None,
+    num_buckets: Optional[int] = None,
 ) -> ParameterShardingGenerator:
     """
     Returns a generator of ParameterShardingPlan for `ShardingType::ROW_WISE` for construct_module_sharding_plan.
 
     Args:
     sizes_placement (Optional[Tuple[List[int], str]]): Only use it in inference for uneven shardinglist of tuples of (sizes, placement); sizes is the row size list
+    compute_kernel (Optional[str]): embedding compute kernel to use for the table
+    num_buckets (Optional[int]): number of buckets to use for the table
 
     Example::
 
@@ -595,6 +600,7 @@ def row_wise(
                 ShardingType.ROW_WISE,
                 local_size,
                 world_size,
+                num_buckets=num_buckets,
             )
             assert len(size_and_offsets) <= world_size
             size_offset_ranks = []

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -87,21 +87,28 @@ class SparseArch(nn.Module):
         tables: List[EmbeddingConfig],
         device: torch.device,
         return_remapped: bool = False,
-        input_hash_size: int = 4000,
+        input_hash_size: List[int] | int = 4000,
         allow_in_place_embed_weight_update: bool = False,
         use_mpzch: bool = False,
     ) -> None:
         super().__init__()
         self._return_remapped = return_remapped
-
+        hash_sizes = [
+            input_hash_size if isinstance(input_hash_size, int) else input_hash_size[i]
+            for i in range(len(tables))
+        ]
         mc_modules: dict[str, ManagedCollisionModule] = {}
         if use_mpzch:
+            num_buckets: List[int] = [
+                int(t.total_num_buckets) if t.total_num_buckets is not None else 4
+                for t in tables
+            ]
             # Parameters hard-coded from test_quant_mc_embedding
             mc_modules["table_0"] = HashZchManagedCollisionModule(
                 zch_size=(tables[0].num_embeddings),
-                input_hash_size=input_hash_size,
+                input_hash_size=hash_sizes[0],
                 device=device,
-                total_num_buckets=4,
+                total_num_buckets=num_buckets[0],
                 eviction_policy_name=HashZchEvictionPolicyName.LRU_EVICTION,
                 eviction_config=HashZchEvictionConfig(
                     features=["feature_0"],
@@ -109,12 +116,11 @@ class SparseArch(nn.Module):
                 ),
                 max_probe=5,
             )
-
             mc_modules["table_1"] = HashZchManagedCollisionModule(
                 zch_size=(tables[1].num_embeddings),
                 device=device,
-                input_hash_size=input_hash_size,
-                total_num_buckets=4,
+                input_hash_size=hash_sizes[1],
+                total_num_buckets=num_buckets[1],
                 eviction_policy_name=HashZchEvictionPolicyName.LRU_EVICTION,
                 eviction_config=HashZchEvictionConfig(
                     features=["feature_1"],
@@ -125,7 +131,7 @@ class SparseArch(nn.Module):
         else:
             mc_modules["table_0"] = MCHManagedCollisionModule(
                 zch_size=(tables[0].num_embeddings),
-                input_hash_size=input_hash_size,
+                input_hash_size=hash_sizes[0],
                 device=device,
                 eviction_interval=2,
                 eviction_policy=DistanceLFU_EvictionPolicy(),
@@ -133,7 +139,7 @@ class SparseArch(nn.Module):
             mc_modules["table_1"] = MCHManagedCollisionModule(
                 zch_size=(tables[1].num_embeddings),
                 device=device,
-                input_hash_size=input_hash_size,
+                input_hash_size=hash_sizes[1],
                 eviction_interval=2,
                 eviction_policy=DistanceLFU_EvictionPolicy(),
             )
@@ -994,6 +1000,59 @@ def _test_2d_mc_syncing_preserves_top_indices(
             torch.testing.assert_close(preserved[nonempty], final_identities[nonempty])
 
 
+def _test_uneven_buckets_per_rank(
+    tables: List[EmbeddingConfig],
+    rank: int,
+    hash_sizes: List[int],
+    world_size: int,
+    sharder: ModuleSharder[nn.Module],
+    backend: str,
+    kjt_input_per_rank: List[KeyedJaggedTensor],
+    indices_to_rank: List[int],
+) -> None:
+    with MultiProcessContext(rank, world_size, backend) as ctx:
+        features = ["feature_0", "feature_1"]
+        sparse_arch = SparseArch(
+            tables,
+            torch.device("meta"),
+            use_mpzch=True,
+            input_hash_size=hash_sizes,
+        )
+        assert ctx.pg is not None
+        module_sharding_plan = construct_module_sharding_plan(
+            sparse_arch._mc_ec,
+            per_param_sharding={
+                "table_0": row_wise(num_buckets=tables[0].total_num_buckets),
+                "table_1": row_wise(num_buckets=tables[1].total_num_buckets),
+            },
+            local_size=None,
+            world_size=world_size,
+            device_type="cuda" if torch.cuda.is_available() else "cpu",
+            sharder=sharder,
+        )
+        sharded_sparse_arch = _shard_modules(
+            module=copy.deepcopy(sparse_arch),
+            plan=ShardingPlan({"_mc_ec": module_sharding_plan}),
+            #  `Optional[ProcessGroup]`.
+            # pyrefly: ignore[bad-argument-type]
+            env=ShardingEnv.from_process_group(ctx.pg),
+            sharders=[sharder],
+            device=ctx.device,
+        )
+
+        assert hasattr(sharded_sparse_arch._mc_ec, "_managed_collision_collection")
+        mc_module = sharded_sparse_arch._mc_ec._managed_collision_collection
+        assert isinstance(mc_module, ShardedManagedCollisionCollection)
+
+        kjt_rank = kjt_input_per_rank[rank].to(ctx.device)
+        mc_module._create_input_dists(features)
+        input_dists = mc_module._input_dists
+        assert len(input_dists) == 1
+        output = input_dists[0](kjt_rank).wait().wait()
+
+        torch.testing.assert_close(output.values().tolist(), indices_to_rank[rank])
+
+
 @skip_if_asan_class
 class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
     @unittest.skipIf(
@@ -1170,6 +1229,82 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
         )
 
     @unittest.skipIf(
+        torch.cuda.device_count() <= 2,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @given(backend=st.sampled_from(["nccl"]))
+    @settings(deadline=None)
+    def test_sharding_zch_uneven_buckets_per_rank(self, backend: str) -> None:
+        WORLD_SIZE = 2
+        # Test on one feature having infinite input space, and other finite
+        HASH_SIZES = [0, 40]  # hash sizes per feature
+        BUCKETS = [3, 5]  # uneven buckets for worldsize=2
+        embedding_config = [
+            EmbeddingConfig(
+                name="table_0",
+                feature_names=["feature_0"],
+                embedding_dim=8,
+                num_embeddings=9,
+                total_num_buckets=BUCKETS[0],
+            ),
+            EmbeddingConfig(
+                name="table_1",
+                feature_names=["feature_1"],
+                embedding_dim=8,
+                num_embeddings=10,
+                total_num_buckets=BUCKETS[1],
+            ),
+        ]
+        # feature_0 does interleave mapping to rank
+        # feature_1 does block mapping to rank
+        kjt_input_per_rank = [  # noqa
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [
+                        0,  # feature_0, rank 0
+                        1,  # feature_0, rank 0
+                        2,  # feature_0, rank 1
+                        3,  # feature_0, rank 0
+                        4,  # feature_0, rank 0
+                        5,  # feature_0, rank 1
+                        0,  # feature_1, rank 0,
+                        10,  # feature_1, rank 0
+                        23,  # feature_1, rank 0
+                        30,  # feature_1, rank 1
+                        32,  # feature_1, rank 1
+                        39,  # feature_1, rank 1
+                    ],
+                ),
+                lengths=torch.LongTensor([1] * 12),
+            ),
+            KeyedJaggedTensor.from_lengths_sync(
+                keys=["feature_0", "feature_1"],
+                values=torch.LongTensor(
+                    [
+                        0,  # feature_0, rank 0
+                        10,  # feature_1, rank 0
+                    ],
+                ),
+                lengths=torch.LongTensor([1, 1]),
+            ),
+        ]
+
+        # Final answer that maps rank to indices
+        rank_to_indices = [[0, 1, 3, 4, 0, 0, 10, 23, 10], [2, 5, 30, 32, 39]]
+
+        self._run_multi_process_test(
+            callable=_test_uneven_buckets_per_rank,
+            world_size=WORLD_SIZE,
+            hash_sizes=HASH_SIZES,
+            tables=embedding_config,
+            backend=backend,
+            sharder=ManagedCollisionEmbeddingCollectionSharder(),
+            kjt_input_per_rank=kjt_input_per_rank,
+            indices_to_rank=rank_to_indices,
+        )
+
+    @unittest.skipIf(
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
@@ -1329,11 +1464,13 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @given(backend=st.sampled_from(["nccl"]))
+    @given(backend=st.sampled_from(["nccl"]), uneven_buckets=st.booleans())
     @settings(deadline=None)
-    def test_sharding_zch_mc_ec_dedup(self, backend: str) -> None:
-
+    def test_sharding_zch_mc_ec_dedup(self, backend: str, uneven_buckets: bool) -> None:
         WORLD_SIZE = 2
+        total_num_buckets = [4, 4]
+        if uneven_buckets:
+            total_num_buckets = [3, 4]
 
         embedding_config = [
             EmbeddingConfig(
@@ -1341,12 +1478,14 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
                 feature_names=["feature_0", "feature_2"],
                 embedding_dim=8,
                 num_embeddings=16,
+                total_num_buckets=total_num_buckets[0],
             ),
             EmbeddingConfig(
                 name="table_1",
                 feature_names=["feature_1"],
                 embedding_dim=8,
                 num_embeddings=32,
+                total_num_buckets=total_num_buckets[1],
             ),
         ]
 

--- a/torchrec/distributed/tests/test_mc_embedding_write.py
+++ b/torchrec/distributed/tests/test_mc_embedding_write.py
@@ -346,7 +346,9 @@ def _create_hashzch_sharded_arch(
 
     module_sharding_plan = construct_module_sharding_plan(
         sparse_arch._mc_ec,
-        per_param_sharding={t.name: row_wise() for t in tables},
+        per_param_sharding={
+            t.name: row_wise(num_buckets=total_num_buckets) for t in tables
+        },
         local_size=ctx.local_size,
         world_size=WORLD_SIZE,
         device_type="cuda" if torch.cuda.is_available() else "cpu",
@@ -372,6 +374,7 @@ def _test_input_dist_2d_weights_mapping(
     sharder: ModuleSharder[nn.Module],
     backend: str,
     local_size: Optional[int] = None,
+    total_num_buckets: int = 4,
 ) -> None:
     """
     Test that input_dist() and compute() with 2D weights preserves the 1:1
@@ -384,7 +387,11 @@ def _test_input_dist_2d_weights_mapping(
     """
     with MultiProcessContext(rank, world_size, backend, local_size) as ctx:
         sharded_sparse_arch = _create_hashzch_sharded_arch(
-            tables, ctx, sharder, write_runtime_meta_dim=EMBEDDING_DIM // WORLD_SIZE
+            tables,
+            ctx,
+            sharder,
+            write_runtime_meta_dim=EMBEDDING_DIM // WORLD_SIZE,
+            total_num_buckets=total_num_buckets,
         )
         mc_ec = sharded_sparse_arch._mc_ec
         assert isinstance(mc_ec, ShardedManagedCollisionEmbeddingCollection)
@@ -691,15 +698,19 @@ class ShardedMCECInputDist2DWeightsTest(MultiProcessTestBase):
         torch.cuda.device_count() <= 1,
         "Not enough GPUs, this test requires at least two GPUs",
     )
-    @given(backend=st.sampled_from(["nccl"]))
+    @given(backend=st.sampled_from(["nccl"]), uneven_buckets=st.booleans())
     @settings(deadline=None)
-    def test_input_dist_2d_weights_mapping(self, backend: str) -> None:
+    def test_input_dist_2d_weights_mapping(
+        self, backend: str, uneven_buckets: bool
+    ) -> None:
+        total_buckets = 3 if uneven_buckets else 4
+
         embedding_config = [
             EmbeddingConfig(
                 name="table_0",
                 feature_names=["feature_0"],
                 embedding_dim=EMBEDDING_DIM,
-                num_embeddings=32,
+                num_embeddings=36,
                 enable_embedding_update=True,
             ),
         ]
@@ -709,6 +720,7 @@ class ShardedMCECInputDist2DWeightsTest(MultiProcessTestBase):
             tables=embedding_config,
             sharder=ManagedCollisionEmbeddingCollectionSharder(),
             backend=backend,
+            total_num_buckets=total_buckets,
         )
 
     @unittest.skipIf(

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -813,7 +813,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         except ValueError:
             raise RuntimeError(
                 f"Attempting to shard HashZchManagedCollisionModule, but rank {device} does not align with bucket boundaries;"
-                + f" please check kwarg total_num_buckets={self._buckets} is a multiple of world size."
+                + " please check if planner is aware of the bucket sizes per rank, and whether there is uneven buckets per rank. "
             )
         new_zch_size = output_id_range[1] - output_id_range[0]
 

--- a/torchrec/modules/mc_modules.py
+++ b/torchrec/modules/mc_modules.py
@@ -9,7 +9,17 @@
 
 import abc
 from logging import getLogger, Logger
-from typing import Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import (
+    Callable,
+    cast,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import torch
 from torch import nn
@@ -393,6 +403,12 @@ class ManagedCollisionCollection(nn.Module):
 
     def embedding_configs(self) -> Sequence[BaseEmbeddingConfig]:
         return self._embedding_configs
+
+    def table_to_number_buckets(self) -> Dict[str, int]:
+        return {
+            table: cast(ManagedCollisionModule, mc_module).buckets()
+            for table, mc_module in self._managed_collision_modules.items()
+        }
 
     def forward(
         self,


### PR DESCRIPTION
Summary:

Context
---------

MP assumes same number of buckets in every rank. KV recently implemented uneven bucket support. Goal: enable MP to have uneven bucket support.

The biggest difference is KV assumes that the input hash size == embedding size. MP however does not have this assumption, and the hash size can even be infinite. The infinite size is the default value used in all MVAI models.

In MP, if the hash size is finite, then it is equivalent to the KV code, however there are differences when the hash size is infinite. The block size ends up being 0 in RwSparseFeatures, and it maps using a interleave pattern to buckets.
This is most evident from the following figure:

{F1989819675}

The bucketize procedure with uneven buckets utilizes binary search on the offsets in **input-id** space, however since it is infinite, it must take into account the size in embedding space. The FBGEMM kernel figures out the hash-size is infinite via size of buckets is zero, and then converts the id into the correct bucket before doing binary search. See this [line in block_bucketize](https://www.internalfb.com/code/fbsource/[87e50772aaf3fca9a06287889a628d815eb24a47]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu?lines=122) when even number of buckets (i.e. no binary search), and this [line in block_bucketize](https://www.internalfb.com/code/fbsource/[87e50772aaf3fca9a06287889a628d815eb24a47]/fbcode/deeplearning/fbgemm/fbgemm_gpu/src/sparse_ops/sparse_block_bucketize_features.cu?lines=136-138) for uneven number of buckets with infinite hash-size.



Implementation
------------------

Major Changes:

* `RwSparseFeaturesDist` now takes the embedding output space size, in cases where hash_size is infinite.
* `RwSparseFeaturesWriteDist` now handles uneven buckets
* mc_modules provies the correct inputs to
`RwSparseFeaturesDist`/`RwSparseFeaturesWriteDist`, including the boolean `uneven_buckets_per_rank ` to indicate this has uneven buckets.
* planner enumerator now correctly gets the number of buckets from MP-ZCH, and so it can properly calculate the correct sharding offsets/sizes.

for tests:
* Added a new test that correctly gets the correct rank done by hand.
* Changed `test_sharding_zch_mc_ec_dedup` test to also test when uneven buckets are used.
* Similarly changed tests inside test_mc_embedding_write to also test using uneven buckets.
* For a quant_mc_module test, updated the error message to be the new error message.

Minor changes:

* Changed Torchrec MPZCH benchmarks to handle uneven buckets
* Updated error message in `hash_mc_modules` to explain that most likely planner is not aware of the bucket boundaries.
* modules/mc_modules: now has a function that returns the number of buckets for all tables.
* Manual sharding e.g. row_wise, now takes into account num buckets. This is used in testing.

Reviewed By: kausv

Differential Revision: D105202494


