### PR TITLE
Log hbm_reserved_bytes for FixedAbsoluteStorageReservation

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -233,6 +233,7 @@ def log_storage_reservation(
     available_hbm_per_rank: int = 0,
     planner_type: str = "",
     technique: OptimizationTechnique = OptimizationTechnique.NONE,
+    hbm_reserved_bytes: Optional[int] = None,
 ) -> None:
     """No-op OSS stub."""
     pass

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -823,6 +823,9 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
             available_hbm_per_rank=storage_constraint.devices[0].storage.hbm,
             planner_type=self.__class__.__name__,
             technique=_technique,
+            hbm_reserved_bytes=getattr(
+                self._storage_reservation, "_hbm_reserved_bytes", None
+            ),
         )
 
         log_planner_config(


### PR DESCRIPTION
Summary:
Part of the migration from `HeuristicalStorageReservation` to `FixedAbsoluteStorageReservation` (rollout plan: https://docs.google.com/document/d/1BZBv9bFzRlpTKdXwe53_xEVD-OYw1nMOlKp50zGhOX4/edit).

The existing `log_storage_reservation()` was designed for percentage-based policies — it logs a `percentage` field that is meaningful for `HeuristicalStorageReservation` (e.g., `0.25`) and `FixedPercentageStorageReservation` (e.g., `0.15`). For `FixedAbsoluteStorageReservation`, it logs `percentage=0.0` which is a dummy value from the parent class constructor, not the actual reservation amount.

This diff adds an `hbm_reserved_bytes` parameter to `log_storage_reservation()` so that `FixedAbsoluteStorageReservation` logs its defining parameter as `hbm_reserved_gb` (e.g., `"2.0"`) in the `training_optimization_events` Scuba table. Both `EmbeddingShardingPlanner` and `LinearProgrammingPlanner` pass this value via `getattr(self._storage_reservation, "_hbm_reserved_bytes", None)` — it is `None` for percentage-based policies and the actual byte count for absolute policies.

Differential Revision: D106704956


