### PR TITLE
Add EMS logging to TrainingOptimizationLogger

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -385,6 +385,14 @@ def log_ssd_offloading_config(
     pass
 
 
+def log_ems_config(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMS,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_kernel_changed(
     table_name: str = "",
     action: str = "",

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -43,6 +43,7 @@ class OptimizationTechnique(Enum):
     ALBT = "albt"
     SSD_OFFLOADING = "ssd_offloading"
     TWO_DIM_SHARDING = "two_dim_sharding"
+    EMS = "ems"
 
 
 @unique

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -58,6 +58,20 @@ from torchrec.distributed.train_pipeline.utils import (
 from torchrec.distributed.types import LazyNoWait, ShardingType
 from torchrec.sparse.jagged_tensor import KeyedTensor
 
+try:
+    from torchrec.distributed.logging_handlers import log_ems_config
+    from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
+except Exception:
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.train_pipeline.experimental_pipelines.import_failure.logging_handlers"
+    )
+
+    DATA_TYPE_NUM_BITS: dict = {}  # type: ignore[no-redef]
+
+    def log_ems_config(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
+        pass
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -1160,6 +1174,43 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         )
         if delay_stash:
             MemoryStashingManager.set_delay_stash(True)
+
+        self._log_ems_config()
+
+    def _log_ems_config(self) -> None:
+        """Emit an ems_config event with table-level stash info."""
+        try:
+            stash_table_names: list[str] = []
+            total_stash_bytes_unsharded: int = 0
+            base_model = self._model
+            if isinstance(base_model, DistributedModelParallel):
+                base_model = base_model.module
+            for module in base_model.modules():
+                embedding_configs = getattr(module, "embedding_configs", None)
+                if embedding_configs is not None:
+                    for ec in embedding_configs:
+                        if getattr(ec, "stash_weights", False):
+                            stash_table_names.append(ec.name)
+                            bits = DATA_TYPE_NUM_BITS.get(ec.data_type)
+                            if bits is not None:
+                                total_stash_bytes_unsharded += (
+                                    ec.num_embeddings * ec.embedding_dim * bits // 8
+                                )
+                            else:
+                                logger.warning(
+                                    f"Skipping stash bytes calculation for {ec.name}: "
+                                    f"unknown data_type {ec.data_type}"
+                                )
+            log_ems_config(
+                metadata={
+                    "num_stash_tables": str(len(stash_table_names)),
+                    "stash_table_names": ",".join(stash_table_names),
+                    "total_stash_bytes_unsharded": str(total_stash_bytes_unsharded),
+                    "pipeline_type": type(self).__name__,
+                },
+            )
+        except Exception:
+            logger.debug("EMS config logging failed", exc_info=True)
 
     def _try_hook_stash(self) -> None:
         """Register a forward pre-hook on ``stash_site_fqn`` to execute


### PR DESCRIPTION
Summary:
Add structured Scuba logging for Embedding Memory Stashing (EMS) to TrainingOptimizationLogger.

Changes:
- Add `EMS = "ems"` to `OptimizationTechnique` enum
- Add `log_ems_config()` helper with OSS stub and Scuba implementation, taking `metadata: Dict[str, str]` for consistency with other logging functions
- Call site in `TrainPipelineSparseDistEmbStash.__init__()` logs EMS config (stash table names, `total_stash_bytes_unsharded`, pipeline type) via `_log_ems_config()`
- Import uses top-level try-catch with `torch._C._log_api_usage_once` fallback, matching the pattern from D103629295
- Exception handling uses `logger.debug(..., exc_info=True)` instead of silent swallowing
- Add 2 unit tests: config logging, multi-technique (EMS + EMO)

Reviewed By: aporialiao

Differential Revision: D103790970


