### PR TITLE
Consolidate pod_size resolution for planner-runtime consistency (#4274)

### DIFF
--- a/torchrec/distributed/comm.py
+++ b/torchrec/distributed/comm.py
@@ -135,15 +135,21 @@ def get_topology_group_world_size(world_size: Optional[int] = None) -> int:
     This is the largest number of processes linked together by high-bandwidth communication.
     If it isn't specified, it falls back to LOCAL_WORLD_SIZE
     """
-    topology_domain_multiple = get_topology_domain_multiple()
     local_world_size = get_local_size(world_size)
 
-    if topology_domain_multiple is None:
+    # Check TORCHREC_RESOLVED_POD_SIZE — set by the planner
+    # When pod sizes are dynamically allocated,
+    # 'TORCHREC_RESOLVED_POD_SIZE' env variable can be set
+    # to the actual allocation while 'TOPOLOGY_DOMAIN_MULTIPLE'
+    # will give us the minimum configured pod size.
+    resolved = os.environ.get("TORCHREC_RESOLVED_POD_SIZE")
+    if resolved is None:
         logger.warning(
-            "Could not determine TOPOLOGY_DOMAIN_MULTIPLE from environment,"
-            " utilizing LOCAL_WORLD_SIZE instead."
+            "TORCHREC_RESOLVED_POD_SIZE not set," " utilizing LOCAL_WORLD_SIZE instead."
         )
         return local_world_size
+
+    topology_domain_multiple = int(resolved)
 
     # Total number of processes/gpu in domain = topology_domain_mult * number_gpu_per_domain
     numb_proc_per_pod = topology_domain_multiple * local_world_size


### PR DESCRIPTION
Summary:

Fix pod_size mismatch between TorchRec planner and runtime on GB200 NVL72 hardware.

When topology-domain-max-group-count > 1, MAST returns a larger pod_size via
host_count_per_domain (e.g., 36 hosts = 4 hosts/group × 9 groups). The planner
(create_topology_configs) uses this MAST value, but the runtime
(get_topology_group_world_size in comm.py) reads only TOPOLOGY_DOMAIN_MULTIPLE
(the minimum per-group size, e.g., 4). This mismatch causes the planner to
generate a sharding plan for a larger topology group than the runtime creates,
resulting in:
  RuntimeError: Number of local shards (0) does not match number of local shards metadata in sharded_tensor_metadata (1) on rank (11) 

This diff consolidates pod_size resolution so planner and runtime always agree:
- detection.py: Add resolve_pod_size() that checks MAST host_count_per_domain
  first, then falls back to TOPOLOGY_DOMAIN_MULTIPLE env var.
- config_utils.py: Use resolve_pod_size() and export the result as
  TORCHREC_RESOLVED_POD_SIZE env var so runtime can read it without
  fb-internal imports.
- comm.py: Read TORCHREC_RESOLVED_POD_SIZE env var first (set by planner),
  fall back to TOPOLOGY_DOMAIN_MULTIPLE. No circular dependency or lazy imports.

Reviewed By: kausv

Differential Revision: D105663332


