### PR TITLE
Fix DMPCollection 2D-sharding test hang from sharding_strategy=None default

### DIFF
--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -161,7 +161,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
         indices_dtype: torch.dtype = torch.int64,
         offsets_dtype: torch.dtype = torch.int64,
         lengths_dtype: torch.dtype = torch.int64,
-        sharding_strategy: Optional[ShardingStrategy] = None,
+        sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT,
         atol: Optional[float] = None,
         rtol: Optional[float] = None,
         rs_awaitable_hook_module: Optional[str] = None,

--- a/torchrec/distributed/test_utils/test_sharding.py
+++ b/torchrec/distributed/test_utils/test_sharding.py
@@ -807,7 +807,7 @@ def sharding_single_rank_test_single_process(
     offsets_dtype: torch.dtype = torch.int64,
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
-    sharding_strategy: Optional[ShardingStrategy] = None,
+    sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT,
     rs_awaitable_hook_module: Optional[str] = None,
     atol: Optional[float] = None,
     rtol: Optional[float] = None,
@@ -980,7 +980,6 @@ def sharding_single_rank_test_single_process(
             use_inter_host_allreduce=use_inter_host_allreduce,
             custom_all_reduce=all_reduce_func,
             submodule_configs=submodule_configs,
-            # pyrefly: ignore[bad-argument-type]
             sharding_strategy=sharding_strategy,
             rs_awaitable_hook_module=rs_awaitable_hook_module,
         )
@@ -1099,7 +1098,7 @@ def sharding_single_rank_test(
     offsets_dtype: torch.dtype = torch.int64,
     lengths_dtype: torch.dtype = torch.int64,
     random_seed: Optional[int] = None,
-    sharding_strategy: Optional[ShardingStrategy] = None,
+    sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT,
     rs_awaitable_hook_module: Optional[str] = None,
     atol: Optional[float] = None,
     rtol: Optional[float] = None,

--- a/torchrec/distributed/tests/test_2d_sharding.py
+++ b/torchrec/distributed/tests/test_2d_sharding.py
@@ -2062,7 +2062,7 @@ class TestFullySharded2DECParallel(MultiProcessTestBase):
         ] = None,
         variable_batch_size: bool = False,
         variable_batch_per_feature: bool = False,
-        sharding_strategy: Optional[ShardingStrategy] = None,
+        sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT,
         rs_awaitable_hook_module: Optional[str] = None,
     ) -> None:
         self._run_multi_process_test(


### PR DESCRIPTION
Summary:
The 2D EC test methods (e.g. `test_sharding_ec_cw_2D`) reliably time out at the 10-minute buck-test cap. Root cause: the torchrec test helpers `sharding_single_rank_test` and `sharding_single_rank_test_single_process` default `sharding_strategy: Optional[ShardingStrategy] = None` and forward that `None` into `DMPCollection(...)`, suppressing the resulting type error with a `# pyrefly: ignore[bad-argument-type]`. `DMPCollection.__init__` declares `sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT` and accesses `sharding_strategy.name` in a rank-0-only logging block (`model_parallel.py:1225`), so `None` raises `AttributeError` on rank 0 only. Rank 0 unwinds into `MultiProcessContext.__exit__` and starts tearing down the WORLD pg; ranks 1-7 reach `init_collective_validation`'s WORLD broadcast and deadlock forever waiting for rank 0.

Fix: change both helpers' annotation to `sharding_strategy: ShardingStrategy = ShardingStrategy.DEFAULT` (matching `DMPCollection`'s signature) and drop the pyrefly ignore.

Reviewed By: siqihuang

Differential Revision: D106421967


