### PR TITLE
Support user_gather_select flag per sharding type (#4295)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -352,6 +352,7 @@ class EmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
         module_fqn: Optional[str] = None,
         sharding_types: Optional[List[str]] = None,
         use_gather_select: bool = False,
+        use_gather_select_per_sharding: Optional[Dict[str, bool]] = None,
         resize_awaitables: Optional[List[Awaitable[torch.Tensor]]] = None,
     ) -> None:
         super().__init__()
@@ -364,6 +365,7 @@ class EmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
         self._module_fqn = module_fqn
         self._sharding_types = sharding_types
         self._use_gather_select = use_gather_select
+        self._use_gather_select_per_sharding = use_gather_select_per_sharding
         self._resize_awaitables = resize_awaitables
 
     def _wait_impl(self) -> Dict[str, JaggedTensor]:
@@ -396,6 +398,15 @@ class EmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
             ):
                 embeddings = w.wait()
 
+            sharding_type = self._sharding_types[i] if self._sharding_types else None
+            if (
+                self._use_gather_select_per_sharding is not None
+                and sharding_type is not None
+                and sharding_type in self._use_gather_select_per_sharding
+            ):
+                use_gather_select = self._use_gather_select_per_sharding[sharding_type]
+            else:
+                use_gather_select = self._use_gather_select
             jt_dict.update(
                 construct_jagged_tensors(
                     embeddings=embeddings,
@@ -406,7 +417,7 @@ class EmbeddingCollectionAwaitable(LazyAwaitable[Dict[str, JaggedTensor]]):
                     original_features=original_features,
                     reverse_indices=reverse_indices,
                     seq_vbe_ctx=seq_vbe_ctx,
-                    use_gather_select=self._use_gather_select,
+                    use_gather_select=use_gather_select,
                 )
             )
 
@@ -571,6 +582,9 @@ class ShardedEmbeddingCollection(
             )
         self._need_indices: bool = module.need_indices()
         self._use_gather_select: bool = module.use_gather_select()
+        self._use_gather_select_per_sharding: Optional[Dict[str, bool]] = (
+            module.use_gather_select_per_sharding()
+        )
         self._inverse_indices_permute_per_sharding: Optional[List[torch.Tensor]] = None
         self._skip_missing_weight_key: List[str] = []
 
@@ -1648,6 +1662,7 @@ class ShardedEmbeddingCollection(
             features_to_permute_indices=self._features_to_permute_indices,
             ctx=ctx,
             use_gather_select=self._use_gather_select,
+            use_gather_select_per_sharding=self._use_gather_select_per_sharding,
         )
 
     def compute_and_output_dist(
@@ -1708,6 +1723,7 @@ class ShardedEmbeddingCollection(
             module_fqn=self._module_fqn,
             sharding_types=list(self._sharding_type_to_sharding.keys()),
             use_gather_select=self._use_gather_select,
+            use_gather_select_per_sharding=self._use_gather_select_per_sharding,
             resize_awaitables=resize_awaitables,
         )
 

--- a/torchrec/distributed/tests/test_embedding_sharding.py
+++ b/torchrec/distributed/tests/test_embedding_sharding.py
@@ -35,7 +35,10 @@ except ImportError:
     )
 from hypothesis import given, settings
 from torchrec.distributed.batched_embedding_kernel import ZeroCollisionKeyValueEmbedding
-from torchrec.distributed.embedding import EmbeddingCollectionContext
+from torchrec.distributed.embedding import (
+    EmbeddingCollectionAwaitable,
+    EmbeddingCollectionContext,
+)
 from torchrec.distributed.embedding_lookup import (
     EmbeddingComputeKernel,
     GroupedEmbeddingsLookup,
@@ -865,3 +868,65 @@ class TestCreateEmbeddingKernelEnrichment(unittest.TestCase):
             backend_type=BackendType.DRAM,
         )
         mock_zc_enrichment_cls.assert_not_called()
