### PR TITLE
Fix malformed VBE lengths in test_tbe_compile_vb (#4296)

### DIFF
--- a/torchrec/distributed/tests/test_pt2.py
+++ b/torchrec/distributed/tests/test_pt2.py
@@ -992,7 +992,15 @@ class TestPt2(unittest.TestCase):
         original_weights = get_weights(m)
 
         indices = torch.Tensor([1, 2, 0, 1, 2]).to(dtype=torch.int64, device=device)
-        lengths = torch.Tensor([2, 3]).to(dtype=torch.int64, device=device)
+        # NOTE: lengths must have total_B entries (sum of batch_size_per_feature_per_rank),
+        # not num_features. Here total_B = 1 + 2 = 3, so lengths must have 3 entries.
+        # Previously this was [2, 3] which produced offsets=[0,2,5] (length 3); the VBE
+        # bounds-check kernel iterates b_t in [0, total_B) and reads offsets[b_t+1],
+        # so at b_t=2 it would read offsets[3] (OOB) and produce undefined indices_end.
+        # Under the old BoundsCheckMode::WARNING, adjust_offset_kernel silently rewrote
+        # offsets[] in place to mask this. Phase 2 of D101843208 removes that papering-
+        # over, turning the OOB into a fatal CUDA_KERNEL_ASSERT.
+        lengths = torch.Tensor([2, 1, 2]).to(dtype=torch.int64, device=device)
         offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
         batch_size_per_feature_per_rank = [[1], [2]]
         inp_f = torch.randn(1, requires_grad=True, device=device)


### PR DESCRIPTION
Summary:

The test had `lengths = [2, 3]` (length 2), but with
`batch_size_per_feature_per_rank = [[1], [2]]` the VBE config has
total_B = 1 + 2 = 3, so `lengths` must have 3 entries.

The resulting offsets tensor (`[0, 2, 5]`, length 3) was too short for
the bounds-check kernel, which iterates `b_t in [0, total_B)` and reads
`offsets[b_t + 1]`; at `b_t = 2` this is an OOB read of `offsets[3]`.

Reviewed By: spcyppt

Differential Revision: D105989330


