### PR TITLE
Route inplace_copy_batch logging through event logger

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -394,6 +394,48 @@ def log_ems_config(
     pass
 
 
+def log_inplace_copy_batch(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.INPLACE_COPY_BATCH,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_clear_input_dist_tensors(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.CLEAR_INPUT_DIST,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_free_features_storage_early(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.FREE_FEATURES_STORAGE_EARLY,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_ems_event(
+    event_name: str = "",
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMS,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_emo_event(
+    event_name: str = "",
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_mpzch_summary(
     best_plan: Optional[List] = None,  # type: ignore[type-arg]
     technique: OptimizationTechnique = OptimizationTechnique.MPZCH,

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -47,6 +47,9 @@ class OptimizationTechnique(Enum):
     MPZCH = "mpzch"
     KVZCH = "kvzch"
     ZORM = "zorm"
+    INPLACE_COPY_BATCH = "inplace_copy_batch"
+    CLEAR_INPUT_DIST = "clear_input_dist"
+    FREE_FEATURES_STORAGE_EARLY = "free_features_storage_early"
 
 
 @unique

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -25,7 +25,7 @@ from typing import (
 
 import torch
 from torch.autograd.profiler import record_function
-from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
+from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.train_pipeline.backward_injection import (
@@ -59,7 +59,10 @@ from torchrec.distributed.types import LazyNoWait, ShardingType
 from torchrec.sparse.jagged_tensor import KeyedTensor
 
 try:
-    from torchrec.distributed.logging_handlers import log_ems_config
+    from torchrec.distributed.logging_handlers import (
+        log_ems_config,
+        log_inplace_copy_batch,
+    )
     from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
 except Exception:
     torch._C._log_api_usage_once(
@@ -69,6 +72,9 @@ except Exception:
     DATA_TYPE_NUM_BITS: dict = {}  # type: ignore[no-redef]
 
     def log_ems_config(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
+        pass
+
+    def log_inplace_copy_batch(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
         pass
 
 
@@ -780,11 +786,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
                     self._inplace_copy_batch_size_logged = True
                     size = _batch_tensor_size(batch)
 
-                    one_time_logger.info(
-                        LazyStr(
-                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
-                        )
-                    )
+                    log_inplace_copy_batch(size)
                 future_batch = self._copy_executor.submit(
                     _to_device,
                     batch,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -40,31 +40,20 @@ from torchrec.distributed.embeddingbag import (
 )
 
 try:
-    from torchrec.distributed.logger import (
-        LazyStr,
-        one_time_logger,
-        one_time_rank0_logger,
-    )
+    from torchrec.distributed.logger import one_time_rank0_logger
 except Exception:
     # Safety measure against torch package issues: old packages may not have
     # these symbols in their archived torchrec.distributed.logger
     torch._C._log_api_usage_once(
         "torchrec.distributed.train_pipeline.train_pipelines.import_failure.logger"
     )
-    one_time_logger = logging.getLogger(__name__)
     one_time_rank0_logger = logging.getLogger(__name__)
-
-    class LazyStr:  # pyre-ignore[11]
-        def __init__(self, fn: Any) -> None:
-            self._fn = fn
-
-        def __str__(self) -> str:
-            return self._fn()
 
 
 try:
     from torchrec.distributed.logging_handlers import (
         EventLoggingHandler,
+        log_inplace_copy_batch,
         TorchrecComponent,
     )
 except Exception:
@@ -75,6 +64,7 @@ except Exception:
     if TYPE_CHECKING:
         from torchrec.distributed.logging_handlers import (
             EventLoggingHandler,
+            log_inplace_copy_batch,
             TorchrecComponent,
         )
     else:
@@ -90,6 +80,9 @@ except Exception:
                     return func
 
                 return decorator
+
+        def log_inplace_copy_batch(*args: object, **kwargs: object) -> None:
+            pass
 
 
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
@@ -355,9 +348,7 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
                 self._inplace_copy_batch_size_logged = True
                 size = _batch_tensor_size(cur_batch)
 
-                one_time_logger.info(
-                    LazyStr(lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB")
-                )
+                log_inplace_copy_batch(size)
             with record_function("## inplace_copy_batch_to_gpu ##"):
                 self._cur_batch = _to_device(
                     cur_batch,
@@ -1093,11 +1084,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                     self._inplace_copy_batch_size_logged = True
                     size = _batch_tensor_size(batch)
 
-                    one_time_logger.info(
-                        LazyStr(
-                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
-                        )
-                    )
+                    log_inplace_copy_batch(size)
                 batch = _to_device(
                     batch,
                     self._device,


### PR DESCRIPTION
Summary:
Replaces the legacy free-text `one_time_logger`/`LazyStr` size log with the structured `log_inplace_copy_batch()` helper at the three `inplace_copy_batch` call sites: `TrainPipelineBase._copy_batch_to_gpu`, `TrainPipelineSparseDist.inplace_copy_batch_to_gpu` (in `train_pipelines.py`), and `TrainPipelineSparseDistT.inplace_copy_batch_to_gpu` (in `experimental_pipelines.py`).

The `_inplace_copy_batch_size_logged` once-only guard is preserved, so steady-state cost is unchanged. `_batch_tensor_size()` is untouched (O(1) tensor metadata reads, no device-to-host sync). The helper import uses a `try`/`except` fallback for torch.package safety. Removes the now-unused `one_time_logger` and `LazyStr` imports from both files.

Reviewed By: TroyGarden

Differential Revision: D107941491


