### PR TITLE
catch inner exception to handle data loading gracefully (#4294)

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines_utils.py
@@ -26,7 +26,11 @@ from torchrec.distributed.train_pipeline.tests.test_train_pipelines_base import 
     TrainPipelineSparseDistTestBase,
 )
 from torchrec.distributed.train_pipeline.tracing import CallArgs, PipelinedPostproc
-from torchrec.distributed.train_pipeline.utils import _rewrite_model
+from torchrec.distributed.train_pipeline.utils import (
+    _is_data_loading_retriable,
+    _rewrite_model,
+    DataLoadingThread,
+)
 from torchrec.distributed.types import ShardingType
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
@@ -423,3 +427,45 @@ class TrainPipelineUtilsTest(TrainPipelineSparseDistTestBase):
         missing_keys, unexpected_keys = sharded_model.load_state_dict(state_dict)
         self.assertEqual(missing_keys, [])
         self.assertEqual(unexpected_keys, [])
+
+
+class _RetryableDataError(Exception):
+    is_retryable: bool = True
+
+
+class _NonRetryableDataError(Exception):
+    is_retryable: bool = False
+
+
+class DataLoadingExceptionTest(unittest.TestCase):
+    def test_is_data_loading_retriable_direct(self) -> None:
+        self.assertTrue(
+            _is_data_loading_retriable(_RetryableDataError("transient network error"))
+        )
+        self.assertFalse(
+            _is_data_loading_retriable(_NonRetryableDataError("permission denied"))
+        )
+
+    def test_is_data_loading_retriable_via_cause(self) -> None:
+        cause = _RetryableDataError("transient network error")
+        wrapper = OSError("data loading failed")
+        wrapper.__cause__ = cause
+        self.assertTrue(_is_data_loading_retriable(wrapper))
+
+    def test_is_data_loading_retriable_no_attribute(self) -> None:
+        self.assertFalse(_is_data_loading_retriable(RuntimeError("plain")))
+
+    def test_data_loading_thread_non_retriable_exception(self) -> None:
+        error = _NonRetryableDataError("permission denied")
+        thread = DataLoadingThread(
+            device=torch.device("cpu"),
+            dataloader_iter=iter([]),
+            to_device_non_blocking=False,
+        )
+        thread._exception = error
+        thread._buffer_filled_event.set()
+
+        with self.assertRaises(_NonRetryableDataError) as ctx:
+            thread.get_next_batch(none_throws=True)
+        self.assertIs(ctx.exception, error)
+        self.assertIsNone(thread._exception)

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -631,6 +631,14 @@ def get_h2d_func(batch: In, device: torch.device) -> Pipelineable:
     return batch.to(device, non_blocking=True)
 
 
+def _is_data_loading_retriable(exception: Exception) -> bool:
+    if hasattr(exception, "is_retryable"):
+        return bool(exception.is_retryable)
+    if hasattr(exception, "__cause__") and hasattr(exception.__cause__, "is_retryable"):
+        return bool(exception.__cause__.is_retryable)
+    return False
+
+
 class DataLoadingThread(Thread, Generic[In]):
     def __init__(
         self,
@@ -657,6 +665,7 @@ class DataLoadingThread(Thread, Generic[In]):
         self._device = device
         self._to_device_non_blocking = to_device_non_blocking
         self._buffered: Optional[In] = None
+        self._exception: Optional[Exception] = None
         self._buffer_empty_event.set()
         one_time_rank0_logger.info(
             f"{self.__class__.__name__} created with device={device}, "
@@ -683,6 +692,22 @@ class DataLoadingThread(Thread, Generic[In]):
                 try:
                     batch = next(self._dataloader_iter)
                 except StopIteration:
+                    self._stop = True
+                    self._buffer_filled_event.set()
+                    return
+                except Exception as e:
+                    if _is_data_loading_retriable(e):
+                        logger.warning(
+                            f"{self.__class__.__name__}: Retriable exception "
+                            f"in data loading (skipping batch): "
+                            f"{type(e).__name__}: {e}"
+                        )
+                        continue
+                    logger.error(
+                        f"{self.__class__.__name__}: Non-retriable exception "
+                        f"in data loading: {type(e).__name__}: {e}"
+                    )
+                    self._exception = e
                     self._stop = True
                     self._buffer_filled_event.set()
                     return
@@ -714,6 +739,10 @@ class DataLoadingThread(Thread, Generic[In]):
         the main thread in the training loop.
         """
         self._buffer_filled_event.wait()
+        if self._exception is not None:
+            e = self._exception
+            self._exception = None
+            raise e
         batch = self._buffered
         if batch is None:
             if none_throws:


### PR DESCRIPTION
Summary:

Currently, `DataLoadingThread` only catches `StopIteration` from the dataloader iterator. Any other exception (e.g., transient data corruption, network hiccups in remote reading) causes the thread to silently die, leaving the main training loop hanging indefinitely on `_buffer_filled_event.wait()`.

This diff adds graceful exception handling in `DataLoadingThread`:

1. **Retriable exceptions**: If an exception (or its `__cause__`) has `is_retryable = True`, the thread logs a warning and skips the batch, continuing to load the next one. This allows transient data loading errors to be tolerated without crashing the training job.

2. **Non-retriable exceptions**: The exception is stored in `self._exception` and re-raised on the main thread in `get_next_batch()`, giving the caller a proper traceback instead of a silent hang.

A helper function `_is_data_loading_retriable()` checks the `is_retryable` attribute on both the exception and its inner cause, since data loading exceptions are often wrapped.

Reviewed By: TroyGarden

Differential Revision: D105330736


