### PR TITLE
test-gen skill: prefer real impls over mocks (#4277)

### DIFF
--- a/torchrec/.claude/skills/test-gen/SKILL.md
+++ b/torchrec/.claude/skills/test-gen/SKILL.md
@@ -193,6 +193,7 @@ Use these utilities when generating tests:
 - NEVER add tests for private methods (starting with `_`) unless they contain complex logic that's critical to test.
 - ALWAYS match the import style of the source file (modern `list[str]` vs `List[str]`).
 - ALWAYS check if similar tests already exist before generating duplicates.
+- ALWAYS prefer real implementations over mocks. Use `MultiProcessContext` + real gloo PG for distributed tests, `ScopedConfigeratorFake` / JK overrides for config and feature flags, and in-memory fakes where they exist. Reach for `mock.patch` / `MagicMock` only when no real fake exists for the dependency, and call out *why* in a one-line comment.
 - Keep generated tests focused and minimal — don't test framework behavior or trivial getters/setters.
 
 ## Instructions from User


### PR DESCRIPTION
Summary:

Adds mocking guidance to the `test-gen` Claude skill so future test scaffolding defaults to real fakes (`MultiProcessContext` + real gloo PG, `ScopedConfigeratorFake`, JK overrides) rather than `MagicMock` / `mock.patch`. Reaching for a mock is still allowed when no real fake exists, but reviewers should see a one-line comment explaining why.

No production code changes; docs-only update to the local Claude skill surface.

Reviewed By: josh-bolgar

Differential Revision: D105869754


