### PR TITLE
Close DataLoadingThread silent-death observability gap (#4270)

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import copy
+import threading
 import unittest
 from contextlib import contextmanager, ExitStack
 from dataclasses import dataclass
@@ -30,6 +31,7 @@ from torchrec.distributed.fp_embeddingbag import (
     FeatureProcessedEmbeddingBagCollectionSharder,
     ShardedFeatureProcessedEmbeddingBagCollection,
 )
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.model_parallel import DMPCollection
 from torchrec.distributed.sharding_plan import (
     construct_module_sharding_plan,
@@ -1843,6 +1845,19 @@ class TrainPipelineSparseDistLiteTest(TrainPipelineSparseDistTestBase):
             torch.testing.assert_close(pred, pred_pipeline)
 
 
+class _RaisingIter:
+    """Iterator whose __next__ always raises — simulates a failed dataloader."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __iter__(self) -> "_RaisingIter":
+        return self
+
+    def __next__(self) -> object:
+        raise self._exc
+
+
 class DataLoadingThreadTest(unittest.TestCase):
     def test_fetch_data(self) -> None:
         data = []
@@ -1861,6 +1876,273 @@ class DataLoadingThreadTest(unittest.TestCase):
         with self.assertRaises(StopIteration):
             data_loader.get_next_batch(True)
         data_loader.stop()
+
+    def test_fetch_failure_captured_on_iterator_exception_when_jk_on(self) -> None:
+        """JK on + iterator raises => get_next_batch re-raises promptly, no hang."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "OOM"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_re_raised_on_subsequent_calls(self) -> None:
+        """Captured exception is terminal: every call re-raises until pipeline.reset()."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            for _ in range(3):
+                with self.assertRaisesRegex(RuntimeError, "OOM"):
+                    data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_captured_on_copy_exception_when_jk_on(self) -> None:
+        """JK on + batch.to(device) raises => get_next_batch surfaces it."""
+        bad_batch = MagicMock()
+        bad_batch.to.side_effect = RuntimeError("CUDA OOM in copy")
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), iter([bad_batch]), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "CUDA OOM in copy"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_silent_when_jk_off(self) -> None:
+        """Off-path byte-exact: BG dies silently, no event fires, no capture."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            self.assertFalse(data_loader._buffer_filled_event.wait(timeout=0.5))
+            self.assertIsNone(data_loader._captured_exception)
+        finally:
+            # Force-stop the orphaned daemon (run() already returned).
+            data_loader._stop = True
+            data_loader._buffer_filled_event.set()
+            data_loader._buffer_empty_event.set()
+
+    def test_fetch_failure_emits_failure_telemetry(self) -> None:
+        """FAILURE Scuba sample has stage, exception_type, error_message, stack_trace."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaises(RuntimeError):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
+
+        self.assertEqual(mock_log_event.call_count, 1)
+        kwargs = mock_log_event.call_args.kwargs
+        self.assertEqual(kwargs["event_type"], EventType.FAILURE)
+        self.assertEqual(kwargs["event_name"], "DataLoadingThread.fetch_failure")
+        self.assertEqual(kwargs["metadata"]["stage"], "next_iterator")
+        self.assertEqual(kwargs["metadata"]["exception_type"], "RuntimeError")
+        self.assertEqual(kwargs["error_message"], "OOM")
+        self.assertTrue(kwargs["stack_trace"])
+
+    def test_fetch_failure_passes_jk_default_false_explicitly(self) -> None:
+        """Pins default=False; torch's justknobs_check defaults to True (fail-open)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ) as mock_jk:
+            # pyrefly: ignore[bad-specialization]
+            DataLoadingThread(torch.device("cpu"), iter([]), True)
+
+        capture_calls = [
+            c
+            for c in mock_jk.call_args_list
+            if c.args
+            and c.args[0]
+            == "pytorch/torchrec:enable_data_loading_thread_failure_capture"
+        ]
+        self.assertEqual(len(capture_calls), 1)
+        self.assertEqual(capture_calls[0].kwargs.get("default"), False)
+
+    def test_stopiteration_not_logged_as_failure_when_jk_on(self) -> None:
+        """End-of-epoch must NOT emit FAILURE on the safe branch."""
+        data = [torch.tensor([i]) for i in range(3)]
+        data_iter = iter(data)
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(torch.device("cpu"), data_iter, True)
+                data_loader.start()
+                try:
+                    for i in range(3):
+                        item = data_loader.get_next_batch()
+                        # pyrefly: ignore[missing-attribute]
+                        self.assertEqual(item.item(), i)
+                    self.assertIsNone(data_loader.get_next_batch(False))
+                finally:
+                    data_loader.stop()
+
+        failure_calls = [
+            c
+            for c in mock_log_event.call_args_list
+            if c.kwargs.get("event_type") == EventType.FAILURE
+        ]
+        self.assertEqual(len(failure_calls), 0)
+
+    def test_consumer_woken_even_when_telemetry_raises(self) -> None:
+        """log_event raising must not skip the consumer wake (no regression to hang)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event",
+                side_effect=RuntimeError("scuba down"),
+            ):
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaisesRegex(RuntimeError, "OOM"):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
+
+    def test_hang_reproduced_without_capture(self) -> None:
+        """Repros the off-path hang: JK off + iterator raises => consumer
+        blocks forever on `_buffer_filled_event.wait()`. In prod this is the
+        1500s DPP starvation kill misclassified as DPP_WORKER_STUCK_FULL_OUTPUT_QUEUE.
+        """
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            result: List[object] = []
+
+            def _consumer() -> None:
+                try:
+                    result.append(data_loader.get_next_batch())
+                except BaseException as e:  # noqa: B036
+                    result.append(e)
+
+            consumer = threading.Thread(target=_consumer, daemon=True)
+            consumer.start()
+            consumer.join(timeout=0.5)
+
+            self.assertTrue(
+                consumer.is_alive(),
+                "Expected get_next_batch() to hang with JK off, but it returned",
+            )
+            self.assertEqual(result, [])
+        finally:
+            # Release the still-blocked consumer and the orphaned daemon.
+            data_loader._stop = True
+            data_loader._buffer_filled_event.set()
+            data_loader._buffer_empty_event.set()
+            consumer.join(timeout=1.0)
+
+    def test_global_excepthook_does_not_wake_consumer(self) -> None:
+        """A process-global `threading.excepthook` observes the dying thread's
+        exception but cannot touch `_buffer_filled_event` — the consumer still
+        hangs. Proves that per-site capture is not redundant with any global
+        uncaught-exception safety net: the global net runs in the dying
+        thread's exit path and has no way to wake the consumer.
+        """
+        captured: List[BaseException] = []
+
+        def _recording_excepthook(args: threading.ExceptHookArgs) -> None:
+            if args.exc_value is not None:
+                captured.append(args.exc_value)
+
+        old_excepthook = threading.excepthook
+        threading.excepthook = _recording_excepthook
+        try:
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+                return_value=False,
+            ):
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+            data_loader.start()
+            try:
+                result: List[object] = []
+
+                def _consumer() -> None:
+                    try:
+                        result.append(data_loader.get_next_batch())
+                    except BaseException as e:  # noqa: B036
+                        result.append(e)
+
+                consumer = threading.Thread(target=_consumer, daemon=True)
+                consumer.start()
+                consumer.join(timeout=0.5)
+
+                self.assertEqual(len(captured), 1)
+                self.assertIsInstance(captured[0], RuntimeError)
+                self.assertEqual(str(captured[0]), "OOM")
+
+                self.assertTrue(
+                    consumer.is_alive(),
+                    "Global threading.excepthook must not unblock the consumer",
+                )
+                self.assertEqual(result, [])
+            finally:
+                data_loader._stop = True
+                data_loader._buffer_filled_event.set()
+                data_loader._buffer_empty_event.set()
+                consumer.join(timeout=1.0)
+        finally:
+            threading.excepthook = old_excepthook
 
 
 class EvalPipelineSparseDistTest(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -30,6 +30,7 @@ from torchrec.distributed.fp_embeddingbag import (
     FeatureProcessedEmbeddingBagCollectionSharder,
     ShardedFeatureProcessedEmbeddingBagCollection,
 )
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.model_parallel import DMPCollection
 from torchrec.distributed.sharding_plan import (
     construct_module_sharding_plan,
@@ -1843,6 +1844,19 @@ class TrainPipelineSparseDistLiteTest(TrainPipelineSparseDistTestBase):
             torch.testing.assert_close(pred, pred_pipeline)
 
 
+class _RaisingIter:
+    """Iterator whose __next__ always raises — simulates a failed dataloader."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __iter__(self) -> "_RaisingIter":
+        return self
+
+    def __next__(self) -> object:
+        raise self._exc
+
+
 class DataLoadingThreadTest(unittest.TestCase):
     def test_fetch_data(self) -> None:
         data = []
@@ -1861,6 +1875,179 @@ class DataLoadingThreadTest(unittest.TestCase):
         with self.assertRaises(StopIteration):
             data_loader.get_next_batch(True)
         data_loader.stop()
+
+    def test_fetch_failure_captured_on_iterator_exception_when_jk_on(self) -> None:
+        """JK on + iterator raises => get_next_batch re-raises promptly, no hang."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "OOM"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_re_raised_on_subsequent_calls(self) -> None:
+        """Captured exception is terminal: every call re-raises until pipeline.reset()."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            for _ in range(3):
+                with self.assertRaisesRegex(RuntimeError, "OOM"):
+                    data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_captured_on_copy_exception_when_jk_on(self) -> None:
+        """JK on + batch.to(device) raises => get_next_batch surfaces it."""
+        bad_batch = MagicMock()
+        bad_batch.to.side_effect = RuntimeError("CUDA OOM in copy")
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), iter([bad_batch]), True
+            )
+        data_loader.start()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "CUDA OOM in copy"):
+                data_loader.get_next_batch()
+        finally:
+            data_loader.stop()
+
+    def test_fetch_failure_silent_when_jk_off(self) -> None:
+        """Off-path byte-exact: BG dies silently, no event fires, no capture."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ):
+            # pyrefly: ignore[bad-specialization]
+            data_loader = DataLoadingThread(
+                torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+            )
+        data_loader.start()
+        try:
+            self.assertFalse(data_loader._buffer_filled_event.wait(timeout=0.5))
+            self.assertIsNone(data_loader._captured_exception)
+        finally:
+            # Force-stop the orphaned daemon (run() already returned).
+            data_loader._stop = True
+            data_loader._buffer_filled_event.set()
+            data_loader._buffer_empty_event.set()
+
+    def test_fetch_failure_emits_failure_telemetry(self) -> None:
+        """FAILURE Scuba sample has stage, exception_type, error_message, stack_trace."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaises(RuntimeError):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
+
+        self.assertEqual(mock_log_event.call_count, 1)
+        kwargs = mock_log_event.call_args.kwargs
+        self.assertEqual(kwargs["event_type"], EventType.FAILURE)
+        self.assertEqual(kwargs["event_name"], "DataLoadingThread.fetch_failure")
+        self.assertEqual(kwargs["metadata"]["stage"], "next_iterator")
+        self.assertEqual(kwargs["metadata"]["exception_type"], "RuntimeError")
+        self.assertEqual(kwargs["error_message"], "OOM")
+        self.assertTrue(kwargs["stack_trace"])
+
+    def test_fetch_failure_passes_jk_default_false_explicitly(self) -> None:
+        """Pins default=False; torch's justknobs_check defaults to True (fail-open)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=False,
+        ) as mock_jk:
+            # pyrefly: ignore[bad-specialization]
+            DataLoadingThread(torch.device("cpu"), iter([]), True)
+
+        capture_calls = [
+            c
+            for c in mock_jk.call_args_list
+            if c.args
+            and c.args[0]
+            == "pytorch/torchrec:enable_data_loading_thread_failure_capture"
+        ]
+        self.assertEqual(len(capture_calls), 1)
+        self.assertEqual(capture_calls[0].kwargs.get("default"), False)
+
+    def test_stopiteration_not_logged_as_failure_when_jk_on(self) -> None:
+        """End-of-epoch must NOT emit FAILURE on the safe branch."""
+        data = [torch.tensor([i]) for i in range(3)]
+        data_iter = iter(data)
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event"
+            ) as mock_log_event:
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(torch.device("cpu"), data_iter, True)
+                data_loader.start()
+                try:
+                    for i in range(3):
+                        item = data_loader.get_next_batch()
+                        # pyrefly: ignore[missing-attribute]
+                        self.assertEqual(item.item(), i)
+                    self.assertIsNone(data_loader.get_next_batch(False))
+                finally:
+                    data_loader.stop()
+
+        failure_calls = [
+            c
+            for c in mock_log_event.call_args_list
+            if c.kwargs.get("event_type") == EventType.FAILURE
+        ]
+        self.assertEqual(len(failure_calls), 0)
+
+    def test_consumer_woken_even_when_telemetry_raises(self) -> None:
+        """log_event raising must not skip the consumer wake (no regression to hang)."""
+        with patch(
+            "torchrec.distributed.train_pipeline.utils.torch._utils_internal.justknobs_check",
+            return_value=True,
+        ):
+            with patch(
+                "torchrec.distributed.train_pipeline.utils.EventLoggingHandler.log_event",
+                side_effect=RuntimeError("scuba down"),
+            ):
+                # pyrefly: ignore[bad-specialization]
+                data_loader = DataLoadingThread(
+                    torch.device("cpu"), _RaisingIter(RuntimeError("OOM")), True
+                )
+                data_loader.start()
+                try:
+                    with self.assertRaisesRegex(RuntimeError, "OOM"):
+                        data_loader.get_next_batch()
+                finally:
+                    data_loader.stop()
 
 
 class EvalPipelineSparseDistTest(unittest.TestCase):

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -10,6 +10,7 @@ import contextlib
 import copy
 import dataclasses
 import logging
+import traceback
 from collections import defaultdict, deque
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
@@ -39,6 +40,7 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
+from torchrec.distributed.logging_utils import EventType
 
 try:
     from torchrec.distributed.logging_handlers import log_pipeline_module_info
@@ -49,6 +51,36 @@ except Exception:
 
     def log_pipeline_module_info(*args: Any, **kwargs: Any) -> None:
         pass
+
+
+try:
+    # Defensive: torch-package / inference builds may strip the shim.
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.utils.import_failure.event_logging_handler"
+    )
+
+    from enum import Enum as _Enum
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            TRAIN_PIPELINE = "train_pipeline"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
 
 
 try:
@@ -658,6 +690,14 @@ class DataLoadingThread(Thread, Generic[In]):
         self._to_device_non_blocking = to_device_non_blocking
         self._buffered: Optional[In] = None
         self._buffer_empty_event.set()
+        # JK-gated capture of non-StopIteration exceptions. Off-path
+        # preserves the original silent-death behavior bit-exact.
+        self._capture_failures_enabled: bool = torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:enable_data_loading_thread_failure_capture",
+            default=False,
+        )
+        self._captured_exception: Optional[BaseException] = None
+        self._captured_exception_event: Event = Event()
         one_time_rank0_logger.info(
             f"{self.__class__.__name__} created with device={device}, "
             f"to_device_non_blocking={to_device_non_blocking}, "
@@ -679,23 +719,80 @@ class DataLoadingThread(Thread, Generic[In]):
             if self._stop:
                 self._buffer_filled_event.set()
                 return
-            with record_function("## load_batch ##"):
-                try:
-                    batch = next(self._dataloader_iter)
-                except StopIteration:
-                    self._stop = True
+            if not self._capture_failures_enabled:
+                # Original off-path: byte-exact preservation. Non-StopIteration
+                # exceptions kill the daemon silently — consumer hangs.
+                with record_function("## load_batch ##"):
+                    try:
+                        batch = next(self._dataloader_iter)
+                    except StopIteration:
+                        self._stop = True
+                        self._buffer_filled_event.set()
+                        return
+                with record_function("## copy_batch_to_gpu ##"):
+                    with torch.get_device_module(self._device).stream(
+                        self._memcpy_stream
+                    ):
+                        self._buffered = cast(
+                            In,
+                            batch.to(
+                                self._device,
+                                non_blocking=self._to_device_non_blocking,
+                            ),
+                        )
+                    self._buffer_empty_event.clear()
                     self._buffer_filled_event.set()
-                    return
-            with record_function("## copy_batch_to_gpu ##"):
-                with torch.get_device_module(self._device).stream(self._memcpy_stream):
-                    self._buffered = cast(
-                        In,
-                        batch.to(
-                            self._device, non_blocking=self._to_device_non_blocking
-                        ),
+                continue
+
+            # Safe path: capture, emit FAILURE event, wake the consumer.
+            stage = "next_iterator"
+            try:
+                with record_function("## load_batch ##"):
+                    try:
+                        batch = next(self._dataloader_iter)
+                    except StopIteration:
+                        self._stop = True
+                        self._buffer_filled_event.set()
+                        return
+                stage = "copy_to_device"
+                with record_function("## copy_batch_to_gpu ##"):
+                    with torch.get_device_module(self._device).stream(
+                        self._memcpy_stream
+                    ):
+                        self._buffered = cast(
+                            In,
+                            batch.to(
+                                self._device,
+                                non_blocking=self._to_device_non_blocking,
+                            ),
+                        )
+                    self._buffer_empty_event.clear()
+                    self._buffer_filled_event.set()
+            except Exception as e:
+                # Telemetry wrapped so a logger/Scuba raise can never skip
+                # the consumer-wake below.
+                try:
+                    logger.exception(
+                        f"{self.__class__.__name__}: exception in {stage}: {e}"
                     )
-                self._buffer_empty_event.clear()
+                    EventLoggingHandler.log_event(
+                        component=TorchrecComponent.TRAIN_PIPELINE.value,
+                        event_name="DataLoadingThread.fetch_failure",
+                        event_type=EventType.FAILURE,
+                        metadata={
+                            "stage": stage,
+                            "exception_type": type(e).__name__,
+                            "device": str(self._device),
+                        },
+                        error_message=str(e),
+                        stack_trace=traceback.format_exc(),
+                    )
+                except BaseException:  # noqa: B036
+                    pass
+                self._captured_exception = e
+                self._captured_exception_event.set()
                 self._buffer_filled_event.set()
+                return
 
     def stop(self) -> None:
         logger.info(f"{self.__class__.__name__}: Stopping data loading thread...")
@@ -714,6 +811,16 @@ class DataLoadingThread(Thread, Generic[In]):
         the main thread in the training loop.
         """
         self._buffer_filled_event.wait()
