### PR TITLE
Replace deprecated _check_is_size and guard_size_oblivious

### DIFF
--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -10,7 +10,7 @@
 from typing import List
 
 import torch
-from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
 
 USE_TORCHDYNAMO_COMPILING_PATH: bool = False
 
@@ -66,9 +66,9 @@ def pt2_checks_tensor_slice(
     if torch.jit.is_scripting() or not is_pt2_compiling():
         return
 
-    torch._check_is_size(start_offset)
-    torch._check_is_size(end_offset)
-    torch._check_is_size(end_offset - start_offset)
+    torch._check(start_offset >= 0)
+    torch._check(end_offset >= 0)
+    torch._check(end_offset - start_offset >= 0)
     torch._check(start_offset <= tensor.size(dim))
     torch._check(end_offset <= tensor.size(dim))
     torch._check(end_offset >= start_offset)
@@ -79,7 +79,7 @@ def pt2_checks_all_is_size(x: List[int]) -> List[int]:
         return x
 
     for i in x:
-        torch._check_is_size(i)
+        torch._check(i >= 0)
     return x
 
 
@@ -92,8 +92,15 @@ def pt2_check_size_nonzero(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def pt2_guard_size_oblivious(x: bool) -> bool:
+def pt2_guard_or_false(x: bool) -> bool:
     if torch.jit.is_scripting() or not is_pt2_compiling():
         return x
 
-    return guard_size_oblivious(x)
+    return guard_or_false(x)
+
+
+def pt2_guard_or_true(x: bool) -> bool:
+    if torch.jit.is_scripting() or not is_pt2_compiling():
+        return x
+
+    return guard_or_true(x)

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -23,7 +23,8 @@ from torchrec.pt2.checks import (
     pt2_check_size_nonzero,
     pt2_checks_all_is_size,
     pt2_checks_tensor_slice,
-    pt2_guard_size_oblivious,
+    pt2_guard_or_false,
+    pt2_guard_or_true,
 )
 from torchrec.streamable import Pipelineable
 
@@ -1249,7 +1250,7 @@ def _assert_tensor_has_no_elements_or_has_integers(
         # TODO(ivankobzarev): Use guard_size_oblivious to pass tensor.numel() == 0 once it is torch scriptable.
         return
 
-    assert pt2_guard_size_oblivious(tensor.numel() == 0) or tensor.dtype in [
+    assert pt2_guard_or_false(tensor.numel() == 0) or tensor.dtype in [
         torch.long,
         torch.int,
         torch.short,
@@ -1389,7 +1390,7 @@ def _maybe_compute_length_per_key(
                         pt2_check_size_nonzero(lengths.view(len(keys), stride)), dim=1
                     )
                 )
-                if pt2_guard_size_oblivious(lengths.numel() != 0)
+                if pt2_guard_or_true(lengths.numel() != 0)
                 else [0] * len(keys)
             )
         )
@@ -1602,7 +1603,7 @@ def _maybe_compute_kjt_to_jt_dict(
             cat_size += i
             torch._check(cat_size <= total_size)
         torch._check(cat_size == total_size)
-        torch._check_is_size(stride)
+        torch._check(stride >= 0)
 
     values_list = torch.split(values, length_per_key)
     split_offsets: list[torch.Tensor] = []
@@ -1613,7 +1614,7 @@ def _maybe_compute_kjt_to_jt_dict(
                 torch.ops.fbgemm.asynchronous_complete_cumsum(lengths)
                 for lengths in split_lengths
             ]
-    elif pt2_guard_size_oblivious(lengths.numel() > 0):
+    elif pt2_guard_or_true(lengths.numel() > 0):
         strided_lengths = lengths.view(len(keys), stride)
         if not torch.jit.is_scripting() and is_torchdynamo_compiling():
             torch._check(strided_lengths.size(0) > 0)
@@ -2731,10 +2732,10 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
                 if not torch.jit.is_scripting() and is_non_strict_exporting():
                     sz = sum(split_length_per_key)
 
-                    [torch._check_is_size(length) for length in split_length_per_key]
+                    [torch._check(length >= 0) for length in split_length_per_key]
                     torch._check(start_offset <= self._values.size(0))
                     torch._check(sz <= self._values.size(0))
-                    torch._check_is_size(start_offset)
+                    torch._check(start_offset >= 0)
 
                     torch._check(start_offset + sz <= self._values.size(0))
 
@@ -2854,7 +2855,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
         permuted_length_per_key_sum = sum(permuted_length_per_key)
         if not torch.jit.is_scripting() and is_non_strict_exporting():
-            torch._check_is_size(permuted_length_per_key_sum)
+            torch._check(permuted_length_per_key_sum >= 0)
             torch._check(permuted_length_per_key_sum != -1)
             torch._check(permuted_length_per_key_sum != 0)
 
@@ -2973,8 +2974,8 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             )
             sz = length_per_key[index]
 
-            torch._check_is_size(start_offset)
-            torch._check_is_size(sz)
+            torch._check(start_offset >= 0)
+            torch._check(sz >= 0)
             torch._check(start_offset <= self.values().size(0))
             torch._check(sz <= self.values().size(0))
 


### PR DESCRIPTION
Summary:
## Problem

`torch._check_is_size` and `guard_size_oblivious` emit `FutureWarning`s on every call:

```
FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious. Use _check(i >= 0) instead.

FutureWarning: guard_size_oblivious will be removed. Consider using explicit unbacked handling potentially utilizing guard_or_false, guard_or_true, or statically_known_true
```

## Fix

1. `torch._check_is_size(i)` → `torch._check(i >= 0)` — per the deprecation message.
2. Remove the deprecated `pt2_guard_size_oblivious` helper (a thin wrapper over `guard_size_oblivious`) and replace it with two new helpers in `torchrec/pt2/checks.py` — `pt2_guard_or_false` and `pt2_guard_or_true` (wrapping `guard_or_false` / `guard_or_true`). Each of its 3 call sites in `torchrec/sparse/jagged_tensor.py` is repointed to whichever helper preserves the original size-oblivious result: `tensor.numel() == 0` → `pt2_guard_or_false`; `lengths.numel() != 0` and `lengths.numel() > 0` → `pt2_guard_or_true`.

## Prod Safety

`_check_is_size(i)` was semantically equivalent to `_check(i >= 0)` with additional size-oblivious hints for the compiler. The replacement `_check(i >= 0)` is the explicitly recommended migration path from the PyTorch deprecation.

`guard_size_oblivious(cond)` evaluates `cond` while treating unbacked sizes as if they are non-zero, so on a data-dependent guard it effectively resolves `== 0` checks to `False` and `!= 0` / `> 0` checks to `True`. To preserve that behavior exactly, the `numel() == 0` site uses `pt2_guard_or_false` (data-dependent → `False`, i.e. treated as non-empty) and the `numel() != 0` / `numel() > 0` sites use `pt2_guard_or_true` (data-dependent → `True`). This avoids the behavior change that a blanket `guard_or_false` replacement would have introduced for the latter two sites (per shuaiyang's review).

Reviewed By: Microve

Differential Revision: D100530526


