### PR TITLE
Make iopath an optional dependency for dataset loaders

### DIFF
--- a/install-requirements.txt
+++ b/install-requirements.txt
@@ -3,4 +3,3 @@ tensordict
 torchmetrics==1.0.3
 tqdm
 pyre-extensions
-iopath

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,11 @@ def main(argv: List[str]) -> None:
         ],
         python_requires=">=3.10",
         install_requires=install_requires,
+        extras_require={
+            # Optional dependencies for the example dataset loaders
+            # (torchrec.datasets, e.g. Criteo/MovieLens file loading).
+            "datasets": ["iopath"],
+        },
         packages=packages,
         zip_safe=False,
         # PyPI package information.

--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -10,12 +10,22 @@
 import os
 import shutil
 import time
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 import numpy as np
 import torch
 import torch.utils.data.datapipes as dp
-from iopath.common.file_io import PathManager, PathManagerFactory
 from pyre_extensions import none_throws
 from torch.utils.data import IterableDataset, IterDataPipe
 from torchrec.datasets.utils import (
@@ -26,6 +36,27 @@ from torchrec.datasets.utils import (
     safe_cast,
 )
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+if TYPE_CHECKING:
+    from iopath.common.file_io import PathManager
+
+
+def _get_path_manager(path_manager_key: str) -> "PathManager":
+    """Lazily import iopath and return a PathManager for the given key.
+
+    iopath is an optional dependency only needed for dataset file loading;
+    raise a helpful error if it is not installed.
+    """
+    try:
+        from iopath.common.file_io import PathManagerFactory
+    except ImportError as e:
+        raise ImportError(
+            "iopath is required for dataset file loading. "
+            "Install with: pip install torchrec[datasets] or pip install iopath"
+        ) from e
+
+    return PathManagerFactory().get(path_manager_key)
+
 
 FREQUENCY_THRESHOLD = 3
 INT_FEATURE_COUNT = 13
@@ -257,7 +288,7 @@ class BinaryCriteoUtils:
         # To be consistent with dense and sparse.
         labels_np = labels_np.reshape((-1, 1))
 
-        path_manager = PathManagerFactory().get(path_manager_key)
+        path_manager = _get_path_manager(path_manager_key)
         for fname, arr in [
             (out_dense_file, dense_np),
             (out_sparse_file, sparse_np),
@@ -281,7 +312,7 @@ class BinaryCriteoUtils:
         Returns:
             shape (Tuple[int, ...]): Shape tuple.
         """
-        path_manager = PathManagerFactory().get(path_manager_key)
+        path_manager = _get_path_manager(path_manager_key)
         with path_manager.open(path, "rb") as fin:
             # pyrefly: ignore[implicit-import]
             np.lib.format.read_magic(fin)
@@ -382,7 +413,7 @@ class BinaryCriteoUtils:
             output (np.ndarray): numpy array with the desired range of data from the
                 supplied npy file.
         """
-        path_manager = PathManagerFactory().get(path_manager_key)
+        path_manager = _get_path_manager(path_manager_key)
         with path_manager.open(fname, "rb") as fin:
             # pyrefly: ignore[implicit-import]
             np.lib.format.read_magic(fin)
@@ -514,7 +545,7 @@ class BinaryCriteoUtils:
                     # Re-map sparse value to contiguous in place.
                     file_to_features[f][col][i] = sparse_to_contiguous_int[sparse]
 
-        path_manager = PathManagerFactory().get(path_manager_key)
+        path_manager = _get_path_manager(path_manager_key)
         for f, features in file_to_features.items():
             output_file = os.path.join(output_dir, f + output_file_suffix)
             with path_manager.open(output_file, "wb") as fout:
@@ -605,7 +636,7 @@ class BinaryCriteoUtils:
 
             curr_first_row = curr_last_row
 
-        path_manager = PathManagerFactory().get(path_manager_key)
+        path_manager = _get_path_manager(path_manager_key)
 
         # Save the full dataset
         if output_dir_full_set is not None:
@@ -750,7 +781,7 @@ class InMemoryBinaryCriteoIterDataPipe(IterableDataset):
         self.mmap_mode = mmap_mode
         self.hashes: np.ndarray = np.array(hashes).reshape((1, CAT_FEATURE_COUNT))
         self.path_manager_key = path_manager_key
-        self.path_manager: PathManager = PathManagerFactory().get(path_manager_key)
+        self.path_manager: "PathManager" = _get_path_manager(path_manager_key)
 
         if shuffle_training_set and stage == "train":
             self._shuffle_and_load_data_for_rank()

--- a/torchrec/datasets/utils.py
+++ b/torchrec/datasets/utils.py
@@ -13,13 +13,25 @@ import random
 from dataclasses import dataclass
 from functools import partial
 from io import IOBase
-from typing import Any, Callable, Iterable, Iterator, List, Sequence, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+)
 
 import torch
-from iopath.common.file_io import PathManager, PathManagerFactory
 from torch.utils.data import functional_datapipe, get_worker_info, IterDataPipe
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 from torchrec.streamable import Pipelineable
+
+if TYPE_CHECKING:
+    from iopath.common.file_io import PathManager
 
 PATH_MANAGER_KEY = "torchrec"
 
@@ -241,7 +253,15 @@ class LoadFiles(IterDataPipe[Tuple[str, "IOBase"]]):
         #       `argument_validation` with this DataPipe may be potentially broken
         self.length: int = length
         self.open_kw = open_kw
-        self.path_manager: PathManager = PathManagerFactory().get(path_manager_key)
+        try:
+            from iopath.common.file_io import PathManagerFactory
+        except ImportError as e:
+            raise ImportError(
+                "iopath is required for dataset file loading. "
+                "Install with: pip install torchrec[datasets] or pip install iopath"
+            ) from e
+
+        self.path_manager: "PathManager" = PathManagerFactory().get(path_manager_key)
         self.path_manager.set_strict_kwargs_checking(False)
 
     # Remove annotation due to 'IOBase' is a general type and true type


### PR DESCRIPTION
Summary:
`iopath` is only used by the example dataset loaders in `torchrec/datasets/` (Criteo/MovieLens file loading via `PathManager`), but it was listed in `install-requirements.txt` and therefore forced on every `pip install torchrec` user. This makes it optional, following the PyTorch-ecosystem convention of a lazy import plus a pip extra.

Because the `iopath` import was at module top level in `torchrec/datasets/utils.py` and `torchrec/datasets/criteo.py`, importing widely-used lightweight symbols like `Batch` (from `datasets/utils.py`) and `RandomRecDataset` (from `datasets/random.py`, which imports `Batch`) transitively pulled in `iopath`. Simply dropping the dependency would have broken those imports, so the import is made lazy:

- `torchrec/datasets/utils.py`: the top-level `from iopath.common.file_io import ...` is removed. `PathManagerFactory` is now imported inside `LoadFiles.__init__` under a `try/except ImportError` that raises a helpful message. The `PathManager` type is imported under `TYPE_CHECKING` and referenced via a string annotation so type checking is preserved without a runtime import.
- `torchrec/datasets/criteo.py`: same treatment via a new `_get_path_manager(path_manager_key)` helper that performs the lazy import and clear error, used at all 6 `PathManagerFactory` call sites.
- `setup.py`: add `extras_require={"datasets": ["iopath"]}` so users can run `pip install torchrec[datasets]`.
- `install-requirements.txt`: remove `iopath` (this is the file `setup.py` reads into `install_requires`). `iopath` is intentionally kept in `requirements.txt` for dev/CI so the dataset tests still run.

The error message raised when iopath is missing is: `iopath is required for dataset file loading. Install with: pip install torchrec[datasets] or pip install iopath`. Core `import torchrec` already never imported `torchrec.datasets`, so core functionality is unaffected.

Differential Revision: D108440054


