### PR TITLE
re-pin metric state to CPU after load_state_dict

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -285,6 +285,10 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         atexit.register(self.shutdown)
 
+        self.register_load_state_dict_post_hook(
+            CPUOffloadedRecMetricModule._move_state_to_cpu_after_load
+        )
+
         logger.info(
             f"CPUOffloadedRecMetricModule initialization complete with {model_out_device.type=}, {update_queue_size=}, {compute_queue_size=}."
         )
@@ -325,8 +329,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         self, model_out: Dict[str, torch.Tensor], **kwargs: Any
     ) -> None:
         """
-        Called during RecMetricModule.update(). Start a non-blocking transfer of
-        the model outputs and append a MetricUpdateJob to the update queue.
+        Called during RecMetricModule.update(). Snapshot the model outputs
+        via a single batched clone, then enqueue a MetricUpdateJob.
 
         Args:
             model_out: intermediate model outputs to be used for metric updates
@@ -937,3 +941,47 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         and is essentially "discarded" after compute().
         """
         pass
+
+    @staticmethod
+    def _move_state_to_cpu_after_load(
+        module: torch.nn.Module, incompatible_keys: Any
+    ) -> None:
+        """`load_state_dict` post-hook: move any non-CPU metric state back to CPU.
+
+        torchmetrics `add_state` stores state via `setattr` (not `register_buffer`),
+        and `_load_from_state_dict` writes loaded tensors the same way — so checkpoint
+        restores can deposit cuda state on a CPU-only metric, crashing the next
+        `update()`. Walk `_reductions` on each `RecMetricComputation` and move via
+        getattr/setattr.
+        """
+        if not isinstance(module, CPUOffloadedRecMetricModule):
+            return
+        moved = 0
+        with torch.no_grad():
+            for metric in module.rec_metrics.rec_metrics:
+                for comp in metric._metrics_computations:  # pyre-ignore[16]
+                    for attr_name in comp._reductions:
+                        state = getattr(comp, attr_name, None)
+                        if isinstance(state, torch.Tensor):
+                            if state.device.type != "cpu":
+                                setattr(comp, attr_name, state.cpu())
+                                moved += 1
+                        elif isinstance(state, list):
+                            list_moved = False
+                            new_list = []
+                            for x in state:
+                                if (
+                                    isinstance(x, torch.Tensor)
+                                    and x.device.type != "cpu"
+                                ):
+                                    new_list.append(x.cpu())
+                                    list_moved = True
+                                else:
+                                    new_list.append(x)
+                            if list_moved:
+                                setattr(comp, attr_name, new_list)
+                                moved += 1
+        if moved:
+            logger.info(
+                f"CPUOffloadedRecMetricModule: moved {moved} state tensors to CPU after load_state_dict"
+            )

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -7,6 +7,7 @@
 
 # pyre-strict
 
+import logging
 import os
 import queue
 import threading
@@ -1701,6 +1702,86 @@ class ForeachCloneTest(unittest.TestCase):
         torch.testing.assert_close(
             snapshot["labels"], torch.tensor([0, 1, 0], dtype=torch.int64)
         )
+
+
+class LoadStateDictDevicePinTest(unittest.TestCase):
+    """`load_state_dict` post-hook re-pins metric state to CPU after restore."""
+
+    def setUp(self) -> None:
+        self.tasks = gen_test_tasks(["task1"])
+        self.initial_states = create_tensor_states(["cross_entropy_sum"])
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["LOCAL_WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["GLOO_DEVICE_TRANSPORT"] = "TCP"
+        self.mock_metric = MockRecMetric(
+            world_size=1,
+            my_rank=0,
+            batch_size=1,
+            tasks=self.tasks,
+            initial_states=self.initial_states,
+        )
+        self.rec_metrics = RecMetricList([self.mock_metric])
+        dist.init_process_group("gloo")
+
+    def tearDown(self) -> None:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        if hasattr(self, "cpu_module"):
+            try:
+                self.cpu_module.shutdown()
+            except RecMetricException as e:
+                # shutdown() raises RecMetricException on thread-stuck / captured-exception paths;
+                # tearDown must not propagate (would mask the real test failure), but log so it's visible.
+                logging.warning(
+                    "CPUOffloadedRecMetricModule.shutdown() failed in tearDown: %s", e
+                )
+
+    def _make_module(self) -> CPUOffloadedRecMetricModule:
+        self.cpu_module = CPUOffloadedRecMetricModule(
+            model_out_device=torch.device("cpu"),
+            batch_size=1,
+            world_size=1,
+            rec_tasks=self.tasks,
+            rec_metrics=self.rec_metrics,
+        )
+        return self.cpu_module
+
+    def _get_first_state(self, module: CPUOffloadedRecMetricModule) -> torch.Tensor:
+        # pyrefly: ignore[bad-index]
+        first_comp = module.rec_metrics.rec_metrics[0]._metrics_computations[
+            0
+        ]  # pyre-ignore[16]
+        for attr_name in first_comp._reductions:  # pyre-ignore[16]
+            state = getattr(first_comp, attr_name, None)
+            if isinstance(state, torch.Tensor):
+                return state
+        self.fail("No tensor state found")
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "needs GPU")
+    def test_post_hook_moves_cuda_state_in_reductions_to_cpu(self) -> None:
+        cpu_module = self._make_module()
+        # pyrefly: ignore[bad-index]
+        first_comp = cpu_module.rec_metrics.rec_metrics[0]._metrics_computations[
+            0
+        ]  # pyre-ignore[16]
+        attr_name = next(iter(first_comp._reductions))  # pyre-ignore[16]
+        with torch.no_grad():
+            # Citrine C7: prefer .to("cuda") over deprecated .cuda()
+            setattr(first_comp, attr_name, getattr(first_comp, attr_name).to("cuda"))
+        self.assertEqual(getattr(first_comp, attr_name).device.type, "cuda")
+        CPUOffloadedRecMetricModule._move_state_to_cpu_after_load(cpu_module, None)
+        self.assertEqual(getattr(first_comp, attr_name).device.type, "cpu")
+
+    def test_post_hook_no_op_when_already_cpu(self) -> None:
+        cpu_module = self._make_module()
+        before = self._get_first_state(cpu_module).clone()
+        CPUOffloadedRecMetricModule._move_state_to_cpu_after_load(cpu_module, None)
+        after = self._get_first_state(cpu_module)
+        self.assertEqual(after.device.type, "cpu")
+        torch.testing.assert_close(before, after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Adds a `load_state_dict` post-hook to `CPUOffloadedRecMetricModule` that re-pins every metric state tensor to CPU after a checkpoint restore.

torchmetrics' `add_state` stores state via `setattr` (not `register_buffer`), and `_load_from_state_dict` writes loaded tensors the same way. If a saved checkpoint has metric state on cuda (or load deposits cuda state by any other path), the restored attribute is on cuda — and the next `update()` crashes with `RuntimeError: Expected all tensors to be on the same device` because the rest of ZORM's metric pipeline runs on CPU.

The hook walks `_reductions` on each `RecMetricComputation` and re-pins any non-cpu state via getattr/setattr. No-op when state is already on cpu.

Reviewed By: yashasingh

Differential Revision: D108029503


