### PR TITLE
Fix DENSE kernel validation test failures

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -1280,7 +1280,7 @@ class ModelParallelStateDictBase(ModelParallelSingleRankBase):
                 ModuleSharder[nn.Module],
                 create_test_sharder(
                     sharder_type,
-                    sharding_type,
+                    ShardingType.DATA_PARALLEL.value,
                     EmbeddingComputeKernel.DENSE.value,
                     fused_params=fused_params,
                 ),

--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -539,7 +539,6 @@ class MultiRankDMPDynamicShardingTest(ModelParallelTestShared):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.FUSED.value,
                 EmbeddingComputeKernel.FUSED_UVM_CACHING.value,
                 EmbeddingComputeKernel.FUSED_UVM.value,
@@ -582,13 +581,7 @@ class MultiRankDMPDynamicShardingTest(ModelParallelTestShared):
         - For Column-Wise sharding: Only Adagrad and SGD (no RowWiseAdagrad)
         """
         if self.device.type == "cpu":
-            assume(
-                kernel_type
-                in (
-                    EmbeddingComputeKernel.DENSE.value,
-                    EmbeddingComputeKernel.FUSED.value,
-                )
-            )
+            assume(kernel_type in (EmbeddingComputeKernel.FUSED.value,))
         elif self.device.type == "cuda":
             assume(torch.cuda.device_count() >= world_size)
 

--- a/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
+++ b/torchrec/distributed/tests/test_sequence_model_parallel_hierarchical.py
@@ -53,7 +53,6 @@ class SequenceModelParallelHierarchicalTest(MultiProcessTestBase):
         ),
         kernel_type=st.sampled_from(
             [
-                EmbeddingComputeKernel.DENSE.value,
                 EmbeddingComputeKernel.FUSED.value,
             ]
         ),


### PR DESCRIPTION
Summary:
Commit D105843722 ("[TorchRec][BE] Add compute kernel validation to sharding planners") added `validate_compute_kernels()` which correctly enforces that DENSE kernel requires DATA_PARALLEL sharding. However, several existing tests parametrize `kernel_type=DENSE` alongside non-DATA_PARALLEL sharding types (table_wise, column_wise, row_wise, table_row_wise, table_column_wise), causing PlannerError failures.

This diff removes `EmbeddingComputeKernel.DENSE.value` from the `kernel_type` hypothesis sampling in tests that only use non-DATA_PARALLEL sharding types. Separate `_dp` test variants already exist that correctly test DENSE + DATA_PARALLEL.

Changes:
- `test_dynamic_sharding.py`: Remove DENSE from kernel_type sampling (TABLE_WISE/COLUMN_WISE sharding) and update CPU assume() guard
- `test_sequence_model_parallel_hierarchical.py`: Remove DENSE from kernel_type (TABLE_ROW_WISE sharding)
- `test_resharding_handler.py`: Remove DENSE from kernel_type (TABLE_WISE/COLUMN_WISE sharding)
- `test_pooled_emb_arch_model_parallel_hierarchical.py`: Remove DENSE from kernel_type (TABLE_ROW_WISE/TABLE_COLUMN_WISE sharding)
- `test_model_parallel_base.py`: Fix `dense_sharders` in `test_rowwise_adagrad_numerical_equivalence` to use DATA_PARALLEL sharding instead of inheriting table_wise
- `test_ads_general_pooled_emb_model_pruning_parallel.py`: Remove DENSE from kernel_type in TW/CW/gloo_tw tests
- `test_disaggregated_tower_model_parallel.py`: Remove DENSE from kernel_type in RW_TW/CW tests, fix duplicate function definitions
- `test_disaggregated_tower_model_parallel_hierarchical.py`: Remove DENSE from kernel_type
- BUCK files: Fix caffe2 dep targets

Differential Revision: D106099489


