### PR TITLE
Wrap `.item()` args to `torch._check*` helpers in `cast` for stricter typing (#4320)

### DIFF
--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -158,13 +158,13 @@ class KJTInputExportDynamicShapeWrapper(torch.nn.Module):
         # Generate unbacked symints to represent sizes
         # for values and weights, constrain them reasonably
         values_size = values[0].item()
-        torch._check_is_size(values_size)
+        torch._check_is_size(cast(int, values_size))
         torch._check(values_size >= lengths.shape[0])
         # pyrefly: ignore[no-matching-overload]
         values = torch.ones(values_size).to(values.device)
         if weights is not None:
             weights_size = weights.int()[0].item()
-            torch._check_is_size(weights_size)
+            torch._check_is_size(cast(int, weights_size))
             torch._check(weights_size >= lengths.shape[0])
             # pyrefly: ignore[no-matching-overload]
             weights = torch.ones(weights_size).to(weights.device)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/5834


X-link: https://github.com/facebookresearch/FBGEMM/pull/2757

The SymInt magic-method typing change added strict annotations to the previously-untyped `torch._check`, `torch._check_is_size`, and `torch._constrain_as_size` helpers (`cond: bool | SymBool`, `i`/`symbol: IntLikeType`). Call sites that pass a `Tensor.item()` result into these helpers now fail type checking, because `Tensor.item()` is typed `bool | float | int`, which is not assignable to `IntLikeType` or `bool | SymBool`. The values are genuinely int/bool-like here (tensor sizes and boolean comparison results); the error comes purely from `item()`'s necessarily-broad return type.

This wraps the offending arguments in `typing.cast(int, ...)` / `typing.cast(bool, ...)`. `typing.cast` is erased at runtime, so behavior is unchanged. We deliberately do not use `int(...)` / `bool(...)`: under `torch.compile` / `torch.export` these `.item()` values are unbacked `SymInt` / `SymBool`, and forcing `int()` / `bool()` would trigger `GuardOnDataDependentSymNode` and alter runtime behavior.

Reviewed By: bobrenjc93

Differential Revision: D107556825