+        if self._capture_failures_enabled and self._captured_exception_event.is_set():
+            # Terminal — pipeline.reset() rebuilds the thread to recover.
+            # Explicit None check (not assert) so python -O still raises
+            # the captured exception instead of TypeError.
+            captured = self._captured_exception
+            if captured is None:
+                raise RuntimeError(
+                    "DataLoadingThread: capture event set without captured exception"
+                )
+            raise captured
         batch = self._buffered
         if batch is None:
             if none_throws:

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -10,6 +10,7 @@ import contextlib
 import copy
 import dataclasses
 import logging
+import traceback
 from collections import defaultdict, deque
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
@@ -39,6 +40,7 @@ from torchrec.distributed.embedding_sharding import (
     KJTSplitsAllToAllMeta,
 )
 from torchrec.distributed.embedding_types import KJTList
+from torchrec.distributed.logging_utils import EventType
 
 try:
     from torchrec.distributed.logging_handlers import log_pipeline_module_info
@@ -49,6 +51,36 @@ except Exception:
 
     def log_pipeline_module_info(*args: Any, **kwargs: Any) -> None:
         pass
+
+
+try:
+    # Defensive: torch-package / inference builds may strip the shim.
+    from torchrec.distributed.logging_handlers import (
+        EventLoggingHandler,
+        TorchrecComponent,
+    )
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.utils.import_failure.event_logging_handler"
+    )
+
+    from enum import Enum as _Enum
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from torchrec.distributed.logging_handlers import (
+            EventLoggingHandler,
+            TorchrecComponent,
+        )
+    else:
+
+        class TorchrecComponent(_Enum):
+            TRAIN_PIPELINE = "train_pipeline"
+
+        class EventLoggingHandler:
+            @staticmethod
+            def log_event(*args: object, **kwargs: object) -> None:
+                pass
 
 
 try:
