### PR TITLE
Expose `last_total_grad_norm` on `GradientClippingOptimizer` (#4293)

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -42,6 +42,9 @@ class GradientClippingOptimizer(OptimizerWrapper):
         param_to_pgs (Dict[torch.nn.Parameter, List[dist.ProcessGroup]], optional): Mapping of parameters
             to process groups. Used for global gradient clipping in n-D model parallelism case.
             Defaults to None, local gradient clipping is used.
+        track_grad_norm (bool): track_grad_norm (bool): If set to True, the optimizer will also track the
+            total gradient norm from the most recent step, which can be retrieved
+            using the `last_total_grad_norm` property.
     """
 
     def __init__(
@@ -54,6 +57,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
         param_to_pgs: Optional[
             Dict[torch.nn.Parameter, List[dist.ProcessGroup]]
         ] = None,
+        track_grad_norm: bool = False,
     ) -> None:
         super().__init__(optimizer)
         self._clipping = clipping
@@ -62,6 +66,8 @@ class GradientClippingOptimizer(OptimizerWrapper):
         self._check_meta: bool = True
         self._enable_global_grad_clip = enable_global_grad_clip
         self._step_num = 0
+        self._track_grad_norm = track_grad_norm
+        self._last_total_grad_norm: Optional[torch.Tensor] = None
 
         # Group parameters by model parallelism process group if global clipping is enabled.
         # Otherwise, all parameters are treated as replicated and will be clipped locally.
@@ -102,6 +108,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
         if self._check_meta:
             # skip gradient clipping and early return
             if any(t.device.type == "meta" for t in self._replicate_params):
+                self._last_total_grad_norm = None
                 super().step(closure)
                 return
             if any(
@@ -109,6 +116,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
                 for params in self._sharded_params.values()
                 for t in params
             ):
+                self._last_total_grad_norm = None
                 super().step(closure)
                 return
             self._check_meta = False
@@ -129,48 +137,68 @@ class GradientClippingOptimizer(OptimizerWrapper):
                     if p.grad is not None and p.grad.numel() > 0
                 ]
                 if replicate_params:
-                    torch.nn.utils.clip_grad_norm_(
+                    self._last_total_grad_norm = torch.nn.utils.clip_grad_norm_(
                         parameters=replicate_params,
                         max_norm=self._max_gradient,
                         norm_type=self._norm_type,
                     )
+                else:
+                    self._last_total_grad_norm = None
             else:
-                self.clip_grad_norm_()
+                result = self.clip_grad_norm_()
+                self._last_total_grad_norm = (
+                    torch.tensor(result) if isinstance(result, float) else result
+                )
 
         elif self._clipping == GradientClipping.VALUE:
+            if self._track_grad_norm:
+                self._last_total_grad_norm, _ = self.compute_total_grad_norm()
             torch.nn.utils.clip_grad_value_(
                 parameters=self._replicate_params, clip_value=self._max_gradient
             )
 
+        elif self._clipping == GradientClipping.NONE:
+            if self._track_grad_norm:
+                self._last_total_grad_norm, _ = self.compute_total_grad_norm()
+
         super().step(closure)
         self._step_num += 1
 
-    def clip_grad_norm_(self) -> Optional[Union[float, torch.Tensor]]:
-        """Clip the gradient norm of all parameters."""
+    @property
+    def last_total_grad_norm(self) -> Optional[torch.Tensor]:
+        """Returns the total gradient norm from the most recent step, or None
+        if no step has run yet."""
+        return self._last_total_grad_norm
 
-        # converts self._norm_type to a float if it's a string. Used in the case where self._norm_type is 'inf'.
-        all_grads = []
-        sharded_params = self._sharded_params
-        replicate_params = self._replicate_params
+    def compute_total_grad_norm(
+        self,
+    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        """Computes the total gradient norm across all parameters without clipping.
 
-        # Process distributed parameters and gradients
+        Returns the total norm and the flat list of gradient tensors."""
         sharded_grads = {
-            pgs: _get_grads(dist_params) for pgs, dist_params in sharded_params.items()
+            pgs: _get_grads(dist_params)
+            for pgs, dist_params in self._sharded_params.items()
         }
+        replicate_grads = _get_grads(self._replicate_params)
 
+        all_grads = []
         for grads in sharded_grads.values():
             all_grads.extend(grads)
-
-        # Process replicated parameters and gradients
-        replicate_grads = _get_grads(replicate_params)
         all_grads.extend(replicate_grads)
 
-        total_grad_norm = _compute_total_norm(
+        total_norm = _compute_total_norm(
             replicate_grads=replicate_grads,
             sharded_grads=sharded_grads,
             norm_type=self._norm_type,
             max_grad_norm=self._max_gradient,
         )
+        return total_norm, all_grads
+
+    def clip_grad_norm_(self) -> Optional[Union[float, torch.Tensor]]:
+        """Clip the gradient norm of all parameters."""
+
+        total_grad_norm, all_grads = self.compute_total_grad_norm()
 
         # pyrefly: ignore[redundant-cast]
         clip_coef = cast(torch.Tensor, self._max_gradient / (total_grad_norm + 1e-6))

--- a/torchrec/optim/tests/test_clipping.py
+++ b/torchrec/optim/tests/test_clipping.py
@@ -220,6 +220,160 @@ class TestGradientClippingOptimizer(unittest.TestCase):
             param_2.grad, expected_grad_2, rtol=1e-05, atol=1e-08
         )
 
+    def test_last_total_grad_norm_none_before_step(self) -> None:
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, {}, [{"params": [param_1]}]
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer, max_gradient=1.0, clipping=GradientClipping.NORM
+        )
+
+        self.assertIsNone(gradient_clipping_optimizer.last_total_grad_norm)
+
+    def test_last_total_grad_norm_stored_after_step(self) -> None:
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, {}, [{"params": [param_1]}]
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer, max_gradient=10.0, clipping=GradientClipping.NORM
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        gradient_clipping_optimizer.step()
+
+        expected_norm = (3.0**2 + 4.0**2) ** 0.5
+        self.assertIsNotNone(gradient_clipping_optimizer.last_total_grad_norm)
+        torch.testing.assert_close(
+            gradient_clipping_optimizer.last_total_grad_norm,
+            torch.tensor(expected_norm),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+
+    def test_last_total_grad_norm_updated_each_step(self) -> None:
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, {}, [{"params": [param_1]}]
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer, max_gradient=10.0, clipping=GradientClipping.NORM
+        )
+
+        # Step 1
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        gradient_clipping_optimizer.step()
+        norm_1 = gradient_clipping_optimizer.last_total_grad_norm
+
+        # Step 2 with different gradients
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([6.0, 8.0])
+        gradient_clipping_optimizer.step()
+        norm_2 = gradient_clipping_optimizer.last_total_grad_norm
+
+        expected_norm_2 = (6.0**2 + 8.0**2) ** 0.5
+        self.assertIsNotNone(norm_2)
+        torch.testing.assert_close(
+            norm_2,
+            torch.tensor(expected_norm_2),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+        # Verify it changed from step 1
+        assert norm_1 is not None
+        assert norm_2 is not None
+        self.assertNotEqual(norm_1.item(), norm_2.item())
+
+    def test_last_total_grad_norm_stored_for_value_clipping(self) -> None:
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, {}, [{"params": [param_1]}]
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.VALUE,
+            track_grad_norm=True,
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        gradient_clipping_optimizer.step()
+
+        expected_norm = (3.0**2 + 4.0**2) ** 0.5
+        self.assertIsNotNone(gradient_clipping_optimizer.last_total_grad_norm)
+        torch.testing.assert_close(
+            gradient_clipping_optimizer.last_total_grad_norm,
+            torch.tensor(expected_norm),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+
+    def test_last_total_grad_norm_stored_for_no_clipping(self) -> None:
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1}, {}, [{"params": [param_1]}]
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.NONE,
+            track_grad_norm=True,
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        gradient_clipping_optimizer.step()
+
+        expected_norm = (3.0**2 + 4.0**2) ** 0.5
+        self.assertIsNotNone(gradient_clipping_optimizer.last_total_grad_norm)
+        torch.testing.assert_close(
+            gradient_clipping_optimizer.last_total_grad_norm,
+            torch.tensor(expected_norm),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+
+    def test_last_total_grad_norm_multi_params(self) -> None:
+        param_1 = Variable(torch.tensor([3.0, 4.0]), requires_grad=True)
+        param_2 = Variable(torch.tensor([6.0, 8.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1, "param_2": param_2},
+            {},
+            [{"params": [param_1]}, {"params": [param_2]}],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer, max_gradient=10.0, clipping=GradientClipping.NORM
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        param_2.grad = torch.tensor([6.0, 8.0])
+        gradient_clipping_optimizer.step()
+
+        expected_norm = (3.0**2 + 4.0**2 + 6.0**2 + 8.0**2) ** 0.5
+        torch.testing.assert_close(
+            gradient_clipping_optimizer.last_total_grad_norm,
+            torch.tensor(expected_norm),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+
     @patch("torch.nn.utils.clip_grad_norm_")
     def test_clip_no_gradients_norm_meta_device(
         self, mock_clip_grad_norm: MagicMock


### PR DESCRIPTION
Summary:

`GradientClippingOptimizer` computes the total gradient norm during `step()` but discards the value, making it impossible for the training pipeline to monitor gradient norms or clipping frequency.

This diff stores the pre-clipping total gradient norm as `_last_total_grad_norm` on every `step()` call, accessible via the `last_total_grad_norm` property. This works for all three clipping modes:
- `NORM`: captures the return value of `clip_grad_norm_` (pre-clipping norm, zero additional cost)
- `VALUE`: computes the norm via `_compute_grad_norm()` before applying value clipping
- `NONE`: computes the norm via `_compute_grad_norm()` for monitoring without clipping

This enables downstream consumers (e.g., MVAI training pipeline) to log gradient norms to TensorBoard for training stability monitoring.

Reviewed By: TroyGarden

Differential Revision: D106550381


