### PR TITLE
Pass D=/I= as keyword args to faiss Index.search in two_tower example (#4326)

### DIFF
--- a/examples/retrieval/modules/two_tower.py
+++ b/examples/retrieval/modules/two_tower.py
@@ -221,7 +221,7 @@ class TwoTowerRetrieval(nn.Module):
             (batch_size, self.k), device=self.device, dtype=torch.int64
         )
         query_embedding = query_embedding.to(torch.float32)  # required by faiss
-        self.faiss_index.search(query_embedding, self.k, distances, candidates)
+        self.faiss_index.search(query_embedding, self.k, D=distances, I=candidates)
 
         # candidate lookup
         candidate_kjt = KeyedJaggedTensor(


### PR DESCRIPTION
Summary:

The faiss Index.search torch overload declares its D/I output tensors as
keyword-only parameters; the retrieval two_tower example passed them
positionally, which the type checker rejects. Pass them as D=/I= keywords
(matches the faiss torch_utils runtime signature).

Reviewed By: angelayi, aeolyus, grievejia

Differential Revision: D107715937


