### PR TITLE
Implement preemption compatibility with TorchRec metrics for ALBT

### DIFF
--- a/torchrec/metrics/tests/test_throughput.py
+++ b/torchrec/metrics/tests/test_throughput.py
@@ -217,6 +217,70 @@ class ThroughputMetricTest(unittest.TestCase):
             },
         )
 
+    @patch(THROUGHPUT_PATH + ".time.monotonic")
+    def test_set_num_batch_selects_resumed_stage(self, time_mock: Mock) -> None:
+        # Seeding _num_batch (e.g. after an ALBT preemption resume) must select
+        # the batch_size_stage matching the resumed position instead of
+        # rewinding to the first stage.
+        time_mock.return_value = 1
+        batch_size_stages = [
+            BatchSizeStage(256, 10),
+            BatchSizeStage(512, 20),
+            BatchSizeStage(1024, None),
+        ]
+        throughput_metric = ThroughputMetric(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            window_seconds=100,
+            batch_size_stages=batch_size_stages,
+        )
+
+        # Resume in the middle stage (10 < num_batch <= 20).
+        throughput_metric.set_num_batch(15)
+        self.assertEqual(throughput_metric._num_batch, 15)
+
+        # The first update() of the resumed run pre-increments to 16, which is
+        # still within the second stage -> reports 512, not 256.
+        throughput_metric.update()
+        self.assertEqual(
+            throughput_metric.compute()["throughput-throughput|batch_size"],
+            512,
+        )
+
+    @patch(THROUGHPUT_PATH + ".time.monotonic")
+    def test_set_num_batch_resumes_into_final_stage(self, time_mock: Mock) -> None:
+        time_mock.return_value = 1
+        batch_size_stages = [BatchSizeStage(256, 1), BatchSizeStage(512, None)]
+        throughput_metric = ThroughputMetric(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            window_seconds=100,
+            batch_size_stages=batch_size_stages,
+        )
+
+        # Resume well past the first stage (max_iters=1).
+        throughput_metric.set_num_batch(5)
+        throughput_metric.update()
+        self.assertEqual(
+            throughput_metric.compute()["throughput-throughput|batch_size"],
+            512,
+        )
+
+    def test_set_num_batch_without_batch_size_stages_is_noop(self) -> None:
+        # Without batch_size_stages (non-ALBT job) set_num_batch must be a no-op:
+        # the metric never tracks _num_batch and keeps the default batch size.
+        throughput_metric = ThroughputMetric(
+            batch_size=self.batch_size,
+            world_size=self.world_size,
+            window_seconds=100,
+            batch_size_stages=None,
+        )
+
+        throughput_metric.set_num_batch(100)
+
+        self.assertFalse(hasattr(throughput_metric, "_num_batch"))
+        self.assertEqual(throughput_metric._get_batch_size(), self.batch_size)
+
     def test_num_batch_without_batch_size_stages(self) -> None:
         # Create the module without the batch_size_stages
         throughput_metric = ThroughputMetric(

--- a/torchrec/metrics/throughput.py
+++ b/torchrec/metrics/throughput.py
@@ -178,6 +178,14 @@ class ThroughputMetric(nn.Module):
         )
         self._steps = 0
 
+    def set_num_batch(self, num_batch: int) -> None:
+        # Seed the batch counter used to select the current batch_size_stage.
+        # Used after a checkpoint resume (e.g. ALBT preemption) to restore the
+        # number of batches already processed so the reported batch size matches
+        # the active stage. No-op when batch_size_stages is not in use.
+        if self._batch_size_stages is not None:
+            self._num_batch = num_batch
+
     def _get_batch_size(self) -> int:
         # No batch size stages, use the default batch size
         if not self._batch_size_stages:


### PR DESCRIPTION
Summary:
Fixes ALBT batch-size reporting on Tensorboard after a preemption/resume.

torchrec's `ThroughputMetric` keeps a private `_num_batch` counter that drives which `batch_size_stage` is active. In the Pyper/sync_sgd flow the metrics module is not part of the sharded checkpoint, so on resume `_num_batch` resets to 0 and the reported batch size incorrectly rewinds to the first stage.

This diff seeds `_num_batch` from the authoritative resume position — the VBS controller's `num_batches_retrieved` (checkpoint key `iter_step`) — so the reported batch size matches the active stage after resume.

Differential Revision: D108047620


