### PR TITLE
Plumb DRAM_SSD_VIRTUAL_TABLE through torchrec planner and infra (#4266)

### DIFF
--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -524,6 +524,7 @@ def _prefetch_and_cached(
         EmbeddingComputeKernel.KEY_VALUE,
         EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
         EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
+        EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
     }:
         return True
 

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -91,6 +91,9 @@ class EmbeddingComputeKernel(Enum):
     DRAM_VIRTUAL_TABLE = (
         "dram_virtual_table"  # dram as kv backend storage for virtual table
     )
+    DRAM_SSD_VIRTUAL_TABLE = (
+        "dram_ssd_virtual_table"  # dram + ssd composite kv backend for virtual table
+    )
     FUSED_TRITON = "fused_triton"
 
 
@@ -104,6 +107,7 @@ def compute_kernel_to_embedding_location(
         EmbeddingComputeKernel.KEY_VALUE,  # use hbm for cache
         EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,  # use hbm for cache
         EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,  # use hbm for cache
+        EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,  # use hbm for cache
     ]:
         return EmbeddingLocation.DEVICE
     elif compute_kernel in [
@@ -568,6 +572,7 @@ class BaseEmbeddingSharder(ModuleSharder[M]):
                     EmbeddingComputeKernel.KEY_VALUE.value,
                     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
                     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+                    EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
                 ]
         else:
             # TODO re-enable model parallel and dense

--- a/torchrec/distributed/planner/constants.py
+++ b/torchrec/distributed/planner/constants.py
@@ -111,6 +111,10 @@ def kernel_bw_lookup(
         ("cuda", EmbeddingComputeKernel.KEY_VALUE.value): ssd_mem_bw,
         ("cuda", EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
         ("cuda", EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value): hbm_to_ddr_mem_bw,
+        (
+            "cuda",
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
+        ): hbm_to_ddr_mem_bw,
     }
 
     if (

--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -60,6 +60,7 @@ GUARDED_COMPUTE_KERNELS: Set[EmbeddingComputeKernel] = {
     EmbeddingComputeKernel.KEY_VALUE,
     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE,
     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE,
+    EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
 }
 
 # sharding types that require explicit user specification for feature-processed modules

--- a/torchrec/distributed/planner/shard_estimators.py
+++ b/torchrec/distributed/planner/shard_estimators.py
@@ -402,6 +402,7 @@ def calculate_shard_storages(
             EmbeddingComputeKernel.KEY_VALUE.value,
             EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
             EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
         }
         or use_virtual_table
     ):
@@ -487,6 +488,7 @@ def _is_table_cached(
         EmbeddingComputeKernel.KEY_VALUE.value,
         EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
         EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+        EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
     }:
         return True
     return False

--- a/torchrec/distributed/test_utils/table_config.py
+++ b/torchrec/distributed/test_utils/table_config.py
@@ -44,6 +44,7 @@ def _process_virtual_table_config(config_dict: Dict[str, Any]) -> None:
         config_dict["use_virtual_table"] = config_dict["location"] in [
             "DRAM_VIRTUAL_TABLE",
             "SSD_VIRTUAL_TABLE",
+            "DRAM_SSD_VIRTUAL_TABLE",
         ]
 
         if config_dict["use_virtual_table"]:

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -486,6 +486,7 @@ def add_params_from_parameter_sharding(
             EmbeddingComputeKernel.KEY_VALUE.value,
             EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
             EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
         }
         and parameter_sharding.key_value_params is not None
     ):


### PR DESCRIPTION
Summary:

Integrates the `DRAM_SSD_VIRTUAL_TABLE` compute kernel across the TorchRec infrastructure to support combined DRAM and SSD virtual table configurations. This ensures the distributed training ecosystem can correctly recognize, shard, and manage embedding tables that utilize this new mixed memory hierarchy alongside existing DRAM and SSD implementations.

Differential Revision: D103941740


