### PR TITLE
worker waits for K-items or sync marker in drain loop

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -83,6 +83,8 @@ logger: logging.Logger = logging.getLogger(__name__)
 metric_update_thread_name: str = "metric_update"
 metric_compute_thread_name: str = "metric_compute"
 
+_DRAIN_WAIT_WARN_INTERVAL_SEC: float = 60.0
+
 
 def _safe_merge_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
     """Concatenate tensors along the batch dim. Falls back to torch.stack
@@ -677,16 +679,22 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     def _drain_update_batch(
         self, first: MetricUpdateJob
     ) -> tuple[list[MetricUpdateJob], Optional[SynchronizationMarker], int]:
-        """Opportunistically drain up to update_batch_size jobs; stop at any
-        SynchronizationMarker."""
+        """Block until pending batch reaches update_batch_size or a
+        SynchronizationMarker arrives."""
         pending_jobs: list[MetricUpdateJob] = [first]
         pending_marker: Optional[SynchronizationMarker] = None
         items_pulled = 1
         while len(pending_jobs) < self._update_batch_size:
             try:
-                next_item = self.update_queue.get_nowait()
+                next_item = self.update_queue.get(timeout=_DRAIN_WAIT_WARN_INTERVAL_SEC)
             except queue.Empty:
-                break
+                logger.warning(
+                    f"metric_update worker blocked > {_DRAIN_WAIT_WARN_INTERVAL_SEC:.0f}s "
+                    f"waiting for batch (pending={len(pending_jobs)}/"
+                    f"{self._update_batch_size}, queue_size={self.update_queue.qsize()}). "
+                    f"Producer may be stalled or compute_interval_steps too large."
+                )
+                continue
             items_pulled += 1
             if isinstance(next_item, MetricUpdateJob):
                 pending_jobs.append(next_item)

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -1410,6 +1410,101 @@ class WorkerSideBatchingTest(unittest.TestCase):
         )
         self.assertEqual(cpu_module._total_updates_processed, 3)
 
+    def test_worker_waits_until_batch_size_or_sync_marker(self) -> None:
+        cpu_module = self._make_module(update_batch_size=4)
+
+        captured_jobs: list[MetricUpdateJob] = []
+        original_process = cpu_module._process_metric_update_job
+
+        def capture(job: MetricUpdateJob) -> None:
+            captured_jobs.append(job)
+            original_process(job)
+
+        with patch.object(
+            cpu_module,
+            "_process_metric_update_job",
+            side_effect=capture,
+        ):
+            for _ in range(2):
+                cpu_module._update_rec_metrics(
+                    {
+                        "task1-prediction": torch.tensor([0.5]),
+                        "task1-label": torch.tensor([0.5]),
+                        "task1-weight": torch.tensor([1.0]),
+                    }
+                )
+
+            time.sleep(0.5)
+            self.assertEqual(len(captured_jobs), 0)
+
+            for _ in range(2):
+                cpu_module._update_rec_metrics(
+                    {
+                        "task1-prediction": torch.tensor([0.5]),
+                        "task1-label": torch.tensor([0.5]),
+                        "task1-weight": torch.tensor([1.0]),
+                    }
+                )
+
+            wait_until_true(lambda: cpu_module._total_updates_processed == 4)
+
+            self.assertEqual(len(captured_jobs), 1)
+            self.assertEqual(captured_jobs[0].merged_count, 4)
+
+    def test_worker_processes_partial_batch_when_marker_arrives(self) -> None:
+        cpu_module = self._make_module(update_batch_size=10)
+
+        captured_jobs: list[MetricUpdateJob] = []
+        original_process = cpu_module._process_metric_update_job
+
+        def capture(job: MetricUpdateJob) -> None:
+            captured_jobs.append(job)
+            original_process(job)
+
+        with patch.object(
+            cpu_module,
+            "_process_metric_update_job",
+            side_effect=capture,
+        ):
+            for _ in range(3):
+                cpu_module._update_rec_metrics(
+                    {
+                        "task1-prediction": torch.tensor([0.5]),
+                        "task1-label": torch.tensor([0.5]),
+                        "task1-weight": torch.tensor([1.0]),
+                    }
+                )
+            time.sleep(0.5)
+            self.assertEqual(len(captured_jobs), 0)
+
+            cpu_module.async_compute()
+
+            wait_until_true(
+                lambda: cpu_module._total_updates_processed == 3
+                and cpu_module._total_computes_enqueued == 1
+            )
+
+            self.assertEqual(len(captured_jobs), 1)
+            self.assertEqual(captured_jobs[0].merged_count, 3)
+
+    def test_shutdown_unblocks_worker_waiting_for_batch(self) -> None:
+        cpu_module = self._make_module(update_batch_size=10)
+
+        cpu_module._update_rec_metrics(
+            {
+                "task1-prediction": torch.tensor([0.5]),
+                "task1-label": torch.tensor([0.5]),
+                "task1-weight": torch.tensor([1.0]),
+            }
+        )
+
+        time.sleep(0.2)
+        self.assertTrue(cpu_module.update_thread.is_alive())
+
+        cpu_module.shutdown()
+
+        self.assertFalse(cpu_module.update_thread.is_alive())
+
 
 class MergeUpdateJobsTest(unittest.TestCase):
     def test_single_job_returned_unchanged(self) -> None:


### PR DESCRIPTION
Summary:
In the update-thread drain loop, replace opportunistic `queue.get_nowait()` with blocking `queue.get()`. The worker now holds a partial batch open until EITHER (a) it reaches `update_batch_size` jobs, OR (b) a `SynchronizationMarker` arrives.

Why: with opportunistic drain, batching silently degenerates to single-item dispatches whenever the worker drains faster than the trainer enqueues. That defeats the PyBind-reduction goal of worker-side micro-batching — the overhead remains but the win never materializes.

The wait design guarantees batching engages. Worst-case wait is bounded by `compute_interval_steps` (default 100), which periodically injects a marker that forces a partial flush. Shutdown is bounded the same way: `shutdown()` enqueues a marker to unblock the worker.

Tradeoffs:
- Individual updates see up to K-1 trainer intervals of added latency before processing. Updates are fully async; trainer is never blocked.
- Worker holds up to K `model_out` references while waiting (~K× host memory vs prior single-item). Bounded by `update_queue_size=100`.

Reviewed By: yashasingh

Differential Revision: D107123970


