### PR TITLE
Move CUDA→CPU transfer to DeferrableMetrics.update boundary

### DIFF
--- a/torchrec/metrics/deferrable_metrics.py
+++ b/torchrec/metrics/deferrable_metrics.py
@@ -54,12 +54,15 @@ def transfer_tensors_to_cpu(
     if source_device is None:
         return tensors, None
 
-    cpu_tensors = {
-        k: v.to(device="cpu", non_blocking=True) if isinstance(v, torch.Tensor) else v
-        for k, v in tensors.items()
-    }
-
     with torch.cuda.device(source_device):
+        cpu_tensors: dict[str, Any] = {}
+        for k, v in tensors.items():
+            if isinstance(v, torch.Tensor):
+                dst = torch.empty(v.shape, dtype=v.dtype, device="cpu", pin_memory=True)
+                dst.copy_(v, non_blocking=True)
+                cpu_tensors[k] = dst
+            else:
+                cpu_tensors[k] = v
         event = torch.cuda.Event()
         event.record()
 
@@ -159,6 +162,13 @@ class DeferrableMetrics(Mapping[str, Any]):
         If backed by Future, defers the merge until Future resolves.
         If other is a DeferrableMetrics, subscribes to it for deferred merge.
 
+        Any CUDA tensors in `other` are eagerly transferred to pinned CPU
+        memory on the calling thread (truly async via pinned destination —
+        caller is not blocked). The stored values are always CPU. This
+        prevents per-tensor `.detach().cpu()` from running on the resolve
+        thread (typically metric_compute), which would otherwise hold the
+        GIL and stall backward.
+
         Ordering constraint: when backed by a Future, update() replaces the
         internal Future with a new merged Future. Any subscribe() callbacks
         registered *before* update() are attached to the original Future and
@@ -183,18 +193,24 @@ class DeferrableMetrics(Mapping[str, Any]):
             return
 
         assert isinstance(other, dict)
-        dict_other: dict[str, Any] = other
+        # Eagerly stage CUDA tensors to pinned CPU. Returns the input dict
+        # unchanged with event=None when nothing is on CUDA.
+        cpu_other, transfer_event = transfer_tensors_to_cpu(other)
 
         if self._resolved:
-            self._data.update(dict_other)
+            if transfer_event is not None:
+                transfer_event.synchronize()
+            self._data.update(cpu_other)
         elif self._future is not None:
             original_future = self._future
             merged_future: Future[dict[str, Any]] = Future()
 
             def _on_complete(f: Future[dict[str, Any]]) -> None:
                 try:
+                    if transfer_event is not None:
+                        transfer_event.synchronize()
                     result = dict(f.result())
-                    result.update(dict_other)
+                    result.update(cpu_other)
                     merged_future.set_result(result)
                 except Exception as e:
                     merged_future.set_exception(e)

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -10,6 +10,7 @@
 import unittest
 from collections.abc import Mapping
 from concurrent.futures import Future
+from typing import Any
 from unittest.mock import patch
 
 import torch
@@ -271,6 +272,60 @@ class TestDeferrableMetrics(unittest.TestCase):
         self.assertEqual(len(received), 1)
         self.assertEqual(received[0]["original"], "data")
         self.assertEqual(received[0]["cpu_val"], "extra")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_update_resolved_cuda_tensors_moved_to_cpu(self) -> None:
+        # Use fp32-exact values (powers of 2) to avoid precision-based assertion noise.
+        dm = DeferrableMetrics({"a": torch.tensor(1.0)})
+        dm.update({"loss": torch.tensor(0.5, device="cuda")})
+        resolved = dm.resolve()
+        self.assertEqual(resolved["loss"].device.type, "cpu")
+        self.assertEqual(resolved["loss"].item(), 0.5)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_update_future_backed_cuda_tensors_moved_to_cpu(self) -> None:
+        f: Future[dict[str, Any]] = Future()
+        dm = DeferrableMetrics(f)
+        dm.update({"loss": torch.tensor(0.25, device="cuda")})
+        f.set_result({"window_ne": torch.tensor(0.5)})
+        resolved = dm.resolve()
+        self.assertEqual(resolved["loss"].device.type, "cpu")
+        self.assertEqual(resolved["loss"].item(), 0.25)
+        self.assertEqual(resolved["window_ne"].item(), 0.5)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_update_bit_identical_to_per_tensor_cpu_extraction(self) -> None:
+        # Reference: per-tensor .cpu() (what publish would do today).
+        torch.manual_seed(0)
+        gpu_dict: dict[str, torch.Tensor] = {
+            f"task_{i}:loss": torch.rand((), device="cuda") for i in range(30)
+        }
+        expected = {k: v.cpu().item() for k, v in gpu_dict.items()}
+
+        f: Future[dict[str, Any]] = Future()
+        dm = DeferrableMetrics(f)
+        dm.update(gpu_dict)
+        f.set_result({})
+        actual = {k: v.item() for k, v in dm.resolve().items()}
+
+        for k in expected:
+            self.assertEqual(expected[k], actual[k])
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_update_does_not_mutate_caller_dict(self) -> None:
+        caller_dict: dict[str, Any] = {"loss": torch.tensor(1.0, device="cuda")}
+        dm = DeferrableMetrics({"a": 1})
+        dm.update(caller_dict)
+        # Caller's dict still has the GPU tensor — we made a defensive copy.
+        self.assertEqual(caller_dict["loss"].device.type, "cuda")
+
+    def test_update_resolved_cpu_only_unchanged(self) -> None:
+        # No CUDA tensors → transfer_tensors_to_cpu short-circuits (no event).
+        dm = DeferrableMetrics({"a": torch.tensor(1.0)})
+        dm.update({"b": torch.tensor(2.0), "name": "task1"})
+        resolved = dm.resolve()
+        self.assertEqual(resolved["b"].item(), 2.0)
+        self.assertEqual(resolved["name"], "task1")
 
 
 class TransferTensorsToCpuTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
Routes the input dict through `transfer_tensors_to_cpu` inside `DeferrableMetrics.update`, so any CUDA tensors are eagerly staged to pinned CPU on the calling thread instead of bubbling through to the resolve thread. Eliminates the per-tensor `.detach().cpu()` work that publish callbacks may call to materialize.

Also makes `transfer_tensors_to_cpu` use pinned destinations + `non_blocking=True`, so the eager D2H is truly async on the caller (otherwise this would shift the blocking from metric_compute to trainer_main, not eliminate it).

Differential Revision: D107415213