+
+
+class EmbeddingCollectionAwaitableUseGatherSelectTest(unittest.TestCase):
+    """Tests per-sharding-type resolution of use_gather_select in _wait_impl."""
+
+    def _build_awaitable(
+        self,
+        sharding_types: List[str],
+        use_gather_select: bool,
+        use_gather_select_per_sharding: Optional[Dict[str, bool]],
+    ) -> EmbeddingCollectionAwaitable:
+        num_shardings = len(sharding_types)
+        awaitables = []
+        for _ in range(num_shardings):
+            w = MagicMock()
+            w.wait.return_value = torch.empty(0)
+            awaitables.append(w)
+        return EmbeddingCollectionAwaitable(
+            awaitables_per_sharding=awaitables,
+            features_per_sharding=[MagicMock() for _ in range(num_shardings)],
+            embedding_names_per_sharding=[[] for _ in range(num_shardings)],
+            ctx=EmbeddingCollectionContext(),
+            sharding_types=sharding_types,
+            use_gather_select=use_gather_select,
+            use_gather_select_per_sharding=use_gather_select_per_sharding,
+        )
+
+    @patch("torchrec.distributed.embedding.construct_jagged_tensors")
+    def test_per_sharding_override_and_fallback(
+        self, mock_construct: MagicMock
+    ) -> None:
+        mock_construct.return_value = {}
+        awaitable = self._build_awaitable(
+            sharding_types=["row_wise", "table_wise", "column_wise"],
+            use_gather_select=False,
+            # row_wise overridden to True, table_wise overridden to False,
+            # column_wise absent -> falls back to use_gather_select (False).
+            use_gather_select_per_sharding={"row_wise": True, "table_wise": False},
+        )
+
+        awaitable._wait_impl()
+
+        selected = [
+            call.kwargs["use_gather_select"] for call in mock_construct.call_args_list
+        ]
+        self.assertEqual(selected, [True, False, False])
+
+    @patch("torchrec.distributed.embedding.construct_jagged_tensors")
+    def test_no_per_sharding_uses_default(self, mock_construct: MagicMock) -> None:
+        mock_construct.return_value = {}
+        awaitable = self._build_awaitable(
+            sharding_types=["row_wise"],
+            use_gather_select=True,
+            use_gather_select_per_sharding=None,
+        )
+
+        awaitable._wait_impl()
+
+        selected = [
+            call.kwargs["use_gather_select"] for call in mock_construct.call_args_list
+        ]
+        self.assertEqual(selected, [True])

--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -409,6 +409,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
         device: Optional[torch.device] = None,
         need_indices: bool = False,
         use_gather_select: bool = False,
+        use_gather_select_per_sharding: Optional[Dict[str, bool]] = None,
     ) -> None:
         super().__init__()
         torch._C._log_api_usage_once(f"torchrec.modules.{self.__class__.__name__}")
@@ -417,6 +418,9 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
         self._embedding_dim: int = -1
         self._need_indices: bool = need_indices
         self._use_gather_select: bool = use_gather_select
+        self._use_gather_select_per_sharding: Optional[Dict[str, bool]] = (
+            use_gather_select_per_sharding
+        )
         self._device: torch.device = (
             device if device is not None else torch.device("cpu")
         )
@@ -550,3 +554,12 @@ class EmbeddingCollection(EmbeddingCollectionInterface):
             bool: Whether the EmbeddingCollection uses torch.gather to select embeddings.
         """
         return self._use_gather_select
+
+    def use_gather_select_per_sharding(self) -> Optional[Dict[str, bool]]:
+        """
+        Returns:
+            Optional[Dict[str, bool]]: Per-sharding-type override for whether to
+            use torch.gather to select embeddings. When a sharding type is present
+            in this dict, its value takes precedence over ``use_gather_select()``.
+        """
+        return self._use_gather_select_per_sharding


### PR DESCRIPTION
Summary:

Currently, we only have 1 `user_gather_select` flag in EmbeddingCollection for all sharding types. 
We want to support having a flag to turn on and off `user_gather_select` per sharding type because we found `user_gather_select` could help or hurt performance depending on whether an embedding collection's sharding_type is `data_parallel` or `row_wise`  

(in our case, it hurts performance in `data_parallel` case since the table is small and many ops are performed on the same row, hence the atomic adds from`scatter_gather` created too many conflicts and is slower than with the flag turned off, but `gather_select` helped performance in the `row_wise` case since we don't have many ops performed on the same row (very sparse))

Reviewed By: ruochen99, TroyGarden

Differential Revision: D103089193