@@ -658,6 +690,14 @@ class DataLoadingThread(Thread, Generic[In]):
         self._to_device_non_blocking = to_device_non_blocking
         self._buffered: Optional[In] = None
         self._buffer_empty_event.set()
+        # JK-gated capture of non-StopIteration exceptions. Off-path
+        # preserves the original silent-death behavior bit-exact.
+        self._capture_failures_enabled: bool = torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:enable_data_loading_thread_failure_capture",
+            default=False,
+        )
+        self._captured_exception: Optional[BaseException] = None
+        self._captured_exception_event: Event = Event()
         one_time_rank0_logger.info(
             f"{self.__class__.__name__} created with device={device}, "
             f"to_device_non_blocking={to_device_non_blocking}, "
@@ -666,36 +706,92 @@ class DataLoadingThread(Thread, Generic[In]):
         )
 
     def run(self) -> None:
-        if self._device.type == "cuda" and torch.cuda.is_available():
-            # set the current device the same as the one used in the main thread
-            torch.cuda.set_device(self._device)
-        elif self._device.type == "mtia" and torch.mtia.is_available():
-            # set the current device the same as the one used in the main thread
-            torch.mtia.set_device(self._device)
-
+        self._set_thread_device()
         while not self._stop:
             self._buffer_empty_event.wait()
             # Set the filled event to unblock progress() and return.
             if self._stop:
                 self._buffer_filled_event.set()
                 return
