### PR TITLE
Fall back to concat-based VBE merge for MTIA devices

### DIFF
--- a/torchrec/distributed/embedding_lookup.py
+++ b/torchrec/distributed/embedding_lookup.py
@@ -778,6 +778,31 @@ class GroupedPooledEmbeddingsLookup(
                         ),
                     )
 
+    """
+    Merge the TBE output when VBE is enabled and multiple TBEs are involved for MTIA.
+    """
+
+    def _merge_variable_batch_embeddings(
+        self, embeddings: List[torch.Tensor], splits: List[List[int]]
+    ) -> torch.Tensor:
+        """Merges VBE embeddings from multiple TBEs via split-and-concat.
+
+        Used for devices that do not support pre-allocated VBE output (e.g.
+        MTIA). Each TBE's output is split by feature/rank boundaries and
+        reassembled in rank-major order (matching the pre-allocated layout)
+        with `torch.cat`.
+        """
+        assert len(embeddings) > 1 and len(splits) > 1
+
+        split_embs = [torch.split(emb, split) for emb, split in zip(embeddings, splits)]
+        combined_embs = [
+            emb
+            for rank in range(self._world_size)
+            for n, embs in zip(self._feature_splits, split_embs)
+            for emb in embs[n * rank : n * rank + n]
+        ]
+        return torch.cat(combined_embs)
+
     def _vbe_splits(
         self, features_by_group: List[KeyedJaggedTensor]
     ) -> List[List[int]]:
@@ -962,9 +987,15 @@ class GroupedPooledEmbeddingsLookup(
         involved.
 
         An 1D empty tensor will be preallocated for TBEs to handle the merging
-        logic.
+        logic. For MTIA devices, pre-allocated VBE output is not supported, so
+        fall back to the concat-based merge approach.
         """
         vbe_splits = self._vbe_splits(features_by_group)
+
+        if device.type == "mtia":
+            return self._merge_variable_batch_embeddings(
+                self._forward(features_by_group), vbe_splits
+            )
 
         vbe_output, vbe_offsets = self._create_vbe_output_and_offsets(
             vbe_splits, device

--- a/torchrec/distributed/test_utils/test_model_parallel.py
+++ b/torchrec/distributed/test_utils/test_model_parallel.py
@@ -8,12 +8,14 @@
 # pyre-strict
 
 import unittest
-from typing import Any, cast, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from hypothesis import assume, given, settings, strategies as st, Verbosity
+from torchrec.distributed.embedding_lookup import GroupedPooledEmbeddingsLookup
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.fbgemm_qcomm_codec import CommType, QCommsConfig
@@ -30,6 +32,27 @@ from torchrec.distributed.types import ModuleSharder, ShardingStrategy, Sharding
 from torchrec.modules.embedding_configs import EmbeddingBagConfig, PoolingType
 from torchrec.test_utils import skip_if_asan_class
 from torchrec.types import DataType
+
+
+# pyre-ignore[2,3]
+def sharding_single_rank_test_concat_vbe_merge(*args, **kwargs):
+    """Wrapper around sharding_single_rank_test that forces the concat-based
+    VBE merge path (instead of pre-allocated) to verify its correctness.
+    """
+
+    # pyre-ignore[2,3]
+    def _concat_forward_with_vbe_merging(self, features_by_group, device):
+        vbe_splits = self._vbe_splits(features_by_group)
+        return self._merge_variable_batch_embeddings(
+            self._forward(features_by_group), vbe_splits
+        )
+
+    with patch.object(
+        GroupedPooledEmbeddingsLookup,
+        "_forward_with_vbe_merging",
+        _concat_forward_with_vbe_merging,
+    ):
+        return sharding_single_rank_test(*args, **kwargs)
 
 
 class ModelParallelTestShared(MultiProcessTestBase):
@@ -165,11 +188,14 @@ class ModelParallelTestShared(MultiProcessTestBase):
         atol: Optional[float] = None,
         rtol: Optional[float] = None,
         rs_awaitable_hook_module: Optional[str] = None,
+        # pyre-ignore[24]
+        test_callable: Optional[Callable] = None,
     ) -> None:
         self._build_tables_and_groups(data_type=data_type)
+        callable_fn = test_callable or sharding_single_rank_test
         # directly run the test with single process
         if world_size == 1:
-            sharding_single_rank_test(
+            callable_fn(
                 rank=0,
                 world_size=world_size,
                 local_size=local_size,
@@ -204,7 +230,7 @@ class ModelParallelTestShared(MultiProcessTestBase):
             )
         else:
             self._run_multi_process_test(
-                callable=sharding_single_rank_test,
+                callable=callable_fn,
                 world_size=world_size,
                 local_size=local_size,
                 pod_size=pod_size,
@@ -862,6 +888,45 @@ class _ModelParallelBase(ModelParallelTestShared):
             variable_batch_per_feature=True,
             has_weighted_tables=False,
             data_type=data_type,
+        )
+
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2,
+        "Not enough GPUs, this test requires at least two GPUs",
+    )
+    @given(
+        sharding_type=st.just(ShardingType.COLUMN_WISE.value),
+        data_type=st.sampled_from([DataType.FP32, DataType.FP16]),
+    )
+    @settings(verbosity=Verbosity.verbose, max_examples=4, deadline=None)
+    def test_sharding_multiple_kernels_concat_merge(
+        self,
+        sharding_type: str,
+        data_type: DataType,
+    ) -> None:
+        fused_params = {"prefetch_pipeline": True}
+        constraints = {
+            table_name: ParameterConstraints(
+                min_partition=4,
+                compute_kernels=(
+                    [EmbeddingComputeKernel.FUSED.value]
+                    if i % 2 == 0
+                    else [EmbeddingComputeKernel.FUSED_UVM_CACHING.value]
+                ),
+                sharding_types=[sharding_type],
+            )
+            for i, table_name in enumerate(self.table_names)
+        }
+
+        self._test_sharding(
+            # pyrefly: ignore[bad-argument-type]
+            sharders=[EmbeddingBagCollectionSharder(fused_params=fused_params)],
+            backend=self.backend,
+            constraints=constraints,
+            variable_batch_per_feature=True,
+            has_weighted_tables=False,
+            data_type=data_type,
+            test_callable=sharding_single_rank_test_concat_vbe_merge,
         )
 
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
MTIA devices use the CPU code path in TBE (`self.use_cpu = True`), which does not support pre-allocated `vbe_output`/`vbe_output_offsets`. This causes an `AssertionError` during training when VBE is enabled with multiple TBEs on MTIA.

This diff adds `_merge_variable_batch_embeddings` (the `torch.cat`-based merge approach) and routes MTIA devices to it in `_forward_with_vbe_merging`, bypassing the pre-allocated tensor path introduced in D67681796. Non-MTIA devices continue to use the pre-allocated path.

Changes:
- `GroupedPooledEmbeddingsLookup`: Added `_merge_variable_batch_embeddings` which splits each TBE's output by feature/rank boundaries and reassembles them in rank-major order via `torch.cat`. Added MTIA device check in `_forward_with_vbe_merging` to route to the concat path.
- `test_model_parallel.py`: Added `test_sharding_multiple_kernels_concat_merge` to verify correctness of the concat-based merge path on CUDA (exercises the same code path MTIA would hit). Added `test_callable` parameter to `_test_sharding` to support custom test callables. Added `sharding_single_rank_test_concat_vbe_merge` wrapper that patches `_forward_with_vbe_merging` to force the concat path.

Reviewed By: spmex

Differential Revision: D105281337


