### PR TITLE
Fix nightly validate-binaries for Python 3.14: add conda-forge channel

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -73,6 +73,9 @@ elif [[ ${MATRIX_PYTHON_VERSION} = '3.13t' ]]; then
     # use conda-forge to install python3.13t
     conda create -y -n "${CONDA_ENV}" python="3.13" python-freethreading -c conda-forge
     conda run -n "${CONDA_ENV}" python -c "import sys; print(f'python GIL enabled: {sys._is_gil_enabled()}')"
+elif [[ ${MATRIX_PYTHON_VERSION} = '3.14' ]]; then
+    # conda currently doesn't support 3.14 unless using the forge channel
+    conda create -y -n "${CONDA_ENV}" python="3.14" -c conda-forge
 else
     conda create -y -n "${CONDA_ENV}" python="${MATRIX_PYTHON_VERSION}"
 fi


### PR DESCRIPTION
Summary:
The nightly smoke-test conda env-creation block in `validate_binaries.sh`
routes plain Python 3.14 into the bare `else` branch, which runs
`conda create -y -n build_binary python=3.14` WITHOUT `-c conda-forge`.
Python 3.14 is not available in conda's default channels, so the
`linux-manywheel-3.14-cu130` nightly job fails at environment creation,
before any wheel install or `import torchrec`.

The release/pypi path later in the same script already handles this
correctly (`conda create ... python=3.14 -c conda-forge`, with an
explanatory comment). This change mirrors that handling into the nightly
block by adding a `3.14` branch before the `else`.

Note on root cause: all cp314+cu130 wheels (torch, fbgemm_gpu) and the
torchrec `py3-none-any` wheel are published on download.pytorch.org, so
this is a conda-env-setup gap, not wheel availability. It is also
unrelated to the logging_handlers stubs (D107941494/PR #4329), which
already exist on master.

Differential Revision: D108174244


