### PR TITLE
Move threading & record_stream benchmarks

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -23,7 +23,6 @@ see README.md for more details
 
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -266,186 +265,6 @@ def a2a_async_twice(
         # again, make sure the device-to-host data transfer is done before the assertion
         ev_d2h.synchronize()
         assert checks1 and checks2
-
-
-# muti-stream memory footprint
-def multi_stream_memory(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    multi_stream: bool = True,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    with record_function("## setup ##"):
-        main_stream = torch.cuda.current_stream()
-        data_copy_stream = torch.cuda.Stream() if multi_stream else nullcontext()
-        data_dist_stream = torch.cuda.Stream() if multi_stream else nullcontext()
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-
-        # the host to device data transfer will block cuda execution without the `pin_memory()`
-        host_data = (torch.rand(dim, dim) - 0.5).pin_memory()
-
-    with record_function("## irrelevant compute before h2d ##"):
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## copy data to device ##"):
-        # use a separate stream to copy data to device, this will not block the main stream
-        with data_copy_stream:
-            device_data = host_data.to(ctx.device, non_blocking=True)
-            # record the data to main stream, so it won't be freed accidently in the data_copy_stream
-            device_data.record_stream(main_stream)
-
-    with record_function("## irrelevant compute after h2d ##"):
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## pre-comms compute ##"):
-        if isinstance(data_copy_stream, torch.cuda.Stream):
-            # make sure the data copy is done before the pre-comms compute
-            main_stream.wait_stream(data_copy_stream)
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=device_data
-        )
-
-    # use a separate stream to do the comms, this will not block the main stream
-    with data_dist_stream:
-        with record_function("## all_to_all_single ##"):
-            if isinstance(data_dist_stream, torch.cuda.Stream):
-                # make sure the pre-comms compute is done before the comms
-                data_dist_stream.wait_stream(main_stream)
-            post_comms = torch.zeros_like(pre_comms)
-            req = dist.all_to_all_single(
-                output=post_comms,
-                input=pre_comms,
-                group=ctx.pg,
-                async_op=True,
-            )
-            # record the data to main stream, so it won't be freed accidently in the data_dist_stream
-            post_comms.record_stream(main_stream)
-        with record_function("## a2a comm validation ##"):
-            # the comm validation is also done in this separate stream since
-            # there's no data dependency afterwards
-            assert req is not None
-            req.wait()
-            checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
-
-    with record_function("## irrelevant compute after a2a ##"):
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## post-comms compute ##"):
-        assert req is not None
-        req.wait()
-        post_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
-        )
-
-    with record_function("## assert ##"):
-        assert checks.item()
-
-
-def single_stream_memory(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    return multi_stream_memory(
-        _batch_inputs=_batch_inputs,
-        dim=dim,
-        num_mul=num_mul,
-        num_concat=num_concat,
-        ctx=ctx,
-        multi_stream=False,
-    )
-
-
-# an optimized version of muti-stream memory footprint
-def multi_stream_optimized(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    with record_function("## setup ##"):
-        main_stream = torch.cuda.current_stream()
-        data_copy_stream = torch.cuda.Stream()
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-
-        # the host to device data transfer will block cuda execution without the `pin_memory()`
-        host_data = (torch.rand(dim, dim) - 0.5).pin_memory()
-        # pre-allocate memory on the device for the incoming data transfer from the host
-        device_data = torch.empty_like(host_data, device=ctx.device)
-
-    with record_function("## irrelevant compute before h2d ##"):
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## copy data to device ##"):
-        with data_copy_stream:
-            # copy data to device, this will not block the main stream
-            device_data.copy_(host_data, non_blocking=True)
-
-    with record_function("## irrelevant compute after h2d ##"):
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## pre-comms compute ##"):
-        # make sure the data copy is done before the pre-comms compute
-        main_stream.wait_stream(data_copy_stream)
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=device_data
-        )
-
-    with record_function("## pre-allocate memory for a2a on main stream ##"):
-        post_comms = torch.zeros_like(pre_comms)
-
-    with record_function("## all_to_all_single ##"):
-        # the all_to_all_single from torch.dist has async feature
-        # it automaically uses a separate stream to do the comms
-        # without introducing extra memory footprint
-        req = dist.all_to_all_single(
-            output=post_comms,
-            input=pre_comms,
-            group=ctx.pg,
-            async_op=True,
-        )
-
-    with record_function("## irrelevant compute after a2a ##"):
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## a2a comm validation ##"):
-        # this req.wait() can be wrapped into a LazyAwaitable
-        assert req is not None
-        req.wait()
-        # still want the compute on the main stream if possible
-        checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
-
-    with record_function("## post-comms compute ##"):
-        post_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
-        )
-
-    with record_function("## assert ##"):
-        assert checks.item()
 
 
 def threading_copy(
@@ -1348,12 +1167,6 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = a2a_async_base
             case "a2a_async_twice":
                 func = a2a_async_twice
-            case "multi_stream_memory":
-                func = multi_stream_memory
-            case "single_stream_memory":
-                func = single_stream_memory
-            case "multi_stream_optimized":
-                func = multi_stream_optimized
             case "threading_copy":
                 func = threading_copy
             case "single_thread_copy":

--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -22,7 +22,6 @@ see README.md for more details
 """
 
 import logging
-from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -265,91 +264,6 @@ def a2a_async_twice(
         # again, make sure the device-to-host data transfer is done before the assertion
         ev_d2h.synchronize()
         assert checks1 and checks2
-
-
-def threading_copy(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    multithreading: bool = True,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    num_tensors = 512
-    dummy_dim = 256
-
-    with record_function("## setup ##"):
-        main_stream = torch.cuda.current_stream()
-        data_copy_stream = torch.cuda.Stream()
-
-        # create a list of small tensors on cpu, pinned for async H2D copy
-        host_tensors = [
-            torch.rand(dummy_dim, dummy_dim).pin_memory() for _ in range(num_tensors)
-        ]
-        # pre-allocate gpu memory so the copy thread only does .copy_()
-        device_tensors = [torch.empty_like(t, device=ctx.device) for t in host_tensors]
-
-        # large tensor on gpu for main-stream compute
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-
-    def _copy_worker() -> None:
-        torch.cuda.set_device(ctx.device)
-        with torch.cuda.stream(data_copy_stream):
-            for i in range(num_tensors):
-                device_tensors[i].copy_(host_tensors[i], non_blocking=True)
-
-    # launch the copy via ThreadPoolExecutor
-    executor: ThreadPoolExecutor | None = None
-    future: Future | None = None
-    with record_function("## submit copy to executor ##"):
-        if multithreading:
-            executor = ThreadPoolExecutor(max_workers=1)
-            future = executor.submit(_copy_worker)
-        else:
-            _copy_worker()
-
-    # run slow gpu operations on the main stream — these should overlap with the copies
-    with record_function("## main stream compute (should overlap with copy) ##"):
-        for _ in range(num_mul):
-            irrelevant_data = _compute(
-                dim=dim, num_mul=1, num_concat=1, ctx=ctx, x=irrelevant_data
-            )
-
-    with record_function("## wait for executor future ##"):
-        if multithreading:
-            assert future is not None
-            future.result()
-            assert executor is not None
-            executor.shutdown(wait=False)
-
-    with record_function("## wait for copy stream ##"):
-        main_stream.wait_stream(data_copy_stream)
-
-    # use the copied data to prove it arrived correctly
-    with record_function("## use copied data ##"):
-        _ = _compute(
-            dim=dummy_dim, num_mul=1, num_concat=1, ctx=ctx, x=device_tensors[0]
-        )
-
-
-def single_thread_copy(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    multithreading: bool = True,
-    **_kwargs: Dict[str, Any],
-):
-    return threading_copy(
-        _batch_inputs=_batch_inputs,
-        dim=dim,
-        num_mul=num_mul,
-        num_concat=num_concat,
-        ctx=ctx,
-        multithreading=False,
-    )
 
 
 def shared_memory_across_process(
@@ -655,93 +569,6 @@ def tolist_overlap_comms(
 
     with record_function("## assert ##"):
         assert checks.item()
-
-
-def data_copy_record_stream(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    use_record_stream: bool = True,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    """
-    Reproduce the record_stream bug fixed by D102202725.
-
-    Without record_stream(), resize_(0) lets the caching allocator reuse
-    HBM while an async D2H copy on a side stream is still in flight,
-    corrupting the copied data (NaN / wrong values).
-    """
-    with record_function("## setup ##"):
-        main_stream = torch.cuda.current_stream()
-        data_copy_stream = torch.cuda.Stream()
-
-        gpu_tensor = torch.full(
-            (num_concat * dim, dim),
-            fill_value=float(ctx.rank + 1),
-            device=ctx.device,
-        )
-        cpu_buffer = torch.empty_like(gpu_tensor, device="cpu").pin_memory()
-
-    with record_function("## async D2H copy on side stream ##"):
-        with torch.cuda.stream(data_copy_stream):
-            data_copy_stream.wait_stream(main_stream)
-            cpu_buffer.copy_(gpu_tensor, non_blocking=True)
-
-        if use_record_stream:
-            gpu_tensor.record_stream(data_copy_stream)
-
-    with record_function("## free source tensor ##"):
-        # untyped_storage().resize_(0) releases the underlying GPU memory
-        # back to the caching allocator. Without record_stream() above,
-        # the allocator may immediately reuse this memory for new
-        # allocations while the D2H copy is still reading from it.
-        gpu_tensor.untyped_storage().resize_(0)
-
-    with record_function("## new allocations that reuse freed HBM ##"):
-        _: list[torch.Tensor] = [
-            torch.full(
-                (num_concat * dim, dim),
-                fill_value=-1.0,
-                device=ctx.device,
-            )
-            for _ in range(num_mul)
-        ]
-
-    with record_function("## wait and validate ##"):
-        data_copy_stream.synchronize()
-        expected = float(ctx.rank + 1)
-        all_correct = bool(torch.all(cpu_buffer == expected).item())
-        has_nan = bool(torch.any(torch.isnan(cpu_buffer)).item())
-        logger.info(
-            f"[rank-{ctx.rank}] record_stream={use_record_stream}: "
-            f"correct={all_correct}, has_nan={has_nan}"
-        )
-
-    with record_function("## validation result ##"):
-        if has_nan:
-            logger.error(f"[rank-{ctx.rank}] NaN detected — missing record_stream()")
-        if not all_correct:
-            logger.error(f"[rank-{ctx.rank}] Data corruption — missing record_stream()")
-
-
-def data_copy_no_record_stream(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    return data_copy_record_stream(
-        _batch_inputs=_batch_inputs,
-        dim=dim,
-        num_mul=num_mul,
-        num_concat=num_concat,
-        ctx=ctx,
-        use_record_stream=False,
-    )
 
 
 def copy_engine_contention(
@@ -1167,10 +994,6 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = a2a_async_base
             case "a2a_async_twice":
                 func = a2a_async_twice
-            case "threading_copy":
-                func = threading_copy
-            case "single_thread_copy":
-                func = single_thread_copy
             case "shared_memory_across_process":
                 func = shared_memory_across_process
             case "multi_async_comms":
@@ -1193,10 +1016,6 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 )
             case s if s.startswith("tolist_overlap_comms"):
                 func = tolist_overlap_comms
-            case "data_copy_record_stream":
-                func = data_copy_record_stream
-            case "data_copy_no_record_stream":
-                func = data_copy_no_record_stream
             case "copy_engine_contention":
                 func = copy_engine_contention
             case "copy_engine_contention_dummy_compute":

--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -268,48 +268,6 @@ def a2a_async_twice(
         assert checks1 and checks2
 
 
-# LazyAwaitable
-def lazyawaitable(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    with record_function("## pre-comms compute ##"):
-        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
-
-    with record_function("## all_to_all_single ##"):
-        # use zeros instead of empty to make sure no previous data used
-        post_comms = torch.zeros_like(pre_comms)
-        req = dist.all_to_all_single(
-            output=post_comms,
-            input=pre_comms,
-            group=ctx.pg,
-            async_op=True,
-        )
-
-    with record_function("## irrelevant compute ##"):
-        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
-
-    with record_function("## comms check ##"):
-        # assertion fails without wait(), this wait() makes the main cuda stream wait
-        # for the comms to finish, so the post-comms compute will be blocked until
-        # the comms is done
-        assert req is not None
-        req.wait()
-        check_awaitable = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
-
-    with record_function("## post-comms compute ##"):
-        post_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
-        )
-
-    with record_function("## assert ##"):
-        assert check_awaitable.item()
-
-
 # muti-stream memory footprint
 def multi_stream_memory(
     _batch_inputs: List[Dict[str, Any]],
@@ -488,97 +446,6 @@ def multi_stream_optimized(
 
     with record_function("## assert ##"):
         assert checks.item()
-
-
-# an optimized version of muti-stream memory footprint
-def non_blocking_copy(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    preallocated: bool = False,
-    use_data_copy_stream: bool = True,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    with record_function("## setup ##"):
-        main_stream = torch.cuda.current_stream()
-        data_copy_stream = (
-            torch.cuda.Stream() if use_data_copy_stream else nullcontext()
-        )
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-
-        # the host to device data transfer will block cuda execution without the `pin_memory()`
-        host_data = (torch.rand(dim, dim) - 0.5).pin_memory()
-        if preallocated:
-            # pre-allocate memory on the device for the incoming data transfer from the host
-            device_data = torch.empty_like(host_data, device=ctx.device)
-        else:
-            device_data = torch.empty(0, device=ctx.device)
-
-    with record_function("## irrelevant compute before h2d ##"):
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## copy data to device ##"):
-        with data_copy_stream:
-            if preallocated:
-                # copy data to device, this will not block the main stream
-                device_data.copy_(host_data, non_blocking=True)
-            else:
-                device_data = host_data.to(ctx.device, non_blocking=True)
-
-    with record_function("## irrelevant compute after h2d ##"):
-        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=irrelevant_data
-        )
-
-    with record_function("## pre-comms compute ##"):
-        # make sure the data copy is done before the pre-comms compute
-        if use_data_copy_stream:
-            # pyrefly: ignore[bad-argument-type]
-            main_stream.wait_stream(data_copy_stream)
-        pre_comms = _compute(
-            dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=device_data
-        )
-
-
-def preallocated_non_blocking_copy(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    return non_blocking_copy(
-        _batch_inputs=_batch_inputs,
-        dim=dim,
-        num_mul=num_mul,
-        num_concat=num_concat,
-        ctx=ctx,
-        preallocated=True,
-    )
-
-
-def blocking_copy(
-    _batch_inputs: List[Dict[str, Any]],
-    dim: int,
-    num_mul: int,
-    num_concat: int,
-    ctx: MultiProcessContext,
-    **_kwargs: Dict[str, Any],
-) -> None:
-    return non_blocking_copy(
-        _batch_inputs=_batch_inputs,
-        dim=dim,
-        num_mul=num_mul,
-        num_concat=num_concat,
-        ctx=ctx,
-        use_data_copy_stream=False,
-    )
 
 
 def threading_copy(
@@ -1481,20 +1348,12 @@ def a2a_single_runner(rank: int, world_size: int, arg: AllToAllSingleRunConfig) 
                 func = a2a_async_base
             case "a2a_async_twice":
                 func = a2a_async_twice
-            case "lazyawaitable":
-                func = lazyawaitable
             case "multi_stream_memory":
                 func = multi_stream_memory
             case "single_stream_memory":
                 func = single_stream_memory
             case "multi_stream_optimized":
                 func = multi_stream_optimized
-            case "non_blocking_copy":
-                func = non_blocking_copy
-            case "preallocated_non_blocking_copy":
-                func = preallocated_non_blocking_copy
-            case "blocking_copy":
-                func = blocking_copy
             case "threading_copy":
                 func = threading_copy
             case "single_thread_copy":

--- a/torchrec/distributed/benchmark/benchmark_data_transfer.py
+++ b/torchrec/distributed/benchmark/benchmark_data_transfer.py
@@ -22,6 +22,7 @@ see README.md for more details
 """
 
 import logging
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, List, Optional
@@ -472,6 +473,207 @@ class StreamMemoryConfig(DataCopyConfig):
 # pyrefly: ignore[missing-attribute]
 @_cc.register
 def stream_memory(arg: StreamMemoryConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+
+
+def benchmark_threading_copy(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    multithreading: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    num_tensors = 512
+    dummy_dim = 256
+
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        data_copy_stream = torch.cuda.Stream()
+
+        # create a list of small tensors on cpu, pinned for async H2D copy
+        host_tensors = [
+            torch.rand(dummy_dim, dummy_dim).pin_memory() for _ in range(num_tensors)
+        ]
+        # pre-allocate gpu memory so the copy thread only does .copy_()
+        device_tensors: List[torch.Tensor] = [
+            torch.empty_like(t, device=ctx.device) for t in host_tensors
+        ]
+
+        # large tensor on gpu for main-stream compute
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+
+    def _copy_worker() -> None:
+        torch.cuda.set_device(ctx.device)
+        with torch.cuda.stream(data_copy_stream):
+            for i in range(num_tensors):
+                device_tensors[i].copy_(host_tensors[i], non_blocking=True)
+
+    # launch the copy via ThreadPoolExecutor
+    executor: ThreadPoolExecutor | None = None
+    future: Future | None = None
+    with record_function("## submit copy to executor ##"):
+        if multithreading:
+            executor = ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(_copy_worker)
+        else:
+            _copy_worker()
+
+    # run slow gpu operations on the main stream — these should overlap with the copies
+    with record_function("## main stream compute (should overlap with copy) ##"):
+        for _ in range(num_mul):
+            irrelevant_data = _compute(
+                dim=dim, num_mul=1, num_concat=1, ctx=ctx, x=irrelevant_data
+            )
+
+    with record_function("## wait for executor future ##"):
+        if multithreading:
+            assert future is not None
+            future.result()
+            assert executor is not None
+            executor.shutdown(wait=False)
+
+    with record_function("## wait for copy stream ##"):
+        main_stream.wait_stream(data_copy_stream)
+
+    # use the copied data to prove it arrived correctly
+    with record_function("## use copied data ##"):
+        # result intentionally discarded: this only proves the copy arrived
+        _compute(dim=dummy_dim, num_mul=1, num_concat=1, ctx=ctx, x=device_tensors[0])
+
+
+@dataclass
+class ThreadingCopyConfig(DataCopyConfig):
+    """
+    run commands:
+    1. multi-threaded: issue the H2D copies from a worker thread
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy \
+        --name=threading_copy
+
+    2. single-threaded: run the copies inline on the main thread
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy \
+        --name=single_thread_copy \
+        --multithreading=False
+
+    use case:
+        in production models the input batch has 500+ tensors copied host-to-device
+        one by one; even though each copy is non-blocking, the per-call CPU overhead
+        (Python loop + CUDA driver dispatch) accumulates and blocks the main thread
+        from dispatching forward-pass kernels. This benchmark simulates that with many
+        small pinned tensors and checks whether issuing the copies from a separate
+        Python thread (via concurrent.futures.ThreadPoolExecutor, on a side CUDA
+        stream) frees the main thread and lets the copies overlap main-stream compute.
+        CUDA calls release the GIL so the background thread does not block the main
+        thread, though the Python copy loop itself still contends on the GIL.
+        see https://github.com/meta-pytorch/torchrec/pull/3774 for more details
+    """
+
+    memory_snapshot: bool = True
+    multithreading: bool = True
+    func: Callable[..., None] = benchmark_threading_copy
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def threading_copy(arg: ThreadingCopyConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+
+
+def benchmark_data_copy_record_stream(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    use_record_stream: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        data_copy_stream = torch.cuda.Stream()
+
+        gpu_tensor = torch.full(
+            (num_concat * dim, dim),
+            fill_value=float(ctx.rank + 1),
+            device=ctx.device,
+        )
+        cpu_buffer = torch.empty_like(gpu_tensor, device="cpu").pin_memory()
+
+    with record_function("## async D2H copy on side stream ##"):
+        with torch.cuda.stream(data_copy_stream):
+            data_copy_stream.wait_stream(main_stream)
+            cpu_buffer.copy_(gpu_tensor, non_blocking=True)
+
+        if use_record_stream:
+            gpu_tensor.record_stream(data_copy_stream)
+
+    with record_function("## free source tensor ##"):
+        # untyped_storage().resize_(0) releases the underlying GPU memory
+        # back to the caching allocator. Without record_stream() above,
+        # the allocator may immediately reuse this memory for new
+        # allocations while the D2H copy is still reading from it.
+        gpu_tensor.untyped_storage().resize_(0)
+
+    with record_function("## new allocations that reuse freed HBM ##"):
+        _: list[torch.Tensor] = [
+            torch.full(
+                (num_concat * dim, dim),
+                fill_value=-1.0,
+                device=ctx.device,
+            )
+            for _ in range(num_mul)
+        ]
+
+    with record_function("## wait and validate ##"):
+        data_copy_stream.synchronize()
+        expected = float(ctx.rank + 1)
+        all_correct = bool(torch.all(cpu_buffer == expected).item())
+        has_nan = bool(torch.any(torch.isnan(cpu_buffer)).item())
+        logger.info(
+            f"[rank-{ctx.rank}] record_stream={use_record_stream}: "
+            f"correct={all_correct}, has_nan={has_nan}"
+        )
+
+    with record_function("## validation result ##"):
+        if has_nan:
+            logger.error(f"[rank-{ctx.rank}] NaN detected — missing record_stream()")
+        if not all_correct:
+            logger.error(f"[rank-{ctx.rank}] Data corruption — missing record_stream()")
+
+
+@dataclass
+class DataCopyRecordStreamConfig(DataCopyConfig):
+    """
+    run commands:
+    1. with record_stream (correct)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream \
+        --name=data_copy_record_stream
+
+    2. without record_stream (reproduces the bug)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream \
+        --name=data_copy_no_record_stream \
+        --use_record_stream=False
+
+    use case:
+        reproduce the NaN corruption bug fixed by D102202725 in EMS memory stashing.
+        record_stream() tells the CUDA caching allocator to defer reuse of a tensor's
+        memory until the recording stream catches up. Without it, freeing the source
+        via untyped_storage().resize_(0) on the main stream lets the allocator hand the
+        block to a new allocation while an async D2H copy on a side stream is still
+        reading it, corrupting the copied data (NaN / wrong values). With
+        use_record_stream the copy validates correctly; without it validation fails.
+        see https://github.com/meta-pytorch/torchrec/pull/4231 for more details
+    """
+
+    memory_snapshot: bool = True
+    use_record_stream: bool = True
+    func: Callable[..., None] = benchmark_data_copy_record_stream
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def data_copy_record_stream(arg: DataCopyRecordStreamConfig) -> None:
     run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 

--- a/torchrec/distributed/benchmark/benchmark_data_transfer.py
+++ b/torchrec/distributed/benchmark/benchmark_data_transfer.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Example usage:
+
+Buck2 (internal):
+    buck2 run @fbcode//mode/opt fbcode//torchrec/distributed/benchmark:benchmark_data_transfer -- \
+        lazyawaitable --name=$(hg whereami | cut -c 1-10)
+
+OSS (external):
+    python -m torchrec.distributed.benchmark.benchmark_data_transfer \
+        lazyawaitable --name=$(git rev-parse --short HEAD || echo $USER)
+
+see README.md for more details
+"""
+
+import logging
+from contextlib import nullcontext
+from dataclasses import dataclass, fields
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.autograd.profiler import record_function
+from torchrec.distributed.benchmark.base import (
+    BenchFuncConfig,
+    benchmark_func,
+    cmd_conf,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    run_multi_process_func,
+)
+from torchrec.distributed.types import DeviceToHostTensorAwaitable
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# pyrefly: ignore[missing-argument]
+_cc = cmd_conf()
+
+
+#################################### util functions ####################################
+def _compute(
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    x: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    a dummy compute function to simulate the GPU load for computing, all
+    operations are on the GPU side, no need to block CPU operations
+    """
+    if x is None:
+        x = torch.rand(dim, dim, device=ctx.device) - 0.5
+    for _ in range(num_mul):
+        x = F.normalize(x @ x) * 10
+    x = torch.sigmoid(x).reshape(1, dim, dim) + ctx.rank
+    return torch.concat([x] * num_concat)
+
+
+def _validate(x: torch.Tensor, ctx: MultiProcessContext) -> torch.Tensor:
+    """
+    validate the correctness of the comms result, the validation is done on GPU
+    returns a GPU tensor with a single boolean value, non-blocking on CPU
+    """
+    mixed_ranks = x.to(torch.int).reshape(ctx.world_size, -1)
+    checks = torch.empty(ctx.world_size, dtype=torch.bool, device=ctx.device)
+    for i in range(ctx.world_size):
+        checks[i] = torch.all(mixed_ranks[i, :] == i)
+    return torch.all(checks)
+
+
+################################# framework components #################################
+
+
+def _unset_benchmark(*_args: Any, **_kwargs: Any) -> None:
+    # placeholder default for DataCopyConfig.func; each benchmark config sets its own
+    raise NotImplementedError("DataCopyConfig.func must be set by a subclass")
+
+
+@dataclass
+class DataCopyConfig(BenchFuncConfig):
+    name: str = ""
+    world_size: int = 2
+    dim: int = 2048
+    profile_dir: str = "."
+    num_benchmarks: int = 2
+    num_profiles: int = 2
+    num_mul: int = 5
+    num_concat: int = 100
+    debug_mode: bool = False
+    backend: str = "nccl"
+    func: Callable[..., None] = _unset_benchmark
+
+
+# single-rank runner
+def single_rank_runner(rank: int, world_size: int, arg: DataCopyConfig) -> None:
+    if arg.backend == "nccl":
+        # Ensure GPUs are available and we have enough of them
+        assert (
+            torch.cuda.is_available() and torch.cuda.device_count() >= world_size
+        ), "CUDA not available or insufficient GPUs for the requested world_size"
+
+    arg.set_log_level()
+
+    # debug mode only works with vscode for now.
+    if arg.debug_mode:
+        # pyrefly: ignore[missing-module-attribute]
+        from fbvscode import attach_debugger
+
+        attach_debugger()
+
+    new_keys = {f.name for f in fields(type(arg))} - {
+        f.name for f in fields(DataCopyConfig)
+    }
+    new_kwargs = {k: getattr(arg, k) for k in new_keys}
+    func_name = getattr(arg.func, "__name__", arg.name)
+    name: str = f"{func_name}_{arg.name}" if arg.name else func_name
+
+    torch.autograd.set_detect_anomaly(True)
+    with MultiProcessContext(
+        rank=rank,
+        world_size=world_size,
+        backend=arg.backend,
+        use_deterministic_algorithms=False,
+    ) as ctx:
+        result = benchmark_func(
+            bench_inputs=[],
+            prof_inputs=[],
+            benchmark_func_kwargs={
+                "ctx": ctx,
+                "dim": arg.dim,
+                "num_mul": arg.num_mul,
+                "num_concat": arg.num_concat,
+            }
+            | new_kwargs,
+            func_to_benchmark=arg.func,
+            rank=rank,
+            # Input is empty, actual traffic is determined by the benchmark function
+            sample_count=0,
+            **arg.benchmark_func_kwargs(name=name),
+        )
+
+        if rank == 0:
+            print(result)
+
+
+###################################### benchmarks ######################################
+def benchmark_lazyawaitable(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## pre-comms compute ##"):
+        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## all_to_all_single ##"):
+        # use zeros instead of empty to make sure no previous data used
+        post_comms = torch.zeros_like(pre_comms)
+        req = dist.all_to_all_single(
+            output=post_comms,
+            input=pre_comms,
+            group=ctx.pg,
+            async_op=True,
+        )
+
+    with record_function("## irrelevant compute ##"):
+        pre_comms = _compute(dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx)
+
+    with record_function("## comms check ##"):
+        # assertion fails without wait(), this wait() makes the main cuda stream wait
+        # for the comms to finish, so the post-comms compute will be blocked until
+        # the comms is done
+        assert req is not None
+        req.wait()
+        check_awaitable = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+
+    with record_function("## post-comms compute ##"):
+        post_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
+        )
+
+    with record_function("## assert ##"):
+        assert check_awaitable.item()
+
+
+@dataclass
+class LazyAwaitableConfig(DataCopyConfig):
+    """
+    run commands:
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer lazyawaitable
+
+    use case:
+        demonstrate the use of the device-to-host lazy awaitable. The
+        DeviceToHostTensorAwaitable wraps a non-blocking device-to-host transfer
+        together with a CUDA event and defers the cudaEventSync until the value is
+        actually read on the host. This removes a CPU-blocking sync point, so the
+        post-comms compute can be scheduled ahead of the host-side assertion --
+        useful for sync-point removal in training optimization.
+        see https://github.com/meta-pytorch/torchrec/pull/3477 for more details
+    """
+
+    name: str = "lazyawaitable"
+    func: Callable[..., None] = benchmark_lazyawaitable
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def lazyawaitable(arg: LazyAwaitableConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+
+
+def benchmark_h2d_data_copy(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    preallocated: bool = False,
+    use_data_copy_stream: bool = True,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        data_copy_stream = (
+            torch.cuda.Stream() if use_data_copy_stream else nullcontext()
+        )
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+
+        # the host to device data transfer will block cuda execution without the `pin_memory()`
+        host_data = (torch.rand(dim, dim) - 0.5).pin_memory()
+        if preallocated:
+            # pre-allocate memory on the device for the incoming data transfer from the host
+            device_data = torch.empty_like(host_data, device=ctx.device)
+        else:
+            device_data = torch.empty(0, device=ctx.device)
+
+    with record_function("## irrelevant compute before h2d ##"):
+        # result intentionally discarded: this only simulates GPU compute load
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=irrelevant_data)
+
+    with record_function("## copy data to device ##"):
+        with data_copy_stream:
+            if preallocated:
+                # copy data to device, this will not block the main stream
+                device_data.copy_(host_data, non_blocking=True)
+            else:
+                device_data = host_data.to(ctx.device, non_blocking=True)
+
+    with record_function("## irrelevant compute after h2d ##"):
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+        # result intentionally discarded: this only simulates GPU compute load
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=irrelevant_data)
+
+    with record_function("## pre-comms compute ##"):
+        # make sure the data copy is done before the pre-comms compute
+        if use_data_copy_stream:
+            # pyrefly: ignore[bad-argument-type]
+            main_stream.wait_stream(data_copy_stream)
+        # result intentionally discarded: this only simulates GPU compute load
+        _compute(dim=dim, num_mul=num_mul, num_concat=1, ctx=ctx, x=device_data)
+
+
+@dataclass
+class H2DCopyConfig(DataCopyConfig):
+    """
+    run commands:
+    1. default: non-blocking host-to-device data copy, w/o pre-allocated memory
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
+        --name=non_blocking_h2d_copy
+
+    2. pre-allocated: non-blocking host-to-device data copy, w/ pre-allocated memory
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
+        --name=pre_allocated_h2d_copy \
+        --preallocated=True
+
+    3. blocking: blocking host-to-device data copy
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
+        --name=blocking_h2d_copy \
+        --use_data_copy_stream=False
+
+    use case:
+        study the CUDA cached-memory footprint of host-to-device copies. A
+        non-blocking copy on a side stream inflates that stream's reserved
+        memory: the copied tensor is allocated on the side stream and is not
+        shared back with the main stream by the caching allocator.
+        Pre-allocating on the main stream and doing an in-place copy on the side
+        stream keeps the footprint as low as a blocking copy.
+        see https://github.com/meta-pytorch/torchrec/pull/3485 and
+        https://github.com/meta-pytorch/torchrec/pull/3510 for more details
+    """
+
+    memory_snapshot: bool = True
+    preallocated: bool = False
+    use_data_copy_stream: bool = True
+    func: Callable[..., None] = benchmark_h2d_data_copy
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def h2d_data_copy(arg: H2DCopyConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+
+
+####################################### backups ########################################
+
+
+if __name__ == "__main__":
+    # pyrefly: ignore[missing-attribute]
+    _cc.main()

--- a/torchrec/distributed/benchmark/benchmark_data_transfer.py
+++ b/torchrec/distributed/benchmark/benchmark_data_transfer.py
@@ -314,7 +314,165 @@ def h2d_data_copy(arg: H2DCopyConfig) -> None:
     run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 
-####################################### backups ########################################
+def benchmark_stream_memory(
+    _batch_inputs: List[Dict[str, Any]],
+    dim: int,
+    num_mul: int,
+    num_concat: int,
+    ctx: MultiProcessContext,
+    multi_stream: bool = True,
+    preallocated: bool = False,
+    **_kwargs: Dict[str, Any],
+) -> None:
+    """
+    Consolidates the three multi-stream memory-footprint benchmarks. It overlaps an
+    H2D copy and an all-to-all with compute, and the flags select the strategy:
+      - single_stream     (multi_stream=False): copy and a2a on the main stream
+      - multi_stream       (multi_stream=True): copy on a side stream, a2a on a
+                            dedicated dist stream
+      - optimized          (multi_stream=True, preallocated=True): pre-allocated
+                            in-place copy on a side stream, and a2a on the main
+                            stream relying on NCCL's own async stream -- keeps the
+                            overlap without the extra reserved-memory footprint
+    """
+    with record_function("## setup ##"):
+        main_stream = torch.cuda.current_stream()
+        data_copy_stream = torch.cuda.Stream() if multi_stream else nullcontext()
+        # the optimized variant lets dist.all_to_all_single use its own async stream,
+        # so a dedicated dist stream is only needed for the plain multi-stream case
+        data_dist_stream = (
+            torch.cuda.Stream() if multi_stream and not preallocated else nullcontext()
+        )
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+
+        # the host to device data transfer will block cuda execution without the `pin_memory()`
+        host_data = (torch.rand(dim, dim) - 0.5).pin_memory()
+        if preallocated:
+            # pre-allocate on the main stream so the freed memory can be reused by it
+            device_data = torch.empty_like(host_data, device=ctx.device)
+        else:
+            # the .to() copy below allocates the device tensor on the copy stream
+            device_data = torch.empty(0, device=ctx.device)
+
+    with record_function("## irrelevant compute before h2d ##"):
+        pre_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
+        )
+
+    with record_function("## copy data to device ##"):
+        # use a separate stream to copy data to device, this will not block the main stream
+        with data_copy_stream:
+            if preallocated:
+                # in-place copy into the main-stream allocation
+                device_data.copy_(host_data, non_blocking=True)
+            else:
+                device_data = host_data.to(ctx.device, non_blocking=True)
+                if multi_stream:
+                    # record to the main stream so it isn't freed early on the copy stream
+                    device_data.record_stream(main_stream)
+
+    with record_function("## irrelevant compute after h2d ##"):
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+        pre_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
+        )
+
+    with record_function("## pre-comms compute ##"):
+        if isinstance(data_copy_stream, torch.cuda.Stream):
+            # make sure the data copy is done before the pre-comms compute
+            main_stream.wait_stream(data_copy_stream)
+        pre_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=device_data
+        )
+
+    # the optimized variant runs a2a on the main stream (NCCL async); the others run
+    # it on data_dist_stream (a side stream when multi_stream)
+    checks: Optional[DeviceToHostTensorAwaitable] = None
+    with data_dist_stream:
+        with record_function("## all_to_all_single ##"):
+            if isinstance(data_dist_stream, torch.cuda.Stream):
+                # make sure the pre-comms compute is done before the comms
+                data_dist_stream.wait_stream(main_stream)
+            post_comms = torch.zeros_like(pre_comms)
+            req = dist.all_to_all_single(
+                output=post_comms,
+                input=pre_comms,
+                group=ctx.pg,
+                async_op=True,
+            )
+            if isinstance(data_dist_stream, torch.cuda.Stream):
+                # record to the main stream so it isn't freed early on the dist stream
+                post_comms.record_stream(main_stream)
+        if not preallocated:
+            with record_function("## a2a comm validation ##"):
+                # validate in the dist stream since there's no data dependency after
+                assert req is not None
+                req.wait()
+                checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+
+    with record_function("## irrelevant compute after a2a ##"):
+        irrelevant_data = torch.rand(dim, dim, device=ctx.device) - 0.5
+        pre_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=irrelevant_data
+        )
+
+    if preallocated:
+        with record_function("## a2a comm validation ##"):
+            # this req.wait() can be wrapped into a LazyAwaitable
+            assert req is not None
+            req.wait()
+            # still want the compute on the main stream if possible
+            checks = DeviceToHostTensorAwaitable(_validate(post_comms, ctx))
+
+    with record_function("## post-comms compute ##"):
+        assert req is not None
+        req.wait()
+        post_comms = _compute(
+            dim=dim, num_mul=num_mul, num_concat=num_concat, ctx=ctx, x=post_comms[0]
+        )
+
+    with record_function("## assert ##"):
+        assert checks is not None
+        assert checks.item()
+
+
+@dataclass
+class StreamMemoryConfig(DataCopyConfig):
+    """
+    run commands:
+    1. single stream: copy + a2a on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
+        --name=single_stream_memory \
+        --multi_stream=False
+
+    2. multi stream: copy on a side stream, a2a on a dedicated dist stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
+        --name=multi_stream_memory
+
+    3. optimized: pre-allocated in-place copy on a side stream, a2a on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
+        --name=multi_stream_optimized \
+        --preallocated=True
+
+    use case:
+        study the CUDA memory footprint when overlapping an H2D copy and an
+        all-to-all with compute across streams. A side-stream copy/comm overlaps
+        well but inflates that stream's reserved memory; pre-allocating on the main
+        stream + in-place copy, and letting all_to_all_single use NCCL's own async
+        stream, keeps the overlap while avoiding the extra footprint.
+        see https://github.com/meta-pytorch/torchrec/pull/3480 for more details
+    """
+
+    memory_snapshot: bool = True
+    multi_stream: bool = True
+    preallocated: bool = False
+    func: Callable[..., None] = benchmark_stream_memory
+
+
+# pyrefly: ignore[missing-attribute]
+@_cc.register
+def stream_memory(arg: StreamMemoryConfig) -> None:
+    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
## 1. Context
Continue moving data-transfer benchmarks out of the overloaded `benchmark_comms.py`. `threading_copy` (multi- vs single-threaded H2D copy) and `data_copy_record_stream` (a `record_stream` correctness repro) are data-transfer benchmarks and belong in `benchmark_data_transfer.py` next to the other copy benchmarks.

## 2. Approach
1. **`threading_copy`**: added `benchmark_threading_copy` + `ThreadingCopyConfig` registered as `threading_copy`. The old `single_thread_copy` wrapper becomes the `--multithreading=False` flag. Documents the production motivation (500+ per-batch H2D copies whose per-call CPU overhead blocks the main thread) and the `ThreadPoolExecutor` offload.
2. **`data_copy_record_stream`**: added `benchmark_data_copy_record_stream` + `DataCopyRecordStreamConfig` registered as `data_copy_record_stream`. The old `data_copy_no_record_stream` wrapper becomes the `--use_record_stream=False` flag (reproduces the bug fixed by D102202725).
3. **Cleanup**: removed both functions, their wrappers, and their `match` cases from `benchmark_comms.py`, and dropped the now-unused `concurrent.futures` import.

## 3. Analysis
1. **Risk: low** — benchmark-only; no library/runtime, public API, sharding, or collective changes.
2. **`benchmark_comms.py` change is deletion-only**; remaining comms benchmarks are untouched.

## 4. Changes
1. **`benchmark_data_transfer.py`**: new `benchmark_threading_copy` / `ThreadingCopyConfig` / `threading_copy` and `benchmark_data_copy_record_stream` / `DataCopyRecordStreamConfig` / `data_copy_record_stream`; added `concurrent.futures` import.
2. **`benchmark_comms.py`**: removed `threading_copy` / `single_thread_copy` / `data_copy_record_stream` / `data_copy_no_record_stream`, their `match` cases, and the unused `concurrent.futures` import.

Differential Revision: D108486071
