### PR TITLE
Surface 2D-sharding asymmetry root cause at the boundary

### DIFF
--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1370,14 +1370,55 @@ class ShardedEmbeddingBagCollection(
                         ),
                     )
 
+                    sharded_tensor_metadata = sharding_spec.build_metadata(
+                        tensor_sizes=self._name_to_table_size[table_name],
+                        tensor_properties=tensor_properties,
+                    )
+
+                    # Use global_rank: torch core's assert in
+                    # ShardedTensor._init_from_local_shards_and_global_metadata
+                    # compares placement.rank() against dist.get_rank() (global).
+                    if isinstance(self._env, ShardingEnv2D):
+                        my_global_rank = self._env.global_rank
+                        expected_for_this_rank = sum(
+                            1
+                            for sm in sharded_tensor_metadata.shards_metadata
+                            if sm.placement is not None
+                            and sm.placement.rank() == my_global_rank
+                        )
+                        if len(local_shards) != expected_for_this_rank:
+                            logger.warning(
+                                "[2d-sharding-diag] shard_count_mismatch table=%s global_rank=%d (see Scuba torchrec_event_logging)",
+                                table_name,
+                                my_global_rank,
+                            )
+                            EventLoggingHandler.log_event(
+                                component=TorchrecComponent.SHARDER.value,
+                                event_name="EmbeddingBagCollectionSharder.2d_diag.shard_count_mismatch",
+                                event_type=EventType.INFO,
+                                metadata={
+                                    "table_name": table_name,
+                                    "local_shards": str(len(local_shards)),
+                                    "expected_for_this_rank": str(
+                                        expected_for_this_rank
+                                    ),
+                                    "total_metadata_shards": str(
+                                        len(sharded_tensor_metadata.shards_metadata)
+                                    ),
+                                    "global_rank": str(my_global_rank),
+                                    "sharding_pg_rank": str(self._env.rank),
+                                    "sharding_pg_size": str(self._env.world_size),
+                                    "global_world_size": str(
+                                        self._env.global_world_size
+                                    ),
+                                },
+                            )
+
                     try:
                         self._model_parallel_name_to_sharded_tensor[table_name] = (
                             ShardedTensor._init_from_local_shards_and_global_metadata(
                                 local_shards=local_shards,
-                                sharded_tensor_metadata=sharding_spec.build_metadata(
-                                    tensor_sizes=self._name_to_table_size[table_name],
-                                    tensor_properties=tensor_properties,
-                                ),
+                                sharded_tensor_metadata=sharded_tensor_metadata,
                                 process_group=(
                                     self._env.sharding_pg
                                     if isinstance(self._env, ShardingEnv2D)

--- a/torchrec/distributed/sharding/twrw_sharding.py
+++ b/torchrec/distributed/sharding/twrw_sharding.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import itertools
+import logging
 import math
 from typing import Any, cast, Dict, List, Optional, Tuple, TypeVar
 
@@ -46,6 +47,7 @@ from torchrec.distributed.embedding_types import (
     ShardedEmbeddingTable,
 )
 from torchrec.distributed.logging_handlers import EventLoggingHandler, TorchrecComponent
+from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.types import (
     Awaitable,
     CommOp,
@@ -63,6 +65,8 @@ C = TypeVar("C", bound=Multistreamable)
 F = TypeVar("F", bound=Multistreamable)
 T = TypeVar("T")
 W = TypeVar("W")
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
@@ -139,13 +143,34 @@ class BaseTwRwEmbeddingSharding(EmbeddingSharding[C, F, T, W]):
         peer_group = get_process_group_ranks(self._pg) if self._is_2D_parallel else None
         for info in sharding_infos:
             # Under 2D parallelism we transform rank to the logical ordering in a regular parallelism scheme
-            rank = (
-                # pyrefly: ignore[unsupported-operation]
-                peer_group.index(info.param_sharding.ranks[0])
-                if peer_group is not None
-                # pyrefly: ignore[unsupported-operation]
-                else info.param_sharding.ranks[0]
-            )
+            # pyrefly: ignore[unsupported-operation]
+            planner_rank = info.param_sharding.ranks[0]
+            if peer_group is not None:
+                pg_members: List[int] = peer_group
+                try:
+                    rank = pg_members.index(planner_rank)
+                except ValueError:
+                    logger.warning(
+                        "[2d-sharding-diag] peer_group_index_failed table=%s planner_rank=%d (see Scuba torchrec_event_logging)",
+                        info.embedding_config.name,
+                        planner_rank,
+                    )
+                    EventLoggingHandler.log_event(
+                        component=TorchrecComponent.SHARDER.value,
+                        event_name="TwRwBaseSharding.2d_diag.peer_group_index_failed",
+                        event_type=EventType.INFO,
+                        metadata={
+                            "table_name": info.embedding_config.name,
+                            "planner_rank": str(planner_rank),
+                            "peer_group_size": str(len(pg_members)),
+                            "peer_group_head": str(pg_members[:8]),
+                            "sharding_pg_size": str(self._world_size),
+                            "global_world_size": str(dist.get_world_size()),
+                        },
+                    )
+                    raise
+            else:
+                rank = planner_rank
             table_node = rank // local_size
             # pyrefly: ignore[missing-attribute]
             shards = info.param_sharding.sharding_spec.shards


### PR DESCRIPTION
Summary:
Add diagnostics to find the root cause of shard-mismatch errors in 2D-sharding-enabled models.

The sharding-mismatch assertion in torch core's `_init_from_local_shards_and_global_metadata` fires ~11K times / 28d on `torchrec_event_logging`, 99% concentrated in `ig_organic_feed_mtml` and `ig_reels_tab_esr_ttsn`. Static analysis through `_remap_sharding_plan_to_groups`, TWRW `_shard`, and `_initialize_torch_state` rules out the obvious local candidates, so the bug is upstream of `_shard`.

This diff adds diagnostic logging at the two failure preconditions to pinpoint the upstream divergence. `twrw_sharding.py` wraps `peer_group.index()` in `try/except ValueError` and emits `TwRwBaseSharding.2d_diag.peer_group_index_failed` before re-raising. `embeddingbag.py` emits `EmbeddingBagCollectionSharder.2d_diag.shard_count_mismatch` before `_init_from_local_shards_and_global_metadata` if `len(local_shards)` disagrees with the per-rank shard count on `ShardingEnv2D`.

Reviewed By: aporialiao

Differential Revision: D106892622


