### PR TITLE
Add DRAM_SSD_VIRTUAL_TABLE embedding lookup and kernel support (#4279)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -612,7 +612,9 @@ def _populate_zero_collision_tbe_params(
         bucket_offsets=bucket_offsets,
         bucket_sizes=bucket_sizes,
         enable_optimizer_offloading=True,
-        backend_return_whole_row=(backend_type == BackendType.DRAM),
+        backend_return_whole_row=(
+            backend_type in (BackendType.DRAM, BackendType.DRAM_SSD)
+        ),
         # pyrefly: ignore[bad-argument-type]
         eviction_policy=eviction_policy,
         embedding_cache_mode=embedding_cache_mode_,

--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -990,6 +990,7 @@ class ShardedEmbeddingCollection(
                     EmbeddingComputeKernel.KEY_VALUE.value,
                     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
                     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+                    EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
                 }
                 if shards_wrapper_map["local_tensors"]:
                     self._model_parallel_name_to_dtensor[table_name] = (
@@ -1078,6 +1079,7 @@ class ShardedEmbeddingCollection(
                     EmbeddingComputeKernel.KEY_VALUE.value,
                     EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
                     EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+                    EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
                 }:
                     ret[table_name] = sharded_t
             return ret
@@ -1224,6 +1226,7 @@ class ShardedEmbeddingCollection(
                 EmbeddingComputeKernel.KEY_VALUE.value,
                 EmbeddingComputeKernel.SSD_VIRTUAL_TABLE.value,
                 EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE.value,
+                EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE.value,
             }:
                 continue
             assert table_config.init_fn is not None

--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -262,6 +262,7 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
                 or table.compute_kernel == EmbeddingComputeKernel.KEY_VALUE
                 or table.compute_kernel == EmbeddingComputeKernel.SSD_VIRTUAL_TABLE
                 or table.compute_kernel == EmbeddingComputeKernel.DRAM_VIRTUAL_TABLE
+                or table.compute_kernel == EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE
             ):
                 self._need_prefetch = True
         if config.compute_kernel == EmbeddingComputeKernel.DENSE:
@@ -330,6 +331,37 @@ class GroupedEmbeddingsLookup(BaseEmbeddingLookup[KeyedJaggedTensor, torch.Tenso
                     device=device,
                     backend_type=BackendType.DRAM,
                 )
+        elif config.compute_kernel == EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE:
+            # for dram + ssd composite kv
+            if config.enable_embedding_update:
+                kv_zch_params = None
+                if (
+                    config.fused_params
+                    and "kvzch_tbe_config" in config.fused_params
+                    and config.is_using_virtual_table()
+                ):
+                    kv_zch_params = config.fused_params.get("kvzch_tbe_config")
+                if kv_zch_params and kv_zch_params.enrichment_policy is not None:
+                    return ZeroCollisionEmbeddingEnrichmentCache(
+                        config=config,
+                        pg=pg,
+                        device=device,
+                        backend_type=BackendType.DRAM_SSD,
+                    )
+                else:
+                    return ZeroCollisionEmbeddingCache(
+                        config=config,
+                        pg=pg,
+                        device=device,
+                        backend_type=BackendType.DRAM_SSD,
+                    )
+            else:
+                raise ValueError(
+                    "DRAM_SSD_VIRTUAL_TABLE compute kernel does not support a plain "
+                    "embedding table; it currently only supports the embedding cache "
+                    "(enable_embedding_update=True)."
+                )
+
         else:
             raise ValueError(f"Compute kernel not supported {config.compute_kernel}")
 
@@ -719,6 +751,14 @@ class GroupedPooledEmbeddingsLookup(
                 device=device,
                 sharding_type=sharding_type,
                 backend_type=BackendType.DRAM,
+            )
+        elif config.compute_kernel == EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE:
+            # DRAM_SSD only supports the embedding cache (EmbeddingCollection),
+            # not pooled EmbeddingBagCollection.
+            raise ValueError(
+                "DRAM_SSD_VIRTUAL_TABLE compute kernel is not supported for "
+                "EmbeddingBagCollection (pooled embeddings); it currently only "
+                "supports the embedding cache via EmbeddingCollection."
             )
         else:
             raise ValueError(f"Compute kernel not supported {config.compute_kernel}")

--- a/torchrec/distributed/tests/test_embedding_lookup.py
+++ b/torchrec/distributed/tests/test_embedding_lookup.py
@@ -8,9 +8,13 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
+from torchrec.distributed.embedding_lookup import (
+    BackendType,
+    GroupedEmbeddingsLookup,
+    GroupedPooledEmbeddingsLookup,
+)
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -148,3 +152,98 @@ class VbeSplitsTest(unittest.TestCase):
                 GroupedPooledEmbeddingsLookup._vbe_splits(lookup, [features])
             self.assertIn("1 ranks", str(ctx.exception))
             self.assertIn("world_size is 4", str(ctx.exception))
+
+
+def _make_virtual_table_config(
+    compute_kernel: EmbeddingComputeKernel,
+    enable_embedding_update: bool = True,
+    fused_params: dict | None = None,
+) -> GroupedEmbeddingConfig:
+    table = ShardedEmbeddingTable(
+        name="table_0",
+        data_type=DataType.FP32,
+        pooling=PoolingType.SUM,
+        is_weighted=False,
+        has_feature_processor=False,
+        compute_kernel=compute_kernel,
+        embedding_dim=16,
+        local_cols=16,
+        num_embeddings=100,
+        feature_names=["feature_0"],
+        use_virtual_table=True,
+    )
+    return GroupedEmbeddingConfig(
+        data_type=DataType.FP32,
+        pooling=PoolingType.SUM,
+        is_weighted=False,
+        has_feature_processor=False,
+        compute_kernel=compute_kernel,
+        embedding_tables=[table],
+        fused_params=fused_params,
+        enable_embedding_update=enable_embedding_update,
+    )
+
+
+class DramSsdVirtualTableKernelTest(unittest.TestCase):
+    @patch("torchrec.distributed.embedding_lookup.ZeroCollisionEmbeddingCache")
+    def test_dram_ssd_creates_embedding_cache(self, mock_cache: MagicMock) -> None:
+        config = _make_virtual_table_config(
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
+            enable_embedding_update=True,
+        )
+        lookup = MagicMock(spec=GroupedEmbeddingsLookup)
+        result = GroupedEmbeddingsLookup._create_embedding_kernel(
+            lookup, config, None, None, None
+        )
+        mock_cache.assert_called_once()
+        self.assertEqual(
+            mock_cache.call_args.kwargs["backend_type"], BackendType.DRAM_SSD
+        )
+        self.assertIs(result, mock_cache.return_value)
+
+    @patch(
+        "torchrec.distributed.embedding_lookup.ZeroCollisionEmbeddingEnrichmentCache"
+    )
+    def test_dram_ssd_creates_enrichment_cache_with_policy(
+        self, mock_cache: MagicMock
+    ) -> None:
+        kvzch_config = MagicMock()
+        kvzch_config.enrichment_policy = MagicMock()
+        config = _make_virtual_table_config(
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
+            enable_embedding_update=True,
+            fused_params={"kvzch_tbe_config": kvzch_config},
+        )
+        lookup = MagicMock(spec=GroupedEmbeddingsLookup)
+        result = GroupedEmbeddingsLookup._create_embedding_kernel(
+            lookup, config, None, None, None
+        )
+        mock_cache.assert_called_once()
+        self.assertEqual(
+            mock_cache.call_args.kwargs["backend_type"], BackendType.DRAM_SSD
+        )
+        self.assertIs(result, mock_cache.return_value)
+
+    def test_dram_ssd_without_embedding_update_raises(self) -> None:
+        config = _make_virtual_table_config(
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
+            enable_embedding_update=False,
+        )
+        lookup = MagicMock(spec=GroupedEmbeddingsLookup)
+        with self.assertRaises(ValueError) as ctx:
+            GroupedEmbeddingsLookup._create_embedding_kernel(
+                lookup, config, None, None, None
+            )
+        self.assertIn("enable_embedding_update", str(ctx.exception))
+
+    def test_dram_ssd_pooled_embedding_bag_not_supported(self) -> None:
+        config = _make_virtual_table_config(
+            EmbeddingComputeKernel.DRAM_SSD_VIRTUAL_TABLE,
+            enable_embedding_update=True,
+        )
+        lookup = MagicMock(spec=GroupedPooledEmbeddingsLookup)
+        with self.assertRaises(ValueError) as ctx:
+            GroupedPooledEmbeddingsLookup._create_embedding_kernel(
+                lookup, config, None, None, None, None
+            )
+        self.assertIn("EmbeddingBagCollection", str(ctx.exception))


### PR DESCRIPTION
Summary:

Add DRAM_SSD_VIRTUAL_TABLE handling to embedding lookup cache creation (ZeroCollisionEmbeddingCache, ZeroCollisionEmbeddingEnrichmentCache, ZeroCollisionKeyValueEmbedding, ZeroCollisionKeyValueEmbeddingBag), batched_embedding_kernel (backend_return_whole_row), embedding module (model parallel name mapping), and embeddingbag (sharded tensor return).

Reviewed By: vinares, EddyLXJ

Differential Revision: D106005891


