### PR TITLE
Load ir_metadata_tensor from bytearray

### DIFF
--- a/torchrec/ir/serializer.py
+++ b/torchrec/ir/serializer.py
@@ -206,7 +206,7 @@ class JsonSerializer(SerializerInterface):
         metadata_dict = serializer.serialize_to_dict(module)
         raw_dict = {"typename": typename, "metadata_dict": metadata_dict}
         ir_metadata_tensor = torch.frombuffer(
-            json.dumps(raw_dict).encode(), dtype=torch.uint8
+            bytearray(json.dumps(raw_dict).encode(), dtype=torch.uint8)
         )
         module.register_buffer("ir_metadata", ir_metadata_tensor, persistent=False)
         serializer.swap_meta_forward(module)


### PR DESCRIPTION
In Python 3.13 there are stricter checks for buffer protocol slots and when torch.frombuffer interacts with a read-only bytes buffer, it triggers a C-level assertion / exception (_Py_CheckSlotResult) leading to a runtime crash.

This solves the issue by allocating a writable buffer before passing to `torch.frombuffer`.

(Though I would not expect `torch.frombuffer` to require a writable buffer, so maybe this is also a bug upstream in `torch`?)