### PR TITLE
Swap stashed tensor storage to CPU buffer for checkpoint compatibility

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -208,6 +208,10 @@ class MemoryStashingManager:
         """
         # (hbm_tensor ref, cpu_buffer, original_storage_size)
         stash_data: List[Tuple[torch.Tensor, torch.Tensor, int]] = []
+        # Original CUDA storages saved before .data= so restore can
+        # re-point tensors (and their views) back to the same storage.
+        _orig_storages: List[torch.UntypedStorage] = []
+        _orig_storage_offsets: List[Union[int, torch.SymInt]] = []
 
         # Restore events populated by ``restore`` and consumed by ``await_restore``
         restore_events: List[torch.cuda.Event] = []
@@ -259,6 +263,13 @@ class MemoryStashingManager:
                         orig_storage_size = tensor.untyped_storage().size()
                         stash_data.append((tensor, cpu_buffer, orig_storage_size))
 
+                    # Save original CUDA storage refs and offsets before
+                    # freeing, so restore can re-point tensors (and views
+                    # sharing the same storage) back to the original storage.
+                    for tensor, _, _ in stash_data:
+                        _orig_storages.append(tensor.untyped_storage())
+                        _orig_storage_offsets.append(tensor.storage_offset())
+
                     # Two-pass: free HBM storage only after all copies are
                     # enqueued.  Tensors may share the same underlying storage
                     # (e.g. views into an all-to-all output buffer), so freeing
@@ -271,6 +282,9 @@ class MemoryStashingManager:
                             seen_storage_ptrs.add(storage_ptr)
                             tensor.untyped_storage().resize_(0)
 
+                for tensor, cpu_buffer, _ in stash_data:
+                    tensor.data = cpu_buffer
+
         def restore(
             _grad: Optional[torch.Tensor] = None,
             sync_event: Optional[torch.cuda.Event] = None,
@@ -279,42 +293,45 @@ class MemoryStashingManager:
             restore_events.clear()
             h2d_stream = cls.h2d_stream()
 
-            size_text = _tensor_size_text([cpu_buf for _, cpu_buf, _ in stash_data])
+            size_text = _tensor_size_text([hbm_ref for hbm_ref, _, _ in stash_data])
             capped_logger.info(
                 f"restore {label}: {len(stash_data)} tensors, total {size_text}"
             )
             with record_function(f"restore {label} on device ({size_text})"):
-                for hbm_ref, _cpu_buf, orig_storage_size in stash_data:
-                    # Re-allocate HBM storage to the original size (which
-                    # may be larger than this tensor if storage is shared).
-                    # For shared storage, the first resize allocates the
-                    # full buffer; subsequent resizes for sibling views are
-                    # no-ops since the storage is already large enough.
-                    cur_size = hbm_ref.untyped_storage().size()
+                for (
+                    (hbm_ref, _cpu_buf, orig_storage_size),
+                    orig_stor,
+                    orig_offset,
+                ) in zip(stash_data, _orig_storages, _orig_storage_offsets):
+                    # Re-allocate the original CUDA storage to its full size
+                    # (which may be larger than this tensor if storage is
+                    # shared).  For shared storage, the first resize allocates
+                    # the full buffer; subsequent resizes for sibling views
+                    # are no-ops since the storage is already large enough.
+                    cur_size = orig_stor.size()
                     if cur_size < orig_storage_size:
-                        hbm_ref.untyped_storage().resize_(orig_storage_size)
+                        orig_stor.resize_(orig_storage_size)
+                    ref = torch.tensor(
+                        [], dtype=hbm_ref.dtype, device=torch.cuda.current_device()
+                    )
+                    ref.set_(orig_stor, orig_offset, hbm_ref.shape, hbm_ref.stride())
+                    hbm_ref.data = ref
 
             # Ensure h2d_stream waits for the caller's stream before any
-            # allocations.  When called from a background thread the default
+            # copies.  When called from a background thread the default
             # stream may differ from the main thread's, so all GPU work
-            # (including resize_ allocations) must happen on h2d_stream.
+            # must happen on h2d_stream.
             if sync_event is not None:
                 h2d_stream.wait_event(sync_event)
             else:
                 h2d_stream.wait_stream(torch.cuda.current_stream())
 
             with record_function(f"restore {label} from host ({size_text})"):
-                for hbm_ref, cpu_buf, _orig_storage_size in stash_data:
-
-                    # Copy data back using a temporary tensor to bypass
-                    # autograd.  copy_() on the original tensor would
+                for hbm_ref, cpu_buf, _ in stash_data:
+                    # Use a temporary tensor viewing the same storage to
+                    # bypass autograd.  copy_() on hbm_ref directly would
                     # increment its version counter, causing "modified by
-                    # inplace operation" errors during backward.  A fresh
-                    # tensor viewing the same storage has its own version
-                    # counter, avoiding the issue.
-                    #
-                    # Use hbm_ref.storage_offset() to place data at the
-                    # correct position within potentially shared storage.
+                    # inplace operation" errors during backward.
                     tmp = torch.tensor([], dtype=hbm_ref.dtype, device=hbm_ref.device)
                     tmp.set_(
                         hbm_ref.untyped_storage(),
@@ -326,11 +343,10 @@ class MemoryStashingManager:
                         tmp.copy_(cpu_buf, non_blocking=True)
                     # Tell the caching allocator this storage is in use on
                     # h2d_stream so the bytes cannot be reused by main-stream
-                    # allocations (e.g. a subsequent resize_(0) + realloc)
-                    # before the H2D copy completes.
+                    # allocations before the H2D copy completes.
                     hbm_ref.record_stream(h2d_stream)
 
-                # only need to record the last event
+                # Only need to record the last event — the stream is ordered.
                 restore_event = torch.cuda.Event()
                 restore_event.record(h2d_stream)
                 restore_events.append(restore_event)

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -44,15 +44,15 @@ class TestStashTensors(unittest.TestCase):
             [tensor]
         )
 
-        # Verify HBM is freed
-        self.assertEqual(tensor.untyped_storage().size(), 0)
+        # Verify tensor is on CPU (HBM freed, data readable for checkpoint)
+        self.assertFalse(tensor.is_cuda)
 
         # Restore
         restore(None)
         await_restore(None)
 
-        # Verify values are correct
-        self.assertGreater(tensor.untyped_storage().size(), 0)
+        # Verify tensor is back on CUDA with correct values
+        self.assertTrue(tensor.is_cuda)
         torch.testing.assert_close(tensor, original, rtol=1e-05, atol=1e-08)
 
     def test_multiple_tensors(self) -> None:
@@ -65,9 +65,9 @@ class TestStashTensors(unittest.TestCase):
             [t1, t2]
         )
 
-        # All freed
-        self.assertEqual(t1.untyped_storage().size(), 0)
-        self.assertEqual(t2.untyped_storage().size(), 0)
+        # All on CPU (HBM freed)
+        self.assertFalse(t1.is_cuda)
+        self.assertFalse(t2.is_cuda)
 
         # Restore
         restore(None)
@@ -187,15 +187,15 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Verify HBM is freed
-        self.assertEqual(original_weights.untyped_storage().size(), 0)
+        # Verify tensor is on CPU (HBM freed, data readable for checkpoint)
+        self.assertFalse(original_weights.is_cuda)
 
         # Restore weights
         MemoryStashingManager.restore_embedding_weights()
         await_restore(None)
 
-        # Verify HBM is restored and values are correct
-        self.assertGreater(original_weights.untyped_storage().size(), 0)
+        # Verify tensor is back on CUDA with correct values
+        self.assertTrue(original_weights.is_cuda)
         torch.testing.assert_close(
             original_weights, original_values, rtol=1e-05, atol=1e-08
         )
@@ -216,10 +216,10 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Verify all are stashed
-        self.assertEqual(weights_1.untyped_storage().size(), 0)
-        self.assertEqual(weights_2.untyped_storage().size(), 0)
-        self.assertEqual(weights_3.untyped_storage().size(), 0)
+        # Verify all are on CPU (HBM freed)
+        self.assertFalse(weights_1.is_cuda)
+        self.assertFalse(weights_2.is_cuda)
+        self.assertFalse(weights_3.is_cuda)
 
         # Restore all
         MemoryStashingManager.restore_embedding_weights()
@@ -247,8 +247,8 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Verify stash worked
-        self.assertEqual(original_weights.untyped_storage().size(), 0)
+        # Verify stash worked (tensor on CPU)
+        self.assertFalse(original_weights.is_cuda)
 
         # Restore
         MemoryStashingManager.restore_embedding_weights()
@@ -317,8 +317,8 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Only CUDA weights should be stashed
-        self.assertEqual(cuda_weights.untyped_storage().size(), 0)
+        # Only CUDA weights should be stashed (moved to CPU)
+        self.assertFalse(cuda_weights.is_cuda)
         self.assertGreater(cpu_weights.untyped_storage().size(), 0)
 
         # Restore
@@ -355,8 +355,8 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Valid weights should be stashed
-        self.assertEqual(valid_weights.untyped_storage().size(), 0)
+        # Valid weights should be stashed (moved to CPU)
+        self.assertFalse(valid_weights.is_cuda)
 
         # Restore
         MemoryStashingManager.restore_embedding_weights()
@@ -412,10 +412,10 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Only the stash_weights=True group should be stashed
-        self.assertEqual(stash_weights.untyped_storage().size(), 0)
+        # Only the stash_weights=True group should be stashed (moved to CPU)
+        self.assertFalse(stash_weights.is_cuda)
         # The stash_weights=False group should NOT be stashed
-        self.assertGreater(no_stash_weights.untyped_storage().size(), 0)
+        self.assertTrue(no_stash_weights.is_cuda)
         self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
 
         # Restore
@@ -461,9 +461,9 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
         await_restore, _restore, _execute_stash = result
 
-        # Both should be stashed
-        self.assertEqual(weights_1.untyped_storage().size(), 0)
-        self.assertEqual(weights_2.untyped_storage().size(), 0)
+        # Both should be stashed (moved to CPU)
+        self.assertFalse(weights_1.is_cuda)
+        self.assertFalse(weights_2.is_cuda)
 
         # Restore
         MemoryStashingManager.restore_embedding_weights()
@@ -486,8 +486,8 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertIsNotNone(result)
 
         # Both should be stashed (no config = stash everything)
-        self.assertEqual(weights_1.untyped_storage().size(), 0)
-        self.assertEqual(weights_2.untyped_storage().size(), 0)
+        self.assertFalse(weights_1.is_cuda)
+        self.assertFalse(weights_2.is_cuda)
 
     def test_is_enabled(self) -> None:
         """Test is_enabled reflects stream initialization state."""
@@ -534,18 +534,16 @@ class TestStashOptimizerState(unittest.TestCase):
         # Stash optimizer state
         await_restore, _restore = MemoryStashingManager.stash_optimizer_state(optimizer)
 
-        # Verify state tensors are freed (storage size should be 0)
+        # Verify large state tensors are stashed to CPU
         for _param, state in optimizer.state.items():
             if isinstance(state, dict):
                 for key, value in state.items():
-                    if isinstance(value, torch.Tensor) and value.is_cuda:
-                        # Only large tensors (>= 1MB) should be stashed
+                    if isinstance(value, torch.Tensor):
                         tensor_size = value.numel() * value.element_size()
                         if tensor_size >= 1024 * 1024:
-                            self.assertEqual(
-                                value.untyped_storage().size(),
-                                0,
-                                f"Tensor {key} should be stashed",
+                            self.assertFalse(
+                                value.is_cuda,
+                                f"Tensor {key} should be stashed to CPU",
                             )
 
         # Restore
@@ -694,23 +692,21 @@ class TestStashOptimizerState(unittest.TestCase):
         # Stash
         await_restore, _restore = MemoryStashingManager.stash_optimizer_state(optimizer)
 
-        # Verify nested tensors are stashed
+        # Verify nested tensors are stashed to CPU
         for param, state in optimizer.state.items():
             if isinstance(state, dict) and "shampoo" in state:
                 shampoo_state = state["shampoo"]
                 for t in shampoo_state.factor_matrices:
                     if t.numel() * t.element_size() >= 1024 * 1024:
-                        self.assertEqual(
-                            t.untyped_storage().size(),
-                            0,
-                            "Factor matrix should be stashed",
+                        self.assertFalse(
+                            t.is_cuda,
+                            "Factor matrix should be stashed to CPU",
                         )
                 for t in shampoo_state.inv_factor_matrices:
                     if t.numel() * t.element_size() >= 1024 * 1024:
-                        self.assertEqual(
-                            t.untyped_storage().size(),
-                            0,
-                            "Inv factor matrix should be stashed",
+                        self.assertFalse(
+                            t.is_cuda,
+                            "Inv factor matrix should be stashed to CPU",
                         )
 
         # Restore
@@ -842,10 +838,10 @@ class TestEmsConfigWiring(unittest.TestCase):
         result = MemoryStashingManager.stash_embedding_weights(lookup)
         self.assertIsNotNone(result)
 
-        # Only the stash_weights=True TBE group should be stashed
-        self.assertEqual(stash_weights.untyped_storage().size(), 0)
+        # Only the stash_weights=True TBE group should be stashed (moved to CPU)
+        self.assertFalse(stash_weights.is_cuda)
         # The stash_weights=False TBE group should NOT be stashed
-        self.assertGreater(no_stash_weights.untyped_storage().size(), 0)
+        self.assertTrue(no_stash_weights.is_cuda)
         self.assertTrue(torch.allclose(no_stash_weights, no_stash_original))
 
         # Restore and verify


### PR DESCRIPTION
Summary:
## 1. Context
Memory stashing frees HBM via `resize_(0)` during the forward pass, but this leaves tensors with 0-size CUDA storage. When DCP `stage_state_dict` runs between stash and restore (e.g., during checkpoint), it cannot read the stashed tensors — they have no data to serialize. This causes checkpoint failures or silently omits stashed embedding weights and optimizer state.

## 2. Approach
1. **CPU buffer swap during stash**: After the async D2H copy and `resize_(0)`, set `tensor.data = cpu_buffer` so the tensor appears as a readable CPU tensor. Checkpoint code can now access valid data without any special handling.
2. **Original storage preservation**: Save references to the original CUDA `UntypedStorage` objects and their `storage_offset`s before freeing. This allows restore to re-point tensors (including views sharing the same underlying storage) back to the correct CUDA storage.
3. **Restore via `set_()` on original storage**: Instead of resizing the tensor's own storage (which is now a CPU buffer), resize the saved original CUDA storage, construct a new CUDA tensor viewing it at the correct offset/shape/stride, and swap `.data` back. This preserves tensor identity for all external references.

## 3. Analysis
1. **Backward compatibility**: No public API changes. `_stash_tensors` is internal. The behavioral change (tensor on CPU vs 0-size CUDA storage) is strictly more useful for consumers.
2. **Shared storage correctness**: Views sharing the same underlying storage are handled correctly. `_orig_storages` may contain duplicate storage refs, but `resize_()` on an already-resized storage is a no-op (guarded by `if cur_size < orig_storage_size`). Each view gets its own `set_()` call with the correct offset.
3. **Async D2H and checkpoint timing**: The D2H copy is async (`non_blocking=True`). The CPU buffer data is only guaranteed valid after `d2h_stream` completes. In practice, checkpoint runs after the training step, providing implicit synchronization.

## 4. Changes
1. **`memory_stashing.py`**: Save original CUDA storage refs and offsets in `_orig_storages`/`_orig_storage_offsets`. After `resize_(0)`, swap `tensor.data` to CPU buffer. Restore re-points tensors to re-allocated original CUDA storage via `set_()` and `.data` swap.
2. **`BUCK`**: Fix dep `//caffe2:_torch` -> `//caffe2:torch`.
3. **`test_memory_stashing.py`**: Update all stash assertions from `storage().size() == 0` to `assertFalse(tensor.is_cuda)`, and restore assertions to `assertTrue(tensor.is_cuda)`.

Differential Revision: D105632395


