### PR TITLE
Remove emo_logger usage in favor of TrainingOptimizationLogger (#4328)

### DIFF
--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -77,7 +77,6 @@ from torchrec.distributed.types import (
     ShardMetadata,
 )
 from torchrec.distributed.utils import get_device_type, none_throws
-from torchrec.utils.emo_logger import DecisionCategory, log_emo_decision
 
 try:
     # This is a safety measure against torch package issues for when
@@ -801,14 +800,6 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         )
         storage_policy = self._storage_reservation.__class__.__name__
         storage_percentage = getattr(self._storage_reservation, "_percentage", None)
-        log_emo_decision(
-            DecisionCategory.PROPOSER,
-            logging.INFO,
-            f"Storage reservation applied: policy={storage_policy}, percentage={storage_percentage}, global_hbm_available={round(bytes_to_gb(global_storage_capacity.hbm), 3)}GB",
-            storage_policy=storage_policy,
-            storage_percentage=storage_percentage,
-            global_hbm_available_gb=round(bytes_to_gb(global_storage_capacity.hbm), 3),
-        )
 
         _technique = detect_technique(
             list(self._constraints.values()) if self._constraints else []


### PR DESCRIPTION
Summary:


The `torchrec/utils/emo_logger/` package is a lightweight in-memory logger that logs EMO decisions to Python stdlib `logging`. It has been superseded by the `TrainingOptimizationLogger` (D97546757), which logs structured events to the `training_optimization_events` Scuba table with richer metadata, thread-safety, and multi-technique support.

The new logger (`log_storage_reservation`, `log_clf_computed`, `log_stats_match`) is already integrated at all callsites. This diff removes the old `log_emo_decision` calls and their imports.

Additionally, adds a `log_clf_computed` call in the `overwrite_load_factor=False` branch of `update_cache_params_helper` to close a logging gap where the initial CLF was only recorded by the old logger.

The `emo_logger/` package itself is not deleted in this diff — it will be removed in a follow-up after this change soaks.

Reviewed By: ahmed-shuaibi

Differential Revision: D104274422