+            fetch = (
+                self._fetch_with_capture
+                if self._capture_failures_enabled
+                else self._fetch_off_path
+            )
+            if not fetch():
+                return
+
+    def _set_thread_device(self) -> None:
+        if self._device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.set_device(self._device)
+        elif self._device.type == "mtia" and torch.mtia.is_available():
+            torch.mtia.set_device(self._device)
+
+    def _fetch_off_path(self) -> bool:
+        # Byte-exact preservation of the original behavior: non-StopIteration
+        # exceptions kill the daemon silently and the consumer hangs.
+        with record_function("## load_batch ##"):
+            try:
+                batch = next(self._dataloader_iter)
+            except StopIteration:
+                self._stop = True
+                self._buffer_filled_event.set()
+                return False
+        self._buffer_to_device(batch)
+        return True
+
+    def _fetch_with_capture(self) -> bool:
+        # JK-on safe path: capture non-StopIteration exceptions, emit a
+        # FAILURE event, and wake the consumer so get_next_batch re-raises
+        # instead of hanging.
+        stage = "next_iterator"
+        try:
             with record_function("## load_batch ##"):
                 try:
                     batch = next(self._dataloader_iter)
                 except StopIteration:
                     self._stop = True
                     self._buffer_filled_event.set()
-                    return
-            with record_function("## copy_batch_to_gpu ##"):
-                with torch.get_device_module(self._device).stream(self._memcpy_stream):
-                    self._buffered = cast(
-                        In,
-                        batch.to(
-                            self._device, non_blocking=self._to_device_non_blocking
-                        ),
-                    )
-                self._buffer_empty_event.clear()
-                self._buffer_filled_event.set()
+                    return False
+            stage = "copy_to_device"
+            self._buffer_to_device(batch)
+            return True
+        except Exception as e:
+            self._emit_fetch_failure(stage, e)
+            self._captured_exception = e
+            self._captured_exception_event.set()
+            self._buffer_filled_event.set()
+            return False
+
+    def _buffer_to_device(self, batch: In) -> None:
+        with record_function("## copy_batch_to_gpu ##"):
+            with torch.get_device_module(self._device).stream(self._memcpy_stream):
+                self._buffered = cast(
+                    In,
+                    batch.to(self._device, non_blocking=self._to_device_non_blocking),
+                )
+            self._buffer_empty_event.clear()
+            self._buffer_filled_event.set()
+
+    def _emit_fetch_failure(self, stage: str, e: Exception) -> None:
+        # Telemetry is wrapped so a logger/Scuba raise can never skip the
+        # consumer-wake in the caller.
+        try:
+            logger.exception(f"{self.__class__.__name__}: exception in {stage}: {e}")
+            EventLoggingHandler.log_event(
+                component=TorchrecComponent.TRAIN_PIPELINE.value,
+                event_name="DataLoadingThread.fetch_failure",
+                event_type=EventType.FAILURE,
+                metadata={
+                    "stage": stage,
+                    "exception_type": type(e).__name__,
+                    "device": str(self._device),
+                },
+                error_message=str(e),
+                stack_trace=traceback.format_exc(),
+            )
+        except BaseException:  # noqa: B036
+            pass
 
     def stop(self) -> None:
         logger.info(f"{self.__class__.__name__}: Stopping data loading thread...")
