### PR TITLE
feat: add ALBT logger framework helpers (#4316)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -46,6 +46,7 @@ class TorchrecComponent(Enum):
     REC_METRICS = "rec_metrics"
     ITEP = "itep"
     DISTRIBUTED_MODEL_PARALLEL = "distributed_model_parallel"
+    ALBT = "albt"
 
 
 class EventLoggingHandler(EventLoggingHandlerBase):
@@ -516,6 +517,64 @@ def log_proposer_result(
     best_perf_rating: Optional[float] = None,
     is_winning_proposer: bool = False,
     technique: OptimizationTechnique = OptimizationTechnique.NONE,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_enablement(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_schedule_conversion(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_warning(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_error(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+    error_message: Optional[str] = None,
+    stack_trace: Optional[str] = None,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_stage_transition(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_validation_success(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_schedule_stage(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
 ) -> None:
     """No-op OSS stub."""
     pass


### PR DESCRIPTION
Summary:

First diff in the ALBT-Logger-for-APS stack (design doc:
https://docs.google.com/document/d/1vEugqTwqJo4S20__XtijI8pG98PhH2K-cflYPSrtbTg).

## Goal

Add the framework layer for structured Scuba logging of ALBT (Adaptive
Local Batch Training, the variable batch-size schedule feature in
apf/data) to the `training_optimization_events` Scuba dataset. Adopts
the OSS-stub / FB-impl / unit-test pattern established by D100034013
(ITEP IEN pruning logger).

This diff is **framework only** — no call-site wiring. Call sites in
`apf/data/` ship in the child diff (D2 / D103718204).

## Changes

1. `fbcode/torchrec/distributed/logging_handlers.py` (OSS stub) — 7
   no-op `log_albt_*` helpers.
2. `fbcode/torchrec/fb/distributed/logging_handlers.py` (FB impl):
   * `TorchrecComponent.ALBT = "albt"` enum value.
   * New `_albt_should_log()` helper that checks `dist.get_rank() == 0`
     to gate ALBT logging to rank 0 only (see "Rank policy" below).
   * 7 real impls that call `TrainingOptimizationLogger.log` with
     `StackLayer.FRAMEWORK`, `OptimizationTechnique.ALBT` (already in
     the enum), `EventScope.JOB`. Each helper checks `_albt_should_log()`
     at the start and returns early if not rank 0.
   * Fixed ALBT helper signatures to use `Optional[Dict[str, str]] = None`
     to match OSS stubs.
3. `fbcode/torchrec/fb/distributed/tests/test_logging_handlers.py`:
   * New `TestALBTLogging` class with 8 unit tests for the helpers.
     Tests mock `_albt_should_log` to verify the rank gate is checked.

## Helper catalog

| Helper | EventType | Notes |
| --- | --- | --- |
| `log_albt_enablement` | INFO | Once per job from rank 0; primary adoption signal — `COUNT DISTINCT mast_job_owner`. |
| `log_albt_schedule_conversion` | INFO | Aggregate APF→DPP conversion summary; `final_dpp_schedule` JSON-encoded. |
| `log_albt_schedule_stage` | INFO | Per-stage row of the converted DPP schedule (mirrors `log_itep_ien_pruning_decision`). |
| `log_albt_validation_success` | INFO | Config validation OK (mirrors `log_itep_ien_pruning_stats`). |
| `log_albt_warning` | INFO | Non-fatal anomalies; `warning_type` field discriminates. |
| `log_albt_error` | FAILURE | `error_message` + `stack_trace` forwarded to `.log` as kwargs. |
| `log_albt_stage_transition` | INFO | JK-gated default-OFF per-stage hot-path event; the JK gate is at the call site, deferred to D3. |

All seven helpers use `StackLayer.FRAMEWORK` + `EventScope.JOB`.

## Rank policy

ALBT events go through `TrainingOptimizationLogger.log`, which writes
directly to Scuba via `ScubaData.add_sample` — this path does NOT
flow through Python's `logging` module and is NOT attached to a
`MastScubaLoggingHandler`, so the handler-level `single_rank=True`
flag does not apply here.

To get one Scuba sample per job (matching the
"fires once per job from rank 0" contract on `log_albt_enablement`
and the unique-user metric `COUNT DISTINCT mast_job_owner`), this
diff adds a rank gate at the ALBT helper level via a new
`_albt_should_log()` helper.

## OSS export

This diff modifies `torchrec/distributed/logging_handlers.py` which is
mirrored to GitHub `meta-pytorch/torchrec`.

Reviewed By: nipung90, AKhazane

Differential Revision: D103713835


