### PR TITLE
Add just knobs to enable_collective validation (#4276)

### DIFF
--- a/torchrec/distributed/collective_utils.py
+++ b/torchrec/distributed/collective_utils.py
@@ -11,11 +11,18 @@
 This file contains utilities for constructing collective based control flows.
 """
 
+import logging
+import os
 from functools import wraps
 from typing import Any, Callable, cast, List, Optional, Tuple, TypeVar
 
 import torch
 import torch.distributed as dist
+
+_USE_COLLECTIVE_VALIDATION: bool = False
+_INITIALIZED: bool = False
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def is_leader(pg: Optional[dist.ProcessGroup], leader_rank: int = 0) -> bool:
@@ -201,3 +208,48 @@ def create_on_rank_and_share_result(
         shared_tensors.append(tensor)
 
     return constructor(shared_tensors)
+
+
+def _resolve_enablement_on_leader() -> bool:
+    """Determine if collective validation is enabled on rank 0.
+
+    Fail-closed on JK errors so a flaky JK service can't hang peers waiting in
+    broadcast_object_list.
+    """
+    enable_via_env = os.environ.get("TORCHREC_VALIDATE_COLLECTIVES", "")
+    if enable_via_env == "0":
+        return False
+    elif enable_via_env == "1":
+        return True
+    try:
+        return torch._utils_internal.justknobs_check(
+            "pytorch/torchrec:enable_collective_validation", default=False
+        )
+    except Exception:
+        logger.exception(
+            "Failed to check JK for collective validation; defaulting to disabled"
+        )
+        return False
+
+
+def init_collective_validation(pg: dist.ProcessGroup) -> None:
+    """Broadcast collective validation flag from rank 0 to all ranks in pg.
+
+    Call once on the world PG during DistributedModelParallel.__init__
+    so all ranks participate. Uses both JK and env var to determine if validation
+    is enabled.
+    """
+    global _USE_COLLECTIVE_VALIDATION, _INITIALIZED
+    if _INITIALIZED:
+        return  # prevents double-DMP / JK initialization
+    _USE_COLLECTIVE_VALIDATION = invoke_on_rank_and_broadcast_result(
+        pg=pg,
+        func=_resolve_enablement_on_leader,
+        rank=0,
+    )
+    _INITIALIZED = True
+    logger.info(f"Collective validation initialized: {_USE_COLLECTIVE_VALIDATION}")
+
+
+def validate_collectives_enabled() -> bool:
+    return _USE_COLLECTIVE_VALIDATION

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -16,6 +16,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed.collective_utils import validate_collectives_enabled
 from torchrec.distributed.comm_ops import (
     all_gather_base_pooled,
     alltoall_pooled,
@@ -103,13 +104,6 @@ _DTYPE_MAX: Dict[torch.dtype, int] = {
 }
 
 _TORCHREC_OVERFLOW_DEBUG: bool = os.environ.get("TORCHREC_OVERFLOW_DEBUG", "0") == "1"
-
-
-def _validate_collectives_enabled() -> bool:
-    # Read on each call so the env var can be flipped at runtime (e.g. by job
-    # config that loads after import) and so tests can patch with mock.patch
-    # instead of mutating module state.
-    return os.environ.get("TORCHREC_VALIDATE_COLLECTIVES", "0") == "1"
 
 
 def _collective_tag_from(*parts: object) -> int:
@@ -451,7 +445,7 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
         self._pg_global_ranks: List[int] = []
         if (
             collective_tag is not None
-            and _validate_collectives_enabled()
+            and validate_collectives_enabled()
             and input_tensors
         ):
             dtype = input_tensors[0].dtype
@@ -920,7 +914,7 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
 
         collective_tag: Optional[int] = None
         tag_parts: Optional[Tuple[object, ...]] = None
-        if _validate_collectives_enabled():
+        if validate_collectives_enabled():
             # Identity components, all rank-invariant by contract:
             # - input.keys(): pre-AllToAll feature list (NOT local `keys`,
             #   which is the post-AllToAll subset and differs per rank).

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -16,9 +16,9 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import distributed as dist, nn
+from torchrec.distributed.collective_utils import validate_collectives_enabled
 from torchrec.distributed.dist_data import (
     _collective_tag_from,
-    _validate_collectives_enabled,
     KJTAllToAllTensorsAwaitable,
     SplitsAllToAllAwaitable,
 )
@@ -956,7 +956,7 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
 
         collective_tag: Optional[int] = None
         tag_parts: Optional[Tuple[object, ...]] = None
-        if _validate_collectives_enabled():
+        if validate_collectives_enabled():
             # Per-request rank-invariant identity, mirroring the tightening
             # applied to KJTAllToAllSplitsAwaitable. A structural-only tag
             # (e.g., len(splits_tensors) + self._lengths) collapses on real

--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -29,7 +29,10 @@ from torch.distributed.remote_device import _remote_device
 from torch.distributed.tensor import DeviceMesh
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
-from torchrec.distributed.collective_utils import create_on_rank_and_share_result
+from torchrec.distributed.collective_utils import (
+    create_on_rank_and_share_result,
+    init_collective_validation,
+)
 from torchrec.distributed.comm import get_local_size, get_topology_domain_multiple
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.logging_handlers import log_two_dim_sharding_config
@@ -303,6 +306,15 @@ class DistributedModelParallel(nn.Module, FusedOptimizerModule):
             assert pg is not None, "Process group is not initialized"
             env = ShardingEnv.from_process_group(pg)
         self._env: ShardingEnv = env
+
+        if self._env.process_group is not None:
+            # Only validate on WORLD or groups that contain all ranks.
+            # Subgroups (e.g., sharding_pg/replica_pg in DMPCollection) must not
+            # issue constructor-time collectives as they can deadlock if DMP
+            # instances are created with different process groups or ordering.
+            pg = self._env.process_group
+            if pg is dist.GroupMember.WORLD or pg.size() == dist.get_world_size():
+                init_collective_validation(pg)
 
         if device is None:
             device = torch.device("cpu")

--- a/torchrec/distributed/tests/test_collective_utils.py
+++ b/torchrec/distributed/tests/test_collective_utils.py
@@ -15,12 +15,21 @@ from unittest import mock
 
 import torch
 import torch.distributed as dist
+import torchrec.distributed.collective_utils as cu
+from hypothesis import given, settings, strategies as st
 from torch._utils_internal import TEST_MASTER_ADDR as MASTER_ADDR  # @manual
 from torchrec.distributed.collective_utils import (
+    _resolve_enablement_on_leader,
     create_on_rank_and_share_result,
+    init_collective_validation,
     invoke_on_rank_and_broadcast_result,
     is_leader,
     run_on_leader,
+    validate_collectives_enabled,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
 )
 from torchrec.test_utils import get_free_port, seed_and_log
 
@@ -374,3 +383,80 @@ class CollectiveUtilsTest(unittest.TestCase):
             # pyrefly: ignore[bad-argument-type]
             callable=self._test_run_on_leader_decorator,
         )
+
+
+class TestEnableCollectiveValidation(MultiProcessTestBase):
+    def tearDown(self) -> None:
+        cu._USE_COLLECTIVE_VALIDATION = False
+        os.environ.pop("TORCHREC_VALIDATE_COLLECTIVES", None)
+        cu._INITIALIZED = False
+        super().tearDown()
+
+    @staticmethod
+    def _test_init_collective_validation(
+        rank: int, world_size: int, backend: str, jk_enabled: bool
+    ) -> None:
+        with MultiProcessContext(rank, world_size, backend) as ctx:
+            assert ctx.pg is not None
+
+            with mock.patch(
+                "torch._utils_internal.justknobs_check", return_value=jk_enabled
+            ) as mock_jk:
+                init_collective_validation(ctx.pg)
+
+            if ctx.rank == 0:
+                # Only rank 0 because of invoke_on_rank_and_broadcast_result
+                mock_jk.assert_called_once_with(
+                    "pytorch/torchrec:enable_collective_validation", default=False
+                )
+            assert cu._INITIALIZED is True
+
+            if jk_enabled:
+                assert cu._USE_COLLECTIVE_VALIDATION is True
+                assert validate_collectives_enabled() is True
+            else:
+                assert cu._USE_COLLECTIVE_VALIDATION is False
+                assert validate_collectives_enabled() is False
+
+    @given(jk_enabled=st.booleans())
+    @settings(deadline=None)
+    def test_init_collective_validation_jk(self, jk_enabled: bool) -> None:
+        world_size = 2
+        self._run_multi_process_test(
+            world_size=world_size,
+            backend="gloo",
+            jk_enabled=jk_enabled,
+            callable=TestEnableCollectiveValidation._test_init_collective_validation,
+        )
+
+    def test_set_env_var_overrides(self) -> None:
+        # Test setting env variable to false overrides jk
+        os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "0"
+        with mock.patch("torch._utils_internal.justknobs_check") as mock_jk:
+            self.assertFalse(_resolve_enablement_on_leader())
+            mock_jk.assert_not_called()
+
+    def test_set_env_var_without_jk(self) -> None:
+        # Test setting env variable to true enables without jk
+        os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "1"
+        with mock.patch("torch._utils_internal.justknobs_check") as mock_jk:
+            self.assertTrue(_resolve_enablement_on_leader())
+            mock_jk.assert_not_called()
+
+    def test_default_is_false(self) -> None:
+        os.environ.pop("TORCHREC_VALIDATE_COLLECTIVES", None)
+        with mock.patch(
+            "torch._utils_internal.justknobs_check", return_value=False
+        ) as mock_jk:
+            self.assertFalse(_resolve_enablement_on_leader())
+            mock_jk.assert_called_once_with(
+                "pytorch/torchrec:enable_collective_validation", default=False
+            )
+
+    def test_when_jk_fails(self) -> None:
+        os.environ.pop("TORCHREC_VALIDATE_COLLECTIVES", None)
+        with mock.patch(
+            "torch._utils_internal.justknobs_check",
+            side_effect=Exception("JustKnobs failed"),
+        ):
+            self.assertFalse(_resolve_enablement_on_leader())

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -8,7 +8,6 @@
 # pyre-strict
 
 import itertools
-import os
 import random
 import unittest
 import unittest.mock
@@ -27,6 +26,7 @@ from typing import (
 import hypothesis.strategies as st
 import torch
 import torch.distributed as dist
+import torchrec.distributed.collective_utils as cu
 from hypothesis import given, settings
 from pyre_extensions import none_throws
 from torchrec.distributed.dist_data import (
@@ -1652,14 +1652,6 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # MultiProcessTestBase.__init__.
         super().__init__(methodName, mp_init_mode="spawn")
 
-    def setUp(self) -> None:
-        super().setUp()
-        os.environ["TORCHREC_VALIDATE_COLLECTIVES"] = "1"
-
-    def tearDown(self) -> None:
-        os.environ.pop("TORCHREC_VALIDATE_COLLECTIVES", None)
-        super().tearDown()
-
     @classmethod
     def _run_test_matching_tags(
         cls,
@@ -1668,6 +1660,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         input_tensors = [
             torch.tensor([rank] * world_size, dtype=torch.int64),
@@ -1696,6 +1689,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         input_tensors = [
             torch.tensor([1] * world_size, dtype=torch.int64),
@@ -1766,6 +1760,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
         import torchrec.distributed.dist_data as dd
 
         dd._TORCHREC_OVERFLOW_DEBUG = True
@@ -1808,6 +1803,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         kjt = KeyedJaggedTensor(
             keys=["f0", "f1"],
@@ -1839,6 +1835,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         kjt = KeyedJaggedTensor(
             keys=["f0"],
@@ -1888,20 +1885,18 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = False
 
         input_tensors = [
             torch.tensor([rank] * world_size, dtype=torch.int64),
         ]
-        with unittest.mock.patch.dict(
-            os.environ, {"TORCHREC_VALIDATE_COLLECTIVES": "0"}
-        ):
-            awaitable = SplitsAllToAllAwaitable(
-                input_tensors=input_tensors,
-                pg=none_throws(dist.group.WORLD),
-                collective_tag=42,
-            )
-            assert awaitable._tag_appended is False
-            result = awaitable.wait()
+        awaitable = SplitsAllToAllAwaitable(
+            input_tensors=input_tensors,
+            pg=none_throws(dist.group.WORLD),
+            collective_tag=42,
+        )
+        assert awaitable._tag_appended is False
+        result = awaitable.wait()
         assert len(result) == 1
         assert result[0] == list(range(world_size))
         dist.destroy_process_group()
@@ -1921,6 +1916,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         tag = (
             _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3)
@@ -1964,6 +1960,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # input.keys() diverge. The tag must distinguish on input.keys() so the
         # mismatch is caught instead of corrupting the all2all silently.
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         keys = ["f0", "f1"] if rank == 0 else ["f0", "f2"]
         input_splits_len = 3
@@ -2008,6 +2005,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # silent-corruption mode the validation must catch. The tag must
         # therefore include the splits identity, not just len(splits).
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         keys = ["f0", "f1"]  # rank-invariant
         splits = (2, 0) if rank == 0 else (1, 1)  # divergent plan
@@ -2053,6 +2051,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # would collide; with the tightened per-request identity
         # (keys, splits, len(splits_tensors)) the tag detects the divergence.
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         # Construct a KJTSplitsAllToAllMeta whose `splits` differs per rank.
         # Everything else is rank-invariant: same keys, same shape.
@@ -2120,6 +2119,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         # out before tagging), the two ranks would compute the same tag and
         # silently corrupt the fused splits-all2all.
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         kjt = KeyedJaggedTensor(
             keys=["f0"],
@@ -2184,9 +2184,8 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         )
 
     def test_tag_raises_on_small_dtype(self) -> None:
-        with unittest.mock.patch.dict(
-            os.environ, {"TORCHREC_VALIDATE_COLLECTIVES": "1"}
-        ):
+        cu._USE_COLLECTIVE_VALIDATION = True
+        try:
             mock_pg = unittest.mock.MagicMock()
             mock_pg.size.return_value = 2
 
@@ -2199,6 +2198,8 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
                     collective_tag=large_tag,
                 )
             self.assertIn("exceeds", str(ctx.exception).lower())
+        finally:
+            cu._USE_COLLECTIVE_VALIDATION = False
 
     @classmethod
     def _run_test_mismatch_emits_scuba_event(
@@ -2208,6 +2209,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         input_tensors = [
             torch.tensor([1] * world_size, dtype=torch.int64),
@@ -2272,6 +2274,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         that the Scuba event reports global ranks (actionable for triage),
         not PG-local indices."""
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         # new_group is collective on WORLD, so every rank must call it,
         # even ranks not in the resulting subgroup.
@@ -2348,6 +2351,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         input_tensors = [
             torch.tensor([1] * world_size, dtype=torch.int64),
@@ -2386,6 +2390,7 @@ class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):
         backend: str,
     ) -> None:
         dist.init_process_group(rank=rank, world_size=world_size, backend=backend)
+        cu._USE_COLLECTIVE_VALIDATION = True
 
         input_tensors = [
             torch.tensor([1] * world_size, dtype=torch.int64),


### PR DESCRIPTION
Summary:

Context
---------
Recently, we dealt with int32 overflows that occured after all2all communication on AMD hardware with the WebFM model. This motivated adding comms validation to torchrec due to potential mismatch between two consequent all2alls. 

Enabling collective validation requires adding an environment variable. The goal of this diff is to add just-knobs check for collection validation with a plan on doing a gradual rollout.

Implementation
------------------

The biggest concern for implementation is per-rank divergence.  This problem is known to cause a large SEV S580285.

Solutions that we have are to do a broadcast from rank 0 to avoid any per-rank divergence.  However, need to ensure the same process group is used throughout, and that it is the global pg. So one way to do this is to do it when the process groups is first made inside DMP, and check if it is a global process group. (Note this handles 2D sharding too).

Reviewed By: kaanbaloglu

Differential Revision: D105336117


