### PR TITLE
fix test_rowwise_adagrad_numerical_equivalence

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -1297,9 +1297,15 @@ class ModelParallelStateDictBase(ModelParallelSingleRankBase):
             eps=1e-8,  # TBE has default eps 1e-8
         )
 
-        # load the baseline model's state_dict onto the new model
-        dense_model.load_state_dict(
-            cast("OrderedDict[str, torch.Tensor]", fused_model.state_dict())
+        # load the baseline model's state_dict onto the new model.
+        # Use copy_state_dict (not load_state_dict) because the two models have
+        # different topologies: fused_model produces ShardedTensor entries in its
+        # state_dict (table-wise + fused), while dense_model's params are
+        # TableBatchedEmbeddingSlice (data-parallel + dense). PyTorch's default
+        # load_state_dict cannot copy ShardedTensor into TableBatchedEmbeddingSlice.
+        copy_state_dict(
+            dense_model.state_dict(),
+            cast("OrderedDict[str, torch.Tensor]", fused_model.state_dict()),
         )
 
         for _ in range(4):
@@ -1311,4 +1317,25 @@ class ModelParallelStateDictBase(ModelParallelSingleRankBase):
             dense_opt.step()
 
         self._eval_models(fused_model, dense_model, batch, is_deterministic=False)
-        self._compare_models(fused_model, dense_model, is_deterministic=False)
+        # The two models use different sharding topologies (fused: table-wise
+        # produces ShardedTensor entries; dense: data-parallel produces plain
+        # tensors), so the symmetric _compare_models helper does not apply.
+        # Compare the underlying table weights directly instead.
+        fused_sd = fused_model.state_dict()
+        dense_sd = dense_model.state_dict()
+        for key, dense_val in dense_sd.items():
+            if not key.endswith(".weight") or "embedding_bags" not in key:
+                continue
+            fused_val = fused_sd[key]
+            fused_tensor = (
+                fused_val.local_shards()[0].tensor
+                if isinstance(fused_val, ShardedTensor)
+                else fused_val
+            )
+            dense_tensor = (
+                dense_val.local_shards()[0].tensor
+                if isinstance(dense_val, ShardedTensor)
+                else dense_val
+            )
+            rtol, atol = _get_default_rtol_and_atol(fused_tensor, dense_tensor)
+            torch.testing.assert_close(fused_tensor, dense_tensor, rtol=rtol, atol=atol)


### PR DESCRIPTION
Summary:
## Background

This test was broken in two stages, neither of which is fully addressed yet:

1. D105843722 (`[TorchRec][BE] Add compute kernel validation to sharding planners`) added `validate_compute_kernels()`, which rejects `DENSE` kernel paired with anything other than `DATA_PARALLEL` sharding. The test's `dense_sharders` was inheriting `sharding_type=TABLE_WISE`, so it started failing with a `PlannerError`.
2. D106099489 (`[TorchRec] Fix DENSE kernel validation test failures`) switched `dense_sharders` to use `ShardingType.DATA_PARALLEL.value`. That cleared the planner error but exposed a second problem: `fused_model` (table-wise + fused) and `dense_model` (data-parallel + dense) now have incompatible state_dict topologies, so the subsequent `load_state_dict` and `_compare_models` calls fail.

## Remaining failures fixed by this diff

1. `dense_model.load_state_dict(fused_model.state_dict())` — `fused_model` emits `ShardedTensor` entries via its `post_state_dict_hook`, but `dense_model`'s params are `TableBatchedEmbeddingSlice` (from the dense TBE kernel). PyTorch's default `load_state_dict` cannot copy `ShardedTensor` → `TableBatchedEmbeddingSlice`, producing `'TableBatchedEmbeddingSlice' object has no attribute 'local_shards'`.
2. `self._compare_models(...)` — `_compare_models` iterates the dense model's state_dict and matches the value types. With the mixed topology, the dense side is a plain tensor while the fused side is a `ShardedTensor`, and `torch.testing.assert_close(sharded_tensor, plain_tensor)` fails inside `ShardedTensor.__torch_function__`.

## Fix

In `fbcode/torchrec/distributed/test_utils/test_model_parallel_base.py`:

- Replaced `dense_model.load_state_dict(...)` with `copy_state_dict(dense_model.state_dict(), fused_model.state_dict())` — the existing utility (already used in this file) that handles `ShardedTensor`/`DTensor`/plain-tensor combinations.
- Replaced `_compare_models(...)` with a direct per-table weight comparison that unwraps `ShardedTensor` on either side before calling `assert_close`.

Differential Revision: D106395745


