### PR TITLE
Fix failing tests by correcting kernel usage

### DIFF
--- a/torchrec/distributed/tests/test_sequence_model_parallel.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel.py
@@ -42,7 +42,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         sharding_type=st.just(ShardingType.ROW_WISE.value),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.FUSED.value,
             ]
         ),
@@ -133,7 +132,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         sharding_type=st.just(ShardingType.TABLE_WISE.value),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.FUSED.value,
             ]
         ),
@@ -193,7 +191,6 @@ class SequenceModelParallelTest(MultiProcessTestBase):
         sharding_type=st.just(ShardingType.COLUMN_WISE.value),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.FUSED.value,
             ]
         ),


### PR DESCRIPTION
Summary:
- Remove DENSE kernel from non-DATA_PARALLEL sharding tests
- Keep DENSE kernel for DATA_PARALLEL tests (the only supported kernel for DP)

Details:
- DENSE kernel is only supported for DATA_PARALLEL sharding
- For ROW_WISE, TABLE_WISE, COLUMN_WISE, only FUSED kernel is available
- The enumerator filters out DENSE when FUSED is present, causing tests to fail

Files modified:
- fbcode/torchrec/distributed/tests/test_sequence_model_parallel.py
- fbcode/torchrec/fb/ads/distributed/tests/test_ads_general_pooled_emb_model_parallel.py
- fbcode/torchrec/fb/distributed/tests/test_pooled_emb_arch_model_parallel_nccl.py
- fbcode/torchrec/fb/distributed/tests/test_sequence_model_parallel.py

Tests fixed:
- torchrec/fb/distributed/tests:test_pooled_emb_arch_model_parallel_nccl
- torchrec/fb/ads/distributed/tests:test_ads_general_pooled_emb_model_parallel
- torchrec/fb/distributed/tests:test_sequence_model_parallel
- torchrec/distributed/tests:test_sequence_model_parallel

Differential Revision: D105843722


