### PR TITLE
Route clear_input_dist and free_features logging through event logger

### DIFF
--- a/torchrec/distributed/logging_handlers.py
+++ b/torchrec/distributed/logging_handlers.py
@@ -394,6 +394,48 @@ def log_ems_config(
     pass
 
 
+def log_inplace_copy_batch(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.INPLACE_COPY_BATCH,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_clear_input_dist_tensors(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.CLEAR_INPUT_DIST,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_free_features_storage_early(
+    size_bytes: int = 0,
+    technique: OptimizationTechnique = OptimizationTechnique.FREE_FEATURES_STORAGE_EARLY,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_ems_event(
+    event_name: str = "",
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMS,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
+def log_emo_event(
+    event_name: str = "",
+    metadata: Optional[Dict[str, str]] = None,
+    technique: OptimizationTechnique = OptimizationTechnique.EMO,
+) -> None:
+    """No-op OSS stub."""
+    pass
+
+
 def log_mpzch_summary(
     best_plan: Optional[List] = None,  # type: ignore[type-arg]
     technique: OptimizationTechnique = OptimizationTechnique.MPZCH,

--- a/torchrec/distributed/logging_utils.py
+++ b/torchrec/distributed/logging_utils.py
@@ -47,6 +47,9 @@ class OptimizationTechnique(Enum):
     MPZCH = "mpzch"
     KVZCH = "kvzch"
     ZORM = "zorm"
+    INPLACE_COPY_BATCH = "inplace_copy_batch"
+    CLEAR_INPUT_DIST = "clear_input_dist"
+    FREE_FEATURES_STORAGE_EARLY = "free_features_storage_early"
 
 
 @unique

--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -25,7 +25,7 @@ from typing import (
 
 import torch
 from torch.autograd.profiler import record_function
-from torchrec.distributed.logger import LazyStr, one_time_logger, one_time_rank0_logger
+from torchrec.distributed.logger import one_time_rank0_logger
 from torchrec.distributed.memory_stashing import MemoryStashingManager
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.train_pipeline.backward_injection import (
@@ -59,7 +59,10 @@ from torchrec.distributed.types import LazyNoWait, ShardingType
 from torchrec.sparse.jagged_tensor import KeyedTensor
 
 try:
-    from torchrec.distributed.logging_handlers import log_ems_config
+    from torchrec.distributed.logging_handlers import (
+        log_ems_config,
+        log_inplace_copy_batch,
+    )
     from torchrec.modules.embedding_configs import DATA_TYPE_NUM_BITS
 except Exception:
     torch._C._log_api_usage_once(
@@ -69,6 +72,9 @@ except Exception:
     DATA_TYPE_NUM_BITS: dict = {}  # type: ignore[no-redef]
 
     def log_ems_config(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
+        pass
+
+    def log_inplace_copy_batch(*args: Any, **kwargs: Any) -> None:  # type: ignore[misc]
         pass
 
 
@@ -780,11 +786,7 @@ class TrainPipelineSparseDistT(TrainPipelineSparseDist[In, Out]):
                     self._inplace_copy_batch_size_logged = True
                     size = _batch_tensor_size(batch)
 
-                    one_time_logger.info(
-                        LazyStr(
-                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
-                        )
-                    )
+                    log_inplace_copy_batch(size)
                 future_batch = self._copy_executor.submit(
                     _to_device,
                     batch,

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -40,31 +40,20 @@ from torchrec.distributed.embeddingbag import (
 )
 
 try:
-    from torchrec.distributed.logger import (
-        LazyStr,
-        one_time_logger,
-        one_time_rank0_logger,
-    )
+    from torchrec.distributed.logger import one_time_rank0_logger
 except Exception:
     # Safety measure against torch package issues: old packages may not have
     # these symbols in their archived torchrec.distributed.logger
     torch._C._log_api_usage_once(
         "torchrec.distributed.train_pipeline.train_pipelines.import_failure.logger"
     )
-    one_time_logger = logging.getLogger(__name__)
     one_time_rank0_logger = logging.getLogger(__name__)
-
-    class LazyStr:  # pyre-ignore[11]
-        def __init__(self, fn: Any) -> None:
-            self._fn = fn
-
-        def __str__(self) -> str:
-            return self._fn()
 
 
 try:
     from torchrec.distributed.logging_handlers import (
         EventLoggingHandler,
+        log_inplace_copy_batch,
         TorchrecComponent,
     )
 except Exception:
@@ -75,6 +64,7 @@ except Exception:
     if TYPE_CHECKING:
         from torchrec.distributed.logging_handlers import (
             EventLoggingHandler,
+            log_inplace_copy_batch,
             TorchrecComponent,
         )
     else:
@@ -90,6 +80,9 @@ except Exception:
                     return func
 
                 return decorator
+
+        def log_inplace_copy_batch(*args: object, **kwargs: object) -> None:
+            pass
 
 
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
@@ -355,9 +348,7 @@ class TrainPipelineBase(TrainPipeline[In, Out]):
                 self._inplace_copy_batch_size_logged = True
                 size = _batch_tensor_size(cur_batch)
 
-                one_time_logger.info(
-                    LazyStr(lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB")
-                )
+                log_inplace_copy_batch(size)
             with record_function("## inplace_copy_batch_to_gpu ##"):
                 self._cur_batch = _to_device(
                     cur_batch,
@@ -1093,11 +1084,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
                     self._inplace_copy_batch_size_logged = True
                     size = _batch_tensor_size(batch)
 
-                    one_time_logger.info(
-                        LazyStr(
-                            lambda: f"inplace_copy_batch size {size / 1024**3:.2f} GB"
-                        )
-                    )
+                    log_inplace_copy_batch(size)
                 batch = _to_device(
                     batch,
                     self._device,

--- a/torchrec/distributed/train_pipeline/utils.py
+++ b/torchrec/distributed/train_pipeline/utils.py
@@ -41,37 +41,35 @@ from torchrec.distributed.embedding_sharding import (
 from torchrec.distributed.embedding_types import KJTList
 
 try:
-    from torchrec.distributed.logging_handlers import log_pipeline_module_info
+    from torchrec.distributed.logging_handlers import (
+        log_clear_input_dist_tensors,
+        log_free_features_storage_early,
+        log_pipeline_module_info,
+    )
 except Exception:
     torch._C._log_api_usage_once(
         "torchrec.distributed.train_pipeline.utils.import_failure.logging_handlers"
     )
+
+    def log_clear_input_dist_tensors(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def log_free_features_storage_early(*args: Any, **kwargs: Any) -> None:
+        pass
 
     def log_pipeline_module_info(*args: Any, **kwargs: Any) -> None:
         pass
 
 
 try:
-    from torchrec.distributed.logger import (
-        LazyStr,
-        one_time_logger,
-        one_time_rank0_logger,
-    )
+    from torchrec.distributed.logger import one_time_rank0_logger
 except Exception:
     # Safety measure against torch package issues: old packages may not have
-    # LazyStr/one_time_logger in their archived torchrec.distributed.logger
+    # one_time_rank0_logger in their archived torchrec.distributed.logger
     torch._C._log_api_usage_once(
         "torchrec.distributed.train_pipeline.utils.import_failure.logger"
     )
 
-    class LazyStr:  # pyre-ignore[11]: Annotation for no-op fallback
-        def __init__(self, fn: Any) -> None:
-            self._fn = fn
-
-        def __str__(self) -> str:
-            return self._fn()
-
-    one_time_logger = logging.getLogger(__name__)
     one_time_rank0_logger = logging.getLogger(__name__)
 from torchrec.distributed.model_parallel import DistributedModelParallel, ShardedModule
 from torchrec.distributed.train_pipeline.pipeline_context import (
@@ -226,13 +224,7 @@ def _clear_releasable_inputs(context: TrainPipelineContext) -> None:
             size += kjt.clear_storage()
         early_released.clear()
     if size > 0:
-
-        def get_kjt_size() -> str:
-            msg: str = f"clear_releasable_inputs {size / 1024**3:.2f} GB"
-            logger.info(msg)
-            return msg
-
-        one_time_logger.info(LazyStr(get_kjt_size))
+        log_free_features_storage_early(size)
 
 
 def _clear_input_dist_tensors(context: TrainPipelineContext) -> None:
@@ -250,15 +242,7 @@ def _clear_input_dist_tensors(context: TrainPipelineContext) -> None:
                 if isinstance(awaitable, KJTAllToAllTensorsAwaitable):
                     size += awaitable.clear_inputs()
     if size > 0:
-
-        def get_size() -> str:
-            msg: str = (
-                f"clear_input_dist_tensors freed {size / 1024**3:.2f} GB ({size} bytes)"
-            )
-            logger.info(msg)
-            return msg
-
-        one_time_logger.info(LazyStr(get_size))
+        log_clear_input_dist_tensors(size)
 
 
 def _start_data_dist(


### PR DESCRIPTION
Summary:
Migrates two memory-technique size logs in `train_pipeline/utils.py` from the legacy free-text `one_time_logger`/`LazyStr` path to the structured event logger:
- `_clear_input_dist_tensors()` now calls `log_clear_input_dist_tensors(size)`.
- the `free_features_storage_early` (clear_releasable_inputs) path now calls `log_free_features_storage_early(size)`.

The `size > 0` guards are preserved at both sites. The helper imports use a `try`/`except` fallback. These were the last consumers of `one_time_logger`/`LazyStr` in the file, so those now-unused imports (and the `LazyStr` fallback shim) are removed; `one_time_rank0_logger` is kept (still used elsewhere).

Reviewed By: TroyGarden

Differential Revision: D107941492


