### PR TITLE
Fix test_compile_multiprocess and surface hidden worker errors (#4308)

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -565,35 +565,42 @@ class SplitsAllToAllAwaitable(Awaitable[List[List[int]]]):
 
         ret = _safe_tolist_2d(self._output_tensor.view(self.num_workers, -1).T)
 
-        # Validate collective tag if present
+        # Validate collective tag if present. The validation block itself is
+        # skipped under torch.compile: .tolist() returns unbacked symints, so
+        # `any(tag != expected for tag in tag_row)` produces data-dependent
+        # expressions that cannot be guarded with fullgraph=True. The tag is
+        # still stripped from `ret` so downstream consumers see the original
+        # tensors; cross-rank consistency is then enforced on every eager
+        # invocation.
         if self._tag_appended:
             tag_row = ret[-1]
             ret = ret[: self._num_original_tensors]
-            # _tag_appended=True implies _collective_tag was not None.
-            assert self._collective_tag is not None
-            expected: int = self._collective_tag
-            if any(tag != expected for tag in tag_row):
-                label = (
-                    str(self._collective_tag_parts)
-                    if self._collective_tag_parts
-                    else "unknown"
-                )
-                self._log_mismatch_event(label, expected, tag_row)
-                raise RuntimeError(
-                    f"All2All collective mismatch detected (collective={label!r}): "
-                    f"expected tag {expected} but received tags {tag_row} from "
-                    f"peers. This indicates ranks are calling different "
-                    f"collectives on the same process group.\n"
-                    f"To debug: identify the rank whose tag differs from this "
-                    f"one, then compare its collective inputs (e.g. "
-                    f"input.keys(), splits, sharding plan) against this rank's. "
-                    f"Common causes: (1) divergent feature lists across ranks, "
-                    f"(2) a rank skipping the collective via early return or "
-                    f"data exhaustion, (3) sharding plan inconsistency. Do NOT "
-                    f"disable the check via TORCHREC_VALIDATE_COLLECTIVES — "
-                    f"the underlying mismatch will still cause silent data "
-                    f"corruption or an NCCL hang downstream."
-                )
+            if not is_torchdynamo_compiling():
+                # _tag_appended=True implies _collective_tag was not None.
+                assert self._collective_tag is not None
+                expected: int = self._collective_tag
+                if any(tag != expected for tag in tag_row):
+                    label = (
+                        str(self._collective_tag_parts)
+                        if self._collective_tag_parts
+                        else "unknown"
+                    )
+                    self._log_mismatch_event(label, expected, tag_row)
+                    raise RuntimeError(
+                        f"All2All collective mismatch detected (collective={label!r}): "
+                        f"expected tag {expected} but received tags {tag_row} from "
+                        f"peers. This indicates ranks are calling different "
+                        f"collectives on the same process group.\n"
+                        f"To debug: identify the rank whose tag differs from this "
+                        f"one, then compare its collective inputs (e.g. "
+                        f"input.keys(), splits, sharding plan) against this rank's. "
+                        f"Common causes: (1) divergent feature lists across ranks, "
+                        f"(2) a rank skipping the collective via early return or "
+                        f"data exhaustion, (3) sharding plan inconsistency. Do NOT "
+                        f"disable the check via TORCHREC_VALIDATE_COLLECTIVES — "
+                        f"the underlying mismatch will still cause silent data "
+                        f"corruption or an NCCL hang downstream."
+                    )
 
         # Check for int32 overflow in AllToAll input. If the input is already
         # corrupted, the corruption happened before the collective.

--- a/torchrec/distributed/test_utils/multi_process.py
+++ b/torchrec/distributed/test_utils/multi_process.py
@@ -28,6 +28,24 @@ from torchrec.test_utils import (
 )
 
 
+def _picklable_exception_wrapper(
+    callable: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    # multiprocessing.Pool pickles worker exceptions (with their traceback)
+    # to send them back to the parent. If the exception value or any frame
+    # locals in the traceback reference unpicklable objects (e.g. modules
+    # held alive by torch._dynamo / torch.compile errors), pickling fails
+    # with MaybeEncodingError and the original error is lost. Convert any
+    # exception to a plain RuntimeError carrying a stringified traceback so
+    # the real failure always reaches the parent process.
+    try:
+        return callable(*args, **kwargs)
+    except Exception as e:
+        raise RuntimeError(
+            f"Worker raised {type(e).__name__}: {e}\n{traceback.format_exc()}"
+        ) from None
+
+
 class MultiProcessContext:
     def __init__(
         self,
@@ -162,7 +180,7 @@ class MultiProcessTestBase(unittest.TestCase):
             for i in range(world_size):
                 kwargs["rank"] = i
                 async_result = pool.apply_async(
-                    functools.partial(callable, **kwargs),
+                    functools.partial(_picklable_exception_wrapper, callable, **kwargs),
                     error_callback=lambda e: exceptions.append(e),
                 )
                 async_results.append(async_result)


### PR DESCRIPTION
Summary:

Two fixes that together unbreak `test_compile_multiprocess` (currently 81.8% flake rate, 33 consecutive trunk failures):

1. `multi_process.py`: `_run_multi_process_test` was hiding worker exceptions whose value or traceback held unpicklable objects (e.g. `torch._dynamo` / `torch.compile` errors that retain module references). `multiprocessing.Pool` silently failed to pickle the exception back to the parent with `MaybeEncodingError`, so the actual error was lost and the test reported only "Detected at least one unsuccessful run". Added `_picklable_exception_wrapper` that catches any worker exception and re-raises it as a plain `RuntimeError` carrying the stringified traceback, so the real failure always reaches the parent process.

2. `dist_data.py`: With the real error surfaced, `SplitsAllToAllAwaitable._wait_impl` was failing under `torch.compile(fullgraph=True)`: `any(tag != expected for tag in tag_row)` compared values from `.tolist()` (unbacked symints), producing a data-dependent expression that `torch._dynamo` could not guard (`UserError: Could not guard on data-dependent expression Ne(u19, ...)`). Skip the validation block when `is_torchdynamo_compiling()` is True. The tag is still stripped from `ret` so downstream consumers see the original tensors; cross-rank consistency is enforced on every eager invocation, which is when divergence between ranks actually occurs.

Differential Revision: D107285225


