### PR TITLE
Pin torch to fbgemm_gpu-compatible version in unit-test CI (release/test)

### DIFF
--- a/.github/workflows/unittest_ci.yml
+++ b/.github/workflows/unittest_ci.yml
@@ -127,15 +127,34 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/${{ matrix.cuda-tag }}
         fi
         echo "index_url: $index_url"
-        conda run -n build_binary \
-          pip install torch --index-url $index_url
+        # For release/test channels, a published fbgemm_gpu release is ABI-locked
+        # to a specific torch (fbgemm 1.X is built against torch 2.(X+5)); the
+        # latest stable torch can be newer than the latest fbgemm release (e.g.
+        # torch 2.12 vs fbgemm 1.6) and crash on import with
+        # "fbgemm_gpu_config.so: undefined symbol: ..._ZNR5torch7Library4_defE...".
+        # So install fbgemm-gpu first and pin torch to the version matching the
+        # fbgemm that actually installed. Nightly stays floating (torch/fbgemm
+        # nightlies share a daily cadence; their dev/date versions can't be mapped).
+        if [[ "${{ inputs.channel }}" = "release" || "${{ inputs.channel }}" = "test" ]]; then
+          conda run -n build_binary \
+            pip install fbgemm-gpu --index-url $index_url
+          fbgemm_ver=$(conda run -n build_binary pip show fbgemm_gpu | grep Version | cut -d' ' -f2)
+          fbgemm_minor=$(echo "$fbgemm_ver" | cut -d'.' -f2)
+          compat_torch="2.$((fbgemm_minor + 5))"
+          echo "Installed fbgemm_gpu=$fbgemm_ver -> pinning torch==${compat_torch}.*"
+          conda run -n build_binary \
+            pip install "torch==${compat_torch}.*" --index-url $index_url
+        else
+          conda run -n build_binary \
+            pip install torch --index-url $index_url
+          conda run -n build_binary \
+            pip install fbgemm-gpu --index-url $index_url
+        fi
         conda run -n build_binary \
           python -c "import torch; print(torch.__version__)"
         echo "torch succeeded"
         conda run -n build_binary \
           python -c "import torch.distributed"
-        conda run -n build_binary \
-          pip install fbgemm-gpu --index-url $index_url
         conda run -n build_binary \
           python -c "import fbgemm_gpu; print(fbgemm_gpu.__version__)"
         echo "fbgemm_gpu succeeded"

--- a/.github/workflows/unittest_ci_cpu.yml
+++ b/.github/workflows/unittest_ci_cpu.yml
@@ -102,15 +102,34 @@ jobs:
           index_url=https://download.pytorch.org/whl/${{ inputs.channel }}/cpu
         fi
         echo "index_url: $index_url"
-        conda run -n build_binary \
-          pip install torch --index-url $index_url
+        # For release/test channels, a published fbgemm_gpu release is ABI-locked
+        # to a specific torch (fbgemm 1.X is built against torch 2.(X+5)); the
+        # latest stable torch can be newer than the latest fbgemm release (e.g.
+        # torch 2.12 vs fbgemm 1.6) and crash on import with
+        # "fbgemm_gpu_config.so: undefined symbol: ..._ZNR5torch7Library4_defE...".
+        # So install fbgemm-gpu first and pin torch to the version matching the
+        # fbgemm that actually installed. Nightly stays floating (torch/fbgemm
+        # nightlies share a daily cadence; their dev/date versions can't be mapped).
+        if [[ "${{ inputs.channel }}" = "release" || "${{ inputs.channel }}" = "test" ]]; then
+          conda run -n build_binary \
+            pip install fbgemm-gpu --index-url $index_url
+          fbgemm_ver=$(conda run -n build_binary pip show fbgemm_gpu | grep Version | cut -d' ' -f2)
+          fbgemm_minor=$(echo "$fbgemm_ver" | cut -d'.' -f2)
+          compat_torch="2.$((fbgemm_minor + 5))"
+          echo "Installed fbgemm_gpu=$fbgemm_ver -> pinning torch==${compat_torch}.*"
+          conda run -n build_binary \
+            pip install "torch==${compat_torch}.*" --index-url $index_url
+        else
+          conda run -n build_binary \
+            pip install torch --index-url $index_url
+          conda run -n build_binary \
+            pip install fbgemm-gpu --index-url $index_url
+        fi
         conda run -n build_binary \
           python -c "import torch; print(torch.__version__)"
         echo "torch succeeded"
         conda run -n build_binary \
           python -c "import torch.distributed"
-        conda run -n build_binary \
-          pip install fbgemm-gpu --index-url $index_url
         conda run -n build_binary \
           python -c "import fbgemm_gpu; print(fbgemm_gpu.__version__)"
         echo "fbgemm_gpu succeeded"


### PR DESCRIPTION
Summary:
unittest_ci_cpu.yml and unittest_ci.yml each have their own inline install
block that does an unpinned `pip install torch` followed by `pip install
fbgemm-gpu` from the channel index. On the release/test channels this floats
torch to the latest stable while fbgemm-gpu floats to its (older) latest
release. A published fbgemm_gpu release is ABI-locked to a specific torch
(fbgemm 1.X is built against torch 2.(X+5)), so the latest stable torch can be
newer than the newest fbgemm release (e.g. torch 2.12 vs fbgemm 1.6) and crash
on import:

  fbgemm_gpu_config.so: undefined symbol: ..._ZNR5torch7Library4_defE...
  (torch::Library::_def)

This is the same ABI mismatch fixed for the binary-validation smoke test in
D108214875 (validate_binaries.sh); these unit-test workflows have a separate
copy of the buggy install and are not covered by that diff.

Fix (mirrors D108214875, adapted inline since these workflows don't define
get_expected_torch_version): for release/test channels, install fbgemm-gpu
FIRST, read the installed version, derive the compatible torch via the X+5 rule
(fbgemm 1.X -> torch 2.(X+5)), and pin `torch==<that>.*`. Nightly (and the
empty/default channel on push/PR, which resolves to the nightly index) keeps
the floating install — torch and fbgemm nightlies share a daily build cadence
and their dev/date versions can't be mapped by the X+5 rule.

Both the CPU (unittest_ci_cpu.yml) and GPU (unittest_ci.yml) workflows are
fixed identically. The existing post-install verification (torch version
print, `import torch.distributed`, fbgemm version print) is preserved, moved
after the install branch.

Differential Revision: D108311734


