### PR TITLE
Bug Fixes and Refactor

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -1033,14 +1033,6 @@ def _run_cuda_profiling(
     """Run optional CUDA profiling with chrome trace export and memory snapshot."""
 
     def _trace_handler(prof: torch.profiler.profile) -> None:
-        try:
-            # pyrefly: ignore[missing-attribute]
-            total_avg = prof.profiler.total_average()
-            logger.info(f" TOTAL_AVERAGE:\n{name}\n{total_avg}")
-        except RecursionError:
-            logger.warning(
-                f"Skipping total_average for {name} due to deep profiler event tree"
-            )
         if not all_rank_traces and rank > 0:
             # only save trace for rank 0 when all_rank_traces is disabled
             return

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -357,6 +357,9 @@ def run_pipeline(
     metric_config: RecMetricConfig,
 ) -> BenchmarkResult:
     tables, weighted_tables, *_ = table_config.generate_tables()
+    table_extended_config = TableExtendedConfigs(
+        mc_configs=table_config.mc_configs_per_table,
+    )
 
     benchmark_res_per_rank = run_multi_process_func(
         func=runner,
@@ -370,6 +373,7 @@ def run_pipeline(
         planner_config=planner_config,
         sharding_config=sharding_config,
         metric_config=metric_config,
+        table_related_configs=table_extended_config,
     )
 
     # Combine results from all ranks into a single BenchmarkResult
@@ -418,26 +422,18 @@ def main(
 
         attach_debugger()
 
-    tables, weighted_tables, *_ = table_config.generate_tables()
-    table_extended_config = TableExtendedConfigs(
-        mc_configs=table_config.mc_configs_per_table,
-    )
     model_config = model_selection.create_model_config()
 
     # launch trainers
-    run_multi_process_func(
-        func=runner,
-        world_size=run_option.world_size,
-        tables=tables,
-        weighted_tables=weighted_tables,
+    run_pipeline(
         run_option=run_option,
-        model_config=model_config,
+        table_config=table_config,
         pipeline_config=pipeline_config,
+        model_config=model_config,
         input_config=input_config,
         planner_config=planner_config,
         sharding_config=sharding_config,
         metric_config=metric_config,
-        table_related_configs=table_extended_config,
     )
 
 

--- a/torchrec/distributed/benchmark/utils.py
+++ b/torchrec/distributed/benchmark/utils.py
@@ -300,7 +300,7 @@ def dump_benchmark_result(
 
     path = os.path.join(
         output_dir,
-        f"torchrec_benchmark_{result.short_name}_{result.rank}.json",
+        f"torchrec_benchmark_{result.short_name}_{result.rank}_{test_name}.json",
     )
     os.makedirs(output_dir, exist_ok=True)
     with open(path, "w") as fh:

--- a/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
+++ b/torchrec/distributed/benchmark/yaml/base_pipeline_light.yml
@@ -2,8 +2,8 @@
 # runs on 2 ranks, showing traces with reasonable workloads
 RunOptions:
   world_size: 2
-  num_batches: 10
-  num_benchmarks: 1
+  num_batches: 20
+  num_benchmarks: 5
   num_profiles: 1
   sharding_type: table_wise
   profile_dir: "."

--- a/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
+++ b/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
@@ -7,8 +7,8 @@
 #     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/metric_scaling_prod.yml
 RunOptions:
   world_size: 2
-  num_batches: 10
-  num_benchmarks: 3
+  num_batches: 20
+  num_benchmarks: 5
   num_profiles: 1
   num_iters: 100
   profile_dir: "."

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_base.yml
@@ -2,8 +2,8 @@
 # runs on 2 ranks, showing traces with reasonable workloads
 RunOptions:
   world_size: 2
-  num_batches: 10
-  num_benchmarks: 1
+  num_batches: 20
+  num_benchmarks: 5
   num_profiles: 1
   sharding_type: table_wise
   profile_dir: "."

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_lite.yml
@@ -2,8 +2,8 @@
 # runs on 2 ranks, showing traces with reasonable workloads
 RunOptions:
   world_size: 2
-  num_batches: 10
-  num_benchmarks: 1
+  num_batches: 20
+  num_benchmarks: 5
   num_profiles: 1
   sharding_type: table_wise
   profile_dir: "."

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -10,6 +10,7 @@ RunOptions:
   profile_dir: "."
   name: "sparse_data_dist_mpzch"
   num_float_features: 1000
+  loglevel: "info"
 PipelineConfig:
   pipeline: "sparse"
 ModelInputConfig:


### PR DESCRIPTION
Summary:
### Summary

This diff combines several bug fixes and refactors:

1. **Add info-level logging** for the MPZCH benchmark to make debugging easier.
2. **Remove `total_average` computation** during benchmark profiling. The value isn’t consumed, and computing it is expensive.
3. **Refactor `run_pipeline` and add the missing `table_config`**, which previously caused inconsistent benchmark behavior between local (OSS) and remote runs.
4. **Update benchmark result JSON naming** to include `test_name`. For single-config RE targets, also append the iteration index to `test_name` to avoid outputs from multiple runs overwriting each other.
5. **Update default benchmark and batching run counts** to improve local stability. Many benchmarks currently default to **10 batches** and **1 benchmark run**, which can produce noisy results. CI already overrides these to **20 batches** and **5 benchmark runs**; this change makes the local defaults match CI for more stable numbers.

Reviewed By: jeffkbkim

Differential Revision: D108247815


