### PR TITLE
Numerics test for window_xauc with custom op (#4313)

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -11,6 +11,7 @@ import abc
 import inspect
 import itertools
 import math
+import weakref
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
@@ -86,6 +87,25 @@ ComputeIterType = Iterator[
 ]
 
 MAX_BUFFER_COUNT = 1000
+_WINDOW_BUFFER_REGISTRY: weakref.WeakValueDictionary[int, Any] = (
+    weakref.WeakValueDictionary()
+)
+_WINDOW_BUFFER_HANDLE_COUNTER: Iterator[int] = itertools.count()
+
+
+@torch.library.custom_op(
+    "torchrec::window_buffer_aggregate_state",
+    mutates_args={"window_state"},
+)
+def _window_buffer_aggregate_state(
+    window_state: torch.Tensor,
+    curr_state: torch.Tensor,
+    buffer_handle: int,
+    size: int,
+) -> None:
+    _WINDOW_BUFFER_REGISTRY[buffer_handle]._aggregate_state_impl(
+        window_state, curr_state, size
+    )
 
 
 class RecMetricException(Exception):
@@ -96,6 +116,8 @@ class WindowBuffer:
     def __init__(self, max_size: int, max_buffer_count: int) -> None:
         self._max_size: int = max_size
         self._max_buffer_count: int = max_buffer_count
+        self._op_handle: int = next(_WINDOW_BUFFER_HANDLE_COUNTER)
+        _WINDOW_BUFFER_REGISTRY[self._op_handle] = self
 
         self._buffers: Deque[torch.Tensor] = deque(maxlen=max_buffer_count)
         self._used_sizes: Deque[int] = deque(maxlen=max_buffer_count)
@@ -104,14 +126,20 @@ class WindowBuffer:
     def aggregate_state(
         self, window_state: torch.Tensor, curr_state: torch.Tensor, size: int
     ) -> None:
+        _window_buffer_aggregate_state(window_state, curr_state, self._op_handle, size)
+
+    def _aggregate_state_impl(
+        self, window_state: torch.Tensor, curr_state: torch.Tensor, size: int
+    ) -> None:
         def remove(window_state: torch.Tensor) -> None:
             window_state -= self._buffers.popleft()
             self._window_used_size -= self._used_sizes.popleft()
 
         if len(self._buffers) == self._buffers.maxlen:
             remove(window_state)
-
-        self._buffers.append(curr_state)
+        # call curr_state.clone() before stashing in deque to ensure Inductor does not reuse
+        # storage with an alias that it doesn't know about
+        self._buffers.append(curr_state.clone())
         self._used_sizes.append(size)
         window_state += curr_state
         self._window_used_size += size
@@ -244,8 +272,6 @@ class RecMetricComputation(Metric, abc.ABC):
                 max_buffer_count=MAX_BUFFER_COUNT,
             )
 
-    # disable pt2 compile for this function as it would exceed the recompilation limit
-    @torch.compiler.disable
     def _aggregate_window_state(
         self, state_name: str, state: torch.Tensor, num_samples: int
     ) -> None:

--- a/torchrec/metrics/tests/test_xauc.py
+++ b/torchrec/metrics/tests/test_xauc.py
@@ -104,17 +104,16 @@ class XAUCMetricTest(unittest.TestCase):
                     labels={DefaultTaskInfo.name: model_output["labels"][0]},
                     weights={DefaultTaskInfo.name: model_output["weights"][0]},
                 )
-        metric_compile = xauc_compile.compute()[
-            f"xauc-{DefaultTaskInfo.name}|lifetime_xauc"
-        ]
-        metric = xauc.compute()[f"xauc-{DefaultTaskInfo.name}|lifetime_xauc"]
-
-        torch.testing.assert_close(
-            metric_compile,
-            metric,
-            atol=1e-4,
-            rtol=1e-4,
-            check_dtype=False,
-            equal_nan=True,
-            msg=f"Compiled: {metric_compile}, Expected: {metric}",
-        )
+        compile_out = xauc_compile.compute()
+        eager_out = xauc.compute()
+        for prefix in ("lifetime_xauc", "window_xauc"):
+            key = f"xauc-{DefaultTaskInfo.name}|{prefix}"
+            torch.testing.assert_close(
+                compile_out[key],
+                eager_out[key],
+                atol=1e-4,
+                rtol=1e-4,
+                check_dtype=False,
+                equal_nan=True,
+                msg=f"[{prefix}] Compiled: {compile_out[key]}, Eager: {eager_out[key]}",
+            )

--- a/torchrec/metrics/tests/test_xauc.py
+++ b/torchrec/metrics/tests/test_xauc.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import functools
 import sysconfig
 import unittest
 from typing import Dict
@@ -69,16 +70,6 @@ class XAUCMetricTest(unittest.TestCase):
         "see https://dev-discuss.pytorch.org/t/torch-compile-support-for-python-3-14-completed/3276",
     )
     def test_xauc_compile(self) -> None:
-        xauc_compile = XAUCMetric(
-            world_size=WORLD_SIZE,
-            my_rank=0,
-            batch_size=BATCH_SIZE,
-            tasks=[DefaultTaskInfo],
-            # pyrefly: ignore[bad-argument-type]
-            enable_pt2_compile=True,
-            window_size=200,
-        )
-
         xauc = XAUCMetric(
             world_size=WORLD_SIZE,
             my_rank=0,
@@ -90,12 +81,23 @@ class XAUCMetricTest(unittest.TestCase):
         )
 
         model_output = generate_model_output()
-        with patch.object(torch._dynamo.config, "fail_on_recompile_limit_hit", True):
+        fullgraph_compile = functools.partial(torch.compile, fullgraph=True)
+        with patch.object(torch, "compile", fullgraph_compile):
+            xauc_compile = XAUCMetric(
+                world_size=WORLD_SIZE,
+                my_rank=0,
+                batch_size=BATCH_SIZE,
+                tasks=[DefaultTaskInfo],
+                # pyrefly: ignore[bad-argument-type]
+                enable_pt2_compile=True,
+                window_size=200,
+            )
             for _ in range(10):
                 xauc_compile.update(
                     predictions={DefaultTaskInfo.name: model_output["predictions"][0]},
                     labels={DefaultTaskInfo.name: model_output["labels"][0]},
                     weights={DefaultTaskInfo.name: model_output["weights"][0]},
+                    _log_tensors=False,  # required for fullgraph=True
                 )
                 xauc.update(
                     predictions={DefaultTaskInfo.name: model_output["predictions"][0]},


### PR DESCRIPTION
Summary:

The prior diff adds the custom op and ensures it can torch.compile without graph breaks, but does not yet validate numerics drift going from eager to torch.compile.

Extend the test to do this for `window_xauc`. We'll use the existing tolerance of 1e-4 as used for `lifetime_xauc`, but this is quite generous. Running it locally, we find that even `1e-12` would pass.

Differential Revision: D106871928