@@ -714,6 +810,16 @@ class DataLoadingThread(Thread, Generic[In]):
         the main thread in the training loop.
         """
         self._buffer_filled_event.wait()
+        if self._capture_failures_enabled and self._captured_exception_event.is_set():
+            # Terminal — pipeline.reset() rebuilds the thread to recover.
+            # Explicit None check (not assert) so python -O still raises
+            # the captured exception instead of TypeError.
+            captured = self._captured_exception
+            if captured is None:
+                raise RuntimeError(
+                    "DataLoadingThread: capture event set without captured exception"
+                )
+            raise captured
         batch = self._buffered
         if batch is None:
             if none_throws:


### PR DESCRIPTION
Summary:

Behind JK `pytorch/torchrec:enable_data_loading_thread_failure_capture` (default off). `DataLoadingThread.run()` at `torchrec/distributed/train_pipeline/utils.py` currently only catches `StopIteration`. Any other exception — most commonly CUDA OOM on `batch.to(device)` or `OSError` on the Hive/Manifold-backed `next(self._dataloader_iter)` — kills the daemon thread silently. The consumer in `TrainPipelineFusedSparseDist.progress()` then blocks forever on `_buffer_filled_event.wait()`, because no producer is left to set it. Symptom: the training job appears stuck, gets SIGABRT'd by DPP starvation kill at 1500s, and surfaces in MAST as the generic `DPP_WORKER_STUCK_FULL_OUTPUT_QUEUE` — root cause is invisible to investigators.

Shares the misclassification class with the dataloader hang fixed in D103494006 / D105399948: a real failure (CUDA OOM, dataloader timeout) gets reported to MAST as a generic stuck-job kill, hiding the actual error type and stack from investigators. Closing this site removes one source of those misclassifications.

When the JK is on, the safe path captures non-`StopIteration` exceptions, emits a `FAILURE` event to `torchrec_event_logging`, and wakes the consumer with the captured error so `get_next_batch()` re-raises it promptly instead of hanging.

Design details:

1. `_captured_exception_event` is a NEW `threading.Event`, separate from the existing `_buffer_filled_event`. Overloading `_buffer_filled_event` would muddy the existing "buffer filled vs end-of-stream vs stop" invariant — that event already has three legitimate setters (normal fill, `StopIteration` exit, `stop()`). A dedicated event keeps the failure-signal channel orthogonal and matches the gold-standard pattern in `torchrec/metrics/cpu_offloaded_metric_module.py:193-194, 300-302, 601-660`.

2. `stage` in the FAILURE metadata distinguishes `next_iterator` vs `copy_to_device` so investigators can see whether the exception came from the dataloader source (Hive/Manifold/etc.) or the host-to-device copy (CUDA OOM, MTIA OOM). One event name (`DataLoadingThread.fetch_failure`) keeps dashboards/alerts single-rooted; the stage axis is queryable via `metadata.stage`.

3. Captured exception is terminal — `get_next_batch()` re-raises the same captured exception on every subsequent call. Recovery is `TrainPipelineFusedSparseDist.reset()`, which already drops and rebuilds `_batch_loader`. Matches the contract in `cpu_offloaded_metric_module.py:300-302`.

4. `default=False` is passed explicitly to `torch._utils_internal.justknobs_check` to dodge the wrapper's default-True trap. A pinning test guards the regression that bit D105399948 round 2.

5. The defensive `EventLoggingHandler` / `TorchrecComponent` import block copies the template from `cpu_offloaded_metric_module.py:23-60` — handles torch-package contexts where even the OSS shim at `torchrec/distributed/logging_handlers.py` is unavailable.

6. `StopIteration` remains a separate `except` arm before `except Exception`, with its original behavior preserved exactly — end-of-epoch is a normal-termination path, not a failure. A regression test asserts no FAILURE event fires on natural iterator exhaustion.

Off-path: when the JK is off, `run()` executes the original `try/except StopIteration` block unchanged. The new `_captured_exception` / `_captured_exception_event` state is initialized but never written; `get_next_batch()`'s new check gates on `_capture_failures_enabled` so it's a no-op when the JK is off. Bit-exact preservation per the killswitch-fallback rule.

Scope: only `TrainPipelineFusedSparseDist` uses `DataLoadingThread` in production today (`train_pipelines.py:1436, 2321, 2338`). `EvalPipelineFusedSparseDist` inherits the field but doesn't exercise it.

Differential Revision: D105462584


