### PR TITLE
Align BackendType import in batched_embedding_kernel with embedding_lookup

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -34,7 +34,6 @@ from typing import (
 import torch
 import torch.distributed as dist
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import BackendType
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
@@ -50,7 +49,7 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
 from fbgemm_gpu.tbe.ssd import ASSOC, SSDTableBatchedEmbeddingBags
 
 try:
-    from fbgemm_gpu.tbe.ssd import EvictionPolicy, KVZCHParams
+    from fbgemm_gpu.tbe.ssd import BackendType, EvictionPolicy, KVZCHParams
 except ImportError:
     # Track via _log_api_usage_once so we can quantify the callers still on
     # a pre-D103282820 fbgemm_gpu and remove this fallback once those base
@@ -58,9 +57,11 @@ except ImportError:
     torch._C._log_api_usage_once(
         "torchrec.distributed.batched_embedding_kernel.import_failure.tbe_ssd_kvzch_types"
     )
-    # Fallback for fbgemm_gpu < D103282820 (EvictionPolicy, KVZCHParams
-    # moved from split_table_batched_embeddings_ops_common to tbe/ssd).
+    # Fallback for fbgemm_gpu < D103282820 (BackendType, EvictionPolicy,
+    # KVZCHParams moved from split_table_batched_embeddings_ops_common
+    # to tbe/ssd).
     from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        BackendType,
         EvictionPolicy,
         KVZCHParams,
     )


### PR DESCRIPTION
Summary:
Follow-up to D105254047 (`[torchrec][compat] Add fbgemm_gpu.tbe.ssd import fallback for D103493980`). That diff migrated `BackendType` in `embedding_lookup.py` to the new canonical `fbgemm_gpu.tbe.ssd` location (with a `try / except ImportError` fallback to `fbgemm_gpu.split_table_batched_embeddings_ops_common`), but missed `batched_embedding_kernel.py`, which kept the legacy import.

After the migration, the two `BackendType` classes coexist as distinct types: pyrefly views `fbgemm_gpu.tbe.ssd.ssd_config.BackendType` and `fbgemm_gpu.split_table_batched_embeddings_ops_common.BackendType` as separate enums. `embedding_lookup.py` resolves to a union of the two, and passing those values into `ZeroCollisionKeyValueEmbedding.__init__` / `ZeroCollisionEmbeddingEnrichmentCache.__init__` / `ZeroCollisionEmbeddingCache.__init__` / `ZeroCollisionKeyValueEmbeddingBag.__init__` (whose `backend_type` parameter is typed against only the legacy class) fails type checking:

```
fbcode/torchrec/distributed/embedding_lookup.py:300:30 Argument `Literal[fbgemm_gpu.tbe.ssd.ssd_config.BackendType.SSD, fbgemm_gpu.split_table_batched_embeddings_ops_common.BackendType.SSD]` is not assignable to parameter `backend_type` with type `fbgemm_gpu.split_table_batched_embeddings_ops_common.BackendType` ...
```

(and 5 more identical failures at lines 317, 324, 331, 712, 721).

Fix: move `BackendType` in `batched_embedding_kernel.py` into the same `try: from fbgemm_gpu.tbe.ssd import …` block alongside `EvictionPolicy` and `KVZCHParams`, with the same `except ImportError` fallback to `split_table_batched_embeddings_ops_common`. Both modules now resolve `BackendType` to the same class, so the parameter type matches the argument type and pyrefly is happy. `arc lint -a` also autodeps-swapped `//caffe2:torch` → `fbsource//third-party/pypi/torch:torch` in the BUCK file (unrelated to the import change but applied for cleanliness).

When the base-layer rollforward referenced in D105254047 finishes, the `except ImportError` branches in both files become dead code and can be deleted together.

Differential Revision: D106401147


