### PR TITLE
Make CPUOffloadedRecMetricModule.shutdown idempotent on raise paths

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -374,10 +374,12 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     @override
     def shutdown(self) -> None:
         """Two-phase shutdown: stop the update thread, then the compute thread.
-        Idempotent — safe under explicit call + atexit."""
+        Idempotent — safe under explicit call + atexit, including the raise paths
+        below (thread-stuck and captured-exception)."""
 
         if self._shutdown_complete:
             return
+        self._shutdown_complete = True
 
         logger.info(
             f"Gracefully shutting down CPUOffloadedRecMetricModule... "
@@ -473,7 +475,6 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             f"updates={self._total_updates_processed}/{self._total_updates_enqueued}, "
             f"computes={self._total_computes_processed}/{self._total_computes_enqueued}"
         )
-        self._shutdown_complete = True
 
     @override
     def compute(self) -> DeferrableMetrics:

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -297,6 +297,35 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "worker died"):
             self.cpu_module.shutdown()
 
+    def test_shutdown_idempotent_after_captured_exception(self) -> None:
+        """First shutdown() re-raises the captured worker exception; subsequent
+        calls (e.g. via atexit after tearDown swallowed the first) must be no-ops
+        rather than re-raising and re-running shutdown work."""
+        with patch.object(
+            self.cpu_module,
+            "_process_metric_update_job",
+            side_effect=RuntimeError("worker died"),
+        ):
+            self.cpu_module.update(
+                {
+                    "task1-prediction": torch.tensor([0.5]),
+                    "task1-label": torch.tensor([0.5]),
+                    "task1-weight": torch.tensor([1.0]),
+                }
+            )
+            self.assertTrue(
+                self.cpu_module._captured_exception_event.wait(timeout=5.0),
+                "update thread did not capture exception",
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "worker died"):
+            self.cpu_module.shutdown()
+
+        self.assertTrue(self.cpu_module._shutdown_complete)
+        with patch.object(self.cpu_module, "_log_event") as mock_log_event:
+            self.cpu_module.shutdown()
+            mock_log_event.assert_not_called()
+
     def test_shutdown_processes_final_sync_marker_in_compute_thread(self) -> None:
         """Two-phase shutdown: the SyncMarker enqueued during update-thread
         flush must be processed by the compute thread before it stops."""


### PR DESCRIPTION
Summary:
The early-return guard at the top of shutdown() only takes effect if a prior call reached the trailing `_shutdown_complete = True`. All three raise paths (thread-stuck x2, captured-exception x1) exit before that, so atexit-driven re-entry after a tearDown-swallowed shutdown re-runs the full sequence and re-raises — surfacing as duplicate "Exception ignored in atexit callback" noise, and on OSS pytest as a non-zero exit that fails CI even though every test passed.

Move the flag set to the top, right after the guard, so any raise leaves the module in a state where subsequent calls early-return.

Differential Revision: D107548941


