### PR TITLE
fix: add ALBT to OSS TorchrecComponent enum (#4318)

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -46,6 +46,7 @@ class TorchrecComponent(Enum):
     REC_METRICS = "rec_metrics"
     ITEP = "itep"
     DISTRIBUTED_MODEL_PARALLEL = "distributed_model_parallel"
+    ALBT = "albt"
 
 
 class EventLoggingHandler(EventLoggingHandlerBase):

--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -521,4 +521,62 @@ def log_proposer_result(
     pass
 
 
+def log_albt_enablement(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_schedule_conversion(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_warning(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_error(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+    error_message: Optional[str] = None,
+    stack_trace: Optional[str] = None,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_stage_transition(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_validation_success(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_albt_schedule_stage(
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.ALBT,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 _log_handlers: dict[str, logging.Handler] = defaultdict(logging.NullHandler)


### PR DESCRIPTION
Summary:

One-line OSS parity fix. The FB-internal `TorchrecComponent` enum
(//torchrec/fb/distributed:logging_handlers, also `base_module`-d to
`torchrec.distributed.logging_handlers`) already defines
`ALBT = "albt"`. The OSS stub at
`fbcode/torchrec/distributed/logging_handlers.py` was missing this
member, so any OSS-side import of `TorchrecComponent.ALBT` would
`AttributeError`.

This is a pre-req for the Pyper call-site wiring that follows on
top of this commit in the stack, which lights up the `log_albt_*`
helpers and indirectly imports the OSS stub when building outside
Meta.

Reviewed By: nipung90, AKhazane

Differential Revision: D105764381


