### PR TITLE
defensive snapshot of model_out via torch._foreach_clone

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -135,6 +135,43 @@ def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
     )
 
 
+def _foreach_clone_dict(d: Mapping[str, Any]) -> Dict[str, Any]:
+    """Batched clone of tensor values; one PyBind crossing for N tensors."""
+    tensor_keys: list[str] = []
+    tensor_values: list[torch.Tensor] = []
+    out: Dict[str, Any] = {}
+    for k, v in d.items():
+        if isinstance(v, torch.Tensor):
+            tensor_keys.append(k)
+            tensor_values.append(v)
+        else:
+            out[k] = v
+    if tensor_values:
+        # no_grad bypasses the autograd dispatch on _foreach_clone, which
+        # rejects integer dtypes (e.g., int labels/required_inputs).
+        with torch.no_grad():
+            cloned = torch._foreach_clone(tensor_values)
+        for k, t in zip(tensor_keys, cloned):
+            out[k] = t
+    return out
+
+
+def _foreach_clone_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in kwargs.items():
+        if isinstance(v, dict):
+            out[k] = _foreach_clone_dict(v)
+        else:
+            out[k] = v
+    top_keys = [k for k, v in out.items() if isinstance(v, torch.Tensor)]
+    if top_keys:
+        with torch.no_grad():
+            cloned = torch._foreach_clone([out[k] for k in top_keys])
+        for k, t in zip(top_keys, cloned):
+            out[k] = t
+    return out
+
+
 class CPUOffloadedRecMetricModule(RecMetricModule):
     """
     RecMetricModule that offloads metric update() and compute() to CPU using background threads.
@@ -303,11 +340,14 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             assert self._captured_exception is not None
             raise self._captured_exception
 
+        snapshot_model_out = _foreach_clone_dict(model_out)
+        snapshot_kwargs = _foreach_clone_kwargs(kwargs)
+
         try:
             self.update_queue.put_nowait(
                 MetricUpdateJob(
-                    model_out=model_out,
-                    kwargs=kwargs,
+                    model_out=snapshot_model_out,
+                    kwargs=snapshot_kwargs,
                 )
             )
             self._total_updates_enqueued += 1

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -20,6 +20,8 @@ import torch.distributed as dist
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.metrics.cpu_offloaded_metric_module import (
+    _foreach_clone_dict,
+    _foreach_clone_kwargs,
     _merge_update_jobs,
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
@@ -1649,6 +1651,56 @@ class MergeUpdateJobsTest(unittest.TestCase):
         ]
         merged = _merge_update_jobs(jobs)
         self.assertEqual(merged.kwargs.get("required_inputs"), {})
+
+
+class ForeachCloneTest(unittest.TestCase):
+    def test_int_tensors_clone_without_autograd_error(self) -> None:
+        d = {
+            "labels": torch.tensor([0, 1, 0], dtype=torch.int64),
+            "weights": torch.tensor([1.0, 1.0, 1.0], requires_grad=True),
+        }
+        out = _foreach_clone_dict(d)
+        self.assertEqual(out["labels"].dtype, torch.int64)
+        self.assertEqual(out["weights"].dtype, torch.float32)
+        torch.testing.assert_close(out["labels"], d["labels"])
+        torch.testing.assert_close(out["weights"], d["weights"])
+        self.assertFalse(out["weights"].requires_grad)
+
+    def test_kwargs_with_int_required_inputs(self) -> None:
+        kwargs = {
+            "required_inputs": {
+                "feature_id": torch.tensor([1, 2, 3], dtype=torch.int32),
+            },
+            "scale": torch.tensor([0.5], requires_grad=True),
+        }
+        out = _foreach_clone_kwargs(kwargs)
+        self.assertEqual(out["required_inputs"]["feature_id"].dtype, torch.int32)
+        torch.testing.assert_close(
+            out["required_inputs"]["feature_id"],
+            kwargs["required_inputs"]["feature_id"],
+        )
+        self.assertFalse(out["scale"].requires_grad)
+
+    def test_dict_clone_independent_of_caller_mutation(self) -> None:
+        """Reproduces the Pyper metric_update_reorder staleness bug at the helper
+        level: caller mutates the source tensor in place after we clone, and the
+        clone must still hold the pre-mutation value. Without _foreach_clone the
+        snapshot would be a reference and silently observe the new value."""
+        src = {
+            "predictions": torch.tensor([1.0, 2.0, 3.0]),
+            "labels": torch.tensor([0, 1, 0], dtype=torch.int64),
+        }
+        snapshot = _foreach_clone_dict(src)
+        # Caller overwrites the underlying storage (like Pyper's pre-allocated
+        # model_out buffer being reused for the next iteration).
+        src["predictions"].zero_()
+        src["labels"].fill_(7)
+        torch.testing.assert_close(
+            snapshot["predictions"], torch.tensor([1.0, 2.0, 3.0])
+        )
+        torch.testing.assert_close(
+            snapshot["labels"], torch.tensor([0, 1, 0], dtype=torch.int64)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Take a defensive batched clone of `model_out` (and any tensor kwargs) in `_update_rec_metrics` before enqueueing a `MetricUpdateJob`, so the worker thread always observes a stable snapshot regardless of what the caller does with its references after `update()` returns.

Differential Revision: D107427093


