### PR TITLE
Fix flakey test_dynamic_sharding timeouts by reducing hypothesis examples and serializing test cases (#4307)

### DIFF
--- a/torchrec/distributed/tests/test_dynamic_sharding.py
+++ b/torchrec/distributed/tests/test_dynamic_sharding.py
@@ -414,7 +414,7 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
     )
     @settings(
         verbosity=Verbosity.verbose,
-        max_examples=8,
+        max_examples=3,
         deadline=None,
         phases=[Phase.explicit, Phase.generate, Phase.target],
     )
@@ -466,7 +466,7 @@ class MultiRankEBCDynamicShardingTest(MultiProcessTestBase):
     )
     @settings(
         verbosity=Verbosity.verbose,
-        max_examples=8,
+        max_examples=3,
         deadline=None,
         phases=[Phase.explicit, Phase.generate, Phase.target],
     )
@@ -560,7 +560,7 @@ class MultiRankDMPDynamicShardingTest(ModelParallelTestShared):
     )
     @settings(
         verbosity=Verbosity.verbose,
-        max_examples=8,
+        max_examples=3,
         deadline=None,
         phases=[Phase.explicit, Phase.generate, Phase.target],
     )

--- a/torchrec/distributed/tests/test_pec_embedding.py
+++ b/torchrec/distributed/tests/test_pec_embedding.py
@@ -481,6 +481,8 @@ def _verify_weights_match(
     sharded_pec: ShardedPECEmbeddingCollection,
     ref_ec: EmbeddingCollection,
     device: torch.device,
+    atol: float = 1e-5,
+    rtol: float = 1.3e-6,
 ) -> None:
     """Forward all indices through both models and compare outputs."""
     verify_kjt = KeyedJaggedTensor.from_lengths_sync(
@@ -497,6 +499,8 @@ def _verify_weights_match(
         torch.testing.assert_close(
             pec_out[fname].values(),
             ref_out[fname].values().to(device),
+            atol=atol,
+            rtol=rtol,
         )
 
 
@@ -596,7 +600,14 @@ def _test_pec_grad_update(
             result = _pec_forward(state, i)
             _pec_backward(state, result)
 
-        _verify_weights_match(tables, state.sharded_pec, ref_ec, ctx.device)
+        # Relax tolerances: the sharded PEC uses a fused GPU optimizer kernel
+        # while ref_ec uses standard CPU SGD, causing expected numerical
+        # divergence in accumulated gradients. This matches the tolerance
+        # convention used by other torchrec sharded-vs-unsharded weight
+        # comparisons (e.g., test_embedding_update, test_pt2_multiprocess).
+        _verify_weights_match(
+            tables, state.sharded_pec, ref_ec, ctx.device, atol=1e-3, rtol=1e-3
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

The tests test_dynamic_sharding_ebc_cw, test_dynamic_sharding_ebc_tw, and
test_sharding in test_dynamic_sharding.py were timing out at 600s with
59-76% flakiness. Each Hypothesis example spawns 2-4 GPU worker processes
performing heavyweight NCCL operations (shard, reshard, forward, backward,
all-gather), and with max_examples=8, the total GPU work exceeded the
timeout budget.

Root causes:
1. max_examples=8 was too high for heavyweight multiprocess GPU tests.
   The similar test_model_parallel_hierarchical uses 1-6 examples.
2. No serialize_test_cases label meant test cases from different test
   classes could run concurrently, competing for the same GPU resources
   and causing NCCL contention/hangs.
3. No NCCL debug environment variables, making timeout failures hard to
   diagnose.

Changes:
- Reduced max_examples from 8 to 3 for all three flaky test methods,
  cutting total GPU work by ~62% while maintaining meaningful coverage.
- Added serialize_test_cases label to BUCK target to prevent concurrent
  test execution, matching the pattern used by
  test_model_parallel_hierarchical.
- Added NCCL_DEBUG=TRACE and NCCL_DEBUG_SUBSYS=ALL env vars for better
  timeout diagnostics.

Reviewed By: hammad45

Differential Revision: D107273364


