### PR TITLE
Include `table_name` in `_initialize_torch_state` error messages (#4290)

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1370,20 +1370,25 @@ class ShardedEmbeddingBagCollection(
                         ),
                     )
 
-                    self._model_parallel_name_to_sharded_tensor[table_name] = (
-                        ShardedTensor._init_from_local_shards_and_global_metadata(
-                            local_shards=local_shards,
-                            sharded_tensor_metadata=sharding_spec.build_metadata(
-                                tensor_sizes=self._name_to_table_size[table_name],
-                                tensor_properties=tensor_properties,
-                            ),
-                            process_group=(
-                                self._env.sharding_pg
-                                if isinstance(self._env, ShardingEnv2D)
-                                else self._env.process_group
-                            ),
+                    try:
+                        self._model_parallel_name_to_sharded_tensor[table_name] = (
+                            ShardedTensor._init_from_local_shards_and_global_metadata(
+                                local_shards=local_shards,
+                                sharded_tensor_metadata=sharding_spec.build_metadata(
+                                    tensor_sizes=self._name_to_table_size[table_name],
+                                    tensor_properties=tensor_properties,
+                                ),
+                                process_group=(
+                                    self._env.sharding_pg
+                                    if isinstance(self._env, ShardingEnv2D)
+                                    else self._env.process_group
+                                ),
+                            )
                         )
-                    )
+                    except RuntimeError as e:
+                        raise RuntimeError(
+                            f"Failed to initialize sharded tensor for table '{table_name}': {e}"
+                        ) from e
 
         def extract_sharded_kvtensors(
             module: ShardedEmbeddingBagCollection,

--- a/torchrec/distributed/test_utils/test_model_parallel_base.py
+++ b/torchrec/distributed/test_utils/test_model_parallel_base.py
@@ -9,6 +9,7 @@
 
 import os
 import unittest
+import unittest.mock
 from collections import defaultdict
 from typing import Any, Callable, cast, Dict, List, Optional, OrderedDict, Tuple, Union
 
@@ -282,6 +283,38 @@ class ModelParallelSparseOnlyBase(unittest.TestCase):
             filter(lambda s: "Validating input features..." in s, logs.output)
         )
         self.assertEqual(1, len(matched_logs))
+
+    def test_initialize_torch_state_error_includes_table_name(self) -> None:
+        with unittest.mock.patch.object(
+            ShardedEmbeddingBagCollection,
+            "_initialize_torch_state",
+            lambda self, **kwargs: None,
+        ):
+            model = self._create_sharded_model()
+
+        sharded_ebc = model.module
+        assert isinstance(sharded_ebc, ShardedEmbeddingBagCollection)
+
+        orig_fn = ShardedTensor._init_from_local_shards_and_global_metadata
+        call_count = 0
+
+        @classmethod  # type: ignore[misc]
+        def fail_on_second_call(cls: type, *args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise RuntimeError("Number of local shards (0) does not match")
+            return orig_fn.__func__(cls, *args, **kwargs)
+
+        ShardedTensor._init_from_local_shards_and_global_metadata = fail_on_second_call  # type: ignore[assignment]
+        try:
+            sharded_ebc._initialize_torch_state()
+            self.fail("Expected RuntimeError")
+        except RuntimeError as e:
+            self.assertIn("large_table", str(e))
+            self.assertIn("Number of local shards (0) does not match", str(e))
+        finally:
+            ShardedTensor._init_from_local_shards_and_global_metadata = orig_fn  # type: ignore[assignment]
 
     def _create_sharded_model(
         self, embedding_dim: int = 128, num_embeddings: int = 256


### PR DESCRIPTION
Summary:

When `ShardedTensor._init_from_local_shards_and_global_metadata` raises a `RuntimeError` (e.g. local shard count mismatch), the original exception does not indicate which embedding table caused the failure, making debugging difficult in models with many tables.

Wrap the call in a try/except to catch `RuntimeError` and re-raise with the `table_name` prepended, so the failing table is immediately identifiable from the stack trace.

Eg failure:
https://www.internalfb.com/mlhub/pipelines/runs/mast/mvai-training-online-2123867714?job_attempt=7&version=3&tab=execution_details&env=PRODUCTION
Stacktrace:
```
  File "/dev/shm/uid-99/b9b7f68c-seed-light-3645-ns-4026537518/torchrec/distributed/embeddingbag.py", line 823, in __init__
    self._initialize_torch_state()
  File "/dev/shm/uid-99/b9b7f68c-seed-light-3645-ns-4026537518/torchrec/distributed/embeddingbag.py", line 1368, in _initialize_torch_state
    ShardedTensor._init_from_local_shards_and_global_metadata(
  File "/dev/shm/uid-99/b9b7f68c-seed-light-3645-ns-4026537518/torch/distributed/_shard/sharded_tensor/api.py", line 971, in _init_from_local_shards_and_global_metadata
    raise RuntimeError(
RuntimeError: Number of local shards (0) does not match number of local shards metadata in sharded_tensor_metadata (1) on rank (62) 
```
But we don't know which table was this for.
S665521 could have been rootcaused faster if we knew that this was for the table with TWRW where no. of shards changed in a new instance of sharding plan.

Reviewed By: gregmacnamara

Differential Revision: D106537397


