### PR TITLE
Refactor to a register_benchmark decorator

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_comms.py
+++ b/torchrec/distributed/benchmark/benchmark_comms.py
@@ -81,11 +81,6 @@ def _validate(x: torch.Tensor, ctx: MultiProcessContext) -> torch.Tensor:
 
 
 ################################# framework components #################################
-def _unset_benchmark(*_args: Any, **_kwargs: Any) -> None:
-    # placeholder default for CommsConfig.func; each benchmark config sets its own
-    raise NotImplementedError("CommsConfig.func must be set by a subclass")
-
-
 @dataclass
 class CommsConfig(BenchFuncConfig):
     name: str = ""
@@ -98,11 +93,15 @@ class CommsConfig(BenchFuncConfig):
     num_concat: int = 100
     debug_mode: bool = False
     backend: str = "nccl"
-    func: Callable[..., None] = _unset_benchmark
 
 
 # single-rank runner
-def single_rank_runner(rank: int, world_size: int, arg: CommsConfig) -> None:
+def single_rank_runner(
+    rank: int,
+    world_size: int,
+    arg: CommsConfig,
+    bench_func: Callable[..., None],
+) -> None:
     if arg.backend == "nccl":
         # Ensure GPUs are available and we have enough of them
         assert (
@@ -122,9 +121,7 @@ def single_rank_runner(rank: int, world_size: int, arg: CommsConfig) -> None:
         f.name for f in fields(CommsConfig)
     }
     new_kwargs = {k: getattr(arg, k) for k in new_keys}
-    func_name = getattr(arg.func, "__name__", arg.name)
-    if func_name.startswith("benchmark_"):
-        func_name = func_name[len("benchmark_") :]
+    func_name = getattr(bench_func, "__name__", arg.name)
     name: str = f"{func_name}_{arg.name}" if arg.name else func_name
 
     torch.autograd.set_detect_anomaly(True)
@@ -149,7 +146,7 @@ def single_rank_runner(rank: int, world_size: int, arg: CommsConfig) -> None:
                 "num_concat": arg.num_concat,
             }
             | new_kwargs,
-            func_to_benchmark=arg.func,
+            func_to_benchmark=bench_func,
             rank=rank,
             # Input is empty, actual traffic is determined by the benchmark function
             sample_count=0,
@@ -160,9 +157,72 @@ def single_rank_runner(rank: int, world_size: int, arg: CommsConfig) -> None:
             print(result)
 
 
+def register_benchmark(
+    config: type[CommsConfig],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    Decorator factory: register a benchmark function with the CLI, bound to the
+    given config class. The decorated function is the per-iteration benchmark and
+    its name is the CLI subcommand. Define the config class first, then:
+
+    @register_benchmark(AllToAllBaseConfig)
+    def all_to_all_base(_batch_inputs, ..., ctx, async_op=False, **_kwargs): ...
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable[..., None]:
+        def dispatch(arg: CommsConfig) -> None:
+            run_multi_process_func(
+                func=single_rank_runner,
+                world_size=arg.world_size,
+                arg=arg,
+                bench_func=func,
+            )
+
+        # CLI subcommand key = benchmark function name; the annotation must be the
+        # concrete config subclass so cmd_conf builds its argparse from its fields
+        dispatch.__name__ = func.__name__
+        dispatch.__annotations__ = {"arg": config, "return": None}
+        # pyrefly: ignore[missing-attribute]
+        _cc.register(dispatch)
+        return func
+
+    return decorator
+
+
 ###################################### benchmarks ######################################
+
+
+@dataclass
+class AllToAllBaseConfig(CommsConfig):
+    """
+    run commands:
+    1. sync (default): blocking all_to_all_single on a single stream
+    > python -m torchrec.distributed.benchmark.benchmark_comms all_to_all_base \
+        --name=sync
+
+    2. async: async_op=True, the main stream waits via req.wait() before post-comms
+    > python -m torchrec.distributed.benchmark.benchmark_comms all_to_all_base \
+        --name=async \
+        --async_op=True
+
+    use case:
+        benchmark all_to_all_single with and without async_op. With async_op the comms
+        runs on a separate (comms) stream, non-blocking for the following main-stream
+        ops, but the pre-allocated output is not valid until the comms is done (the
+        pre-check fails); when a later op depends on the output, the caller must
+        req.wait() so the main stream waits on the comms stream. Either way, the
+        device-side validation result is read on the host via a non-blocking D2H copy
+        gated by a CUDA event, so the host assertion only blocks until the value is
+        actually available -- not on the whole comms.
+        see https://github.com/meta-pytorch/torchrec/pull/3436 for more details
+    """
+
+    async_op: bool = False
+
+
 # all_to_all_single on a single stream, sync or async
-def benchmark_all_to_all_base(
+@register_benchmark(AllToAllBaseConfig)
+def all_to_all_base(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -219,42 +279,27 @@ def benchmark_all_to_all_base(
 
 
 @dataclass
-class AllToAllBaseConfig(CommsConfig):
+class A2AAsyncTwiceConfig(CommsConfig):
     """
     run commands:
-    1. sync (default): blocking all_to_all_single on a single stream
-    > python -m torchrec.distributed.benchmark.benchmark_comms all_to_all_base \
-        --name=sync
-
-    2. async: async_op=True, the main stream waits via req.wait() before post-comms
-    > python -m torchrec.distributed.benchmark.benchmark_comms all_to_all_base \
-        --name=async \
-        --async_op=True
+    > python -m torchrec.distributed.benchmark.benchmark_comms a2a_async_twice
 
     use case:
-        benchmark all_to_all_single with and without async_op. With async_op the comms
-        runs on a separate (comms) stream, non-blocking for the following main-stream
-        ops, but the pre-allocated output is not valid until the comms is done (the
-        pre-check fails); when a later op depends on the output, the caller must
-        req.wait() so the main stream waits on the comms stream. Either way, the
-        device-side validation result is read on the host via a non-blocking D2H copy
-        gated by a CUDA event, so the host assertion only blocks until the value is
-        actually available -- not on the whole comms.
-        see https://github.com/meta-pytorch/torchrec/pull/3436 for more details
+        model the data-dependent comms chain in TWRW output dist (intra-node
+        reduce_scatter -> decode/convert -> cross-node all_to_all). The second a2a and
+        the decode run on a side stream so the main stream's following compute
+        (rw-lookup / dense forward) overlaps instead of blocking on req.wait(). The
+        side stream's allocations inflate GPU reserved memory (the caching allocator
+        reserves per-stream pools) -- the compute-overlap vs memory-footprint tradeoff.
+        see https://github.com/meta-pytorch/torchrec/pull/3440 for more details
     """
 
-    async_op: bool = False
-    func: Callable[..., None] = benchmark_all_to_all_base
-
-
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def all_to_all_base(arg: AllToAllBaseConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
+    memory_snapshot: bool = True
 
 
 # all_to_all_single with sync and single stream
-def benchmark_a2a_async_twice(
+@register_benchmark(A2AAsyncTwiceConfig)
+def a2a_async_twice(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -333,32 +378,26 @@ def benchmark_a2a_async_twice(
 
 
 @dataclass
-class A2AAsyncTwiceConfig(CommsConfig):
+class SharedMemoryAcrossProcessConfig(CommsConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_comms a2a_async_twice
+    > python -m torchrec.distributed.benchmark.benchmark_comms shared_memory_across_process
 
     use case:
-        model the data-dependent comms chain in TWRW output dist (intra-node
-        reduce_scatter -> decode/convert -> cross-node all_to_all). The second a2a and
-        the decode run on a side stream so the main stream's following compute
-        (rw-lookup / dense forward) overlaps instead of blocking on req.wait(). The
-        side stream's allocations inflate GPU reserved memory (the caching allocator
-        reserves per-stream pools) -- the compute-overlap vs memory-footprint tradeoff.
-        see https://github.com/meta-pytorch/torchrec/pull/3440 for more details
+        for read-only eval/inference, place the full embedding table in CPU shared
+        memory (/dev/shm) once and let all ranks on the host map the same physical
+        pages -- no sharding, no input/output dist, zero data copies (except one copy
+        on the creator rank). Host-level embedding footprint stays the size of the full
+        table regardless of rank count. Delegates to create_on_rank_and_share_result;
+        CPU-only, same-host (pass an intra-node process group).
+        see https://github.com/meta-pytorch/torchrec/pull/3810 for more details
     """
 
     memory_snapshot: bool = True
-    func: Callable[..., None] = benchmark_a2a_async_twice
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def a2a_async_twice(arg: A2AAsyncTwiceConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_shared_memory_across_process(
+@register_benchmark(SharedMemoryAcrossProcessConfig)
+def shared_memory_across_process(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -394,7 +433,7 @@ def benchmark_shared_memory_across_process(
         # Keep the tensor alive across benchmark iterations so the shared
         # memory file in /dev/shm is not cleaned up prematurely.
         # pyrefly: ignore[missing-attribute]
-        benchmark_shared_memory_across_process._shm_tensor = shared_tensor
+        shared_memory_across_process._shm_tensor = shared_tensor
 
     if ctx.rank != 0:
         with record_function(f"## rank-{ctx.rank}: validate shared data ##"):
@@ -408,32 +447,26 @@ def benchmark_shared_memory_across_process(
 
 
 @dataclass
-class SharedMemoryAcrossProcessConfig(CommsConfig):
+class MultiAsyncCommsConfig(CommsConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_comms shared_memory_across_process
+    > python -m torchrec.distributed.benchmark.benchmark_comms multi_async_comms
 
     use case:
-        for read-only eval/inference, place the full embedding table in CPU shared
-        memory (/dev/shm) once and let all ranks on the host map the same physical
-        pages -- no sharding, no input/output dist, zero data copies (except one copy
-        on the creator rank). Host-level embedding footprint stays the size of the full
-        table regardless of rank count. Delegates to create_on_rank_and_share_result;
-        CPU-only, same-host (pass an intra-node process group).
-        see https://github.com/meta-pytorch/torchrec/pull/3810 for more details
+        demonstrate two collectives (a2a + all_reduce) issued in different CPU-side
+        order across two ranks, over two independent process groups (ctx.pg + ar_pg):
+        rank 0 runs a2a then all_reduce, rank 1 runs them in the opposite order. Both
+        ranks still complete correctly since each collective matches on its own group.
+        see https://github.com/meta-pytorch/torchrec/pull/4149 for more details
     """
 
-    memory_snapshot: bool = True
-    func: Callable[..., None] = benchmark_shared_memory_across_process
+    # request a dedicated all-reduce process group (passed to func as ar_pg)
+    needs_ar_pg: bool = True
+    all_rank_traces: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def shared_memory_across_process(arg: SharedMemoryAcrossProcessConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_multi_async_comms(
+@register_benchmark(MultiAsyncCommsConfig)
+def multi_async_comms(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -524,32 +557,37 @@ def benchmark_multi_async_comms(
 
 
 @dataclass
-class MultiAsyncCommsConfig(CommsConfig):
+class CompetingCommsConfig(CommsConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_comms multi_async_comms
+    1. default: a2a and all_reduce compete freely on separate streams
+    > python -m torchrec.distributed.benchmark.benchmark_comms competing_comms
+
+    2. wait for comm1: stream_b waits for the a2a before issuing the all_reduce
+    > python -m torchrec.distributed.benchmark.benchmark_comms competing_comms \
+        --name=serialized \
+        --serialized=True
 
     use case:
-        demonstrate two collectives (a2a + all_reduce) issued in different CPU-side
-        order across two ranks, over two independent process groups (ctx.pg + ar_pg):
-        rank 0 runs a2a then all_reduce, rank 1 runs them in the opposite order. Both
-        ranks still complete correctly since each collective matches on its own group.
-        see https://github.com/meta-pytorch/torchrec/pull/4149 for more details
+        collectives on different process groups have independent NCCL communicators, so
+        two of them issued concurrently genuinely compete for NVLink bandwidth (e.g.
+        sparse-dist a2a overlapping with dense-grad all_reduce). This runs a2a on
+        stream_a and all_reduce on stream_b (separate PGs). With serialized=True,
+        stream_b calls req_a.wait() before issuing the all_reduce, serializing the two
+        so each gets full bandwidth -- without blocking the CPU or main stream (only the
+        side stream waits). Compare against the default (free overlap) to see the
+        contention vs serialization tradeoff.
+        see https://github.com/meta-pytorch/torchrec/pull/4251 for more details
     """
 
+    serialized: bool = False
+    all_rank_traces: bool = True
     # request a dedicated all-reduce process group (passed to func as ar_pg)
     needs_ar_pg: bool = True
-    all_rank_traces: bool = True
-    func: Callable[..., None] = benchmark_multi_async_comms
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def multi_async_comms(arg: MultiAsyncCommsConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_competing_comms(
+@register_benchmark(CompetingCommsConfig)
+def competing_comms(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -627,43 +665,28 @@ def benchmark_competing_comms(
 
 
 @dataclass
-class CompetingCommsConfig(CommsConfig):
+class TolistOverlapCommsConfig(CommsConfig):
     """
     run commands:
-    1. default: a2a and all_reduce compete freely on separate streams
-    > python -m torchrec.distributed.benchmark.benchmark_comms competing_comms
-
-    2. wait for comm1: stream_b waits for the a2a before issuing the all_reduce
-    > python -m torchrec.distributed.benchmark.benchmark_comms competing_comms \
-        --name=serialized \
-        --serialized=True
+    > python -m torchrec.distributed.benchmark.benchmark_comms tolist_overlap_comms
 
     use case:
-        collectives on different process groups have independent NCCL communicators, so
-        two of them issued concurrently genuinely compete for NVLink bandwidth (e.g.
-        sparse-dist a2a overlapping with dense-grad all_reduce). This runs a2a on
-        stream_a and all_reduce on stream_b (separate PGs). With serialized=True,
-        stream_b calls req_a.wait() before issuing the all_reduce, serializing the two
-        so each gets full bandwidth -- without blocking the CPU or main stream (only the
-        side stream waits). Compare against the default (free overlap) to see the
-        contention vs serialization tradeoff.
-        see https://github.com/meta-pytorch/torchrec/pull/4251 for more details
+        probe how .tolist() (a CPU-blocking D2H sync) interacts with in-flight async
+        comms across streams, used to investigate an AMD NCCL hang. .tolist() only
+        blocks the CPU thread; it should not stall comms already enqueued on other
+        streams -- which holds on NVIDIA, and on AMD too once the streams stay separate.
+        The real divergence is comm-stream allocation: on AMD a side stream can collapse
+        into the main stream, serializing comm+compute and making .tolist() appear to
+        wait on the comms (a device-wide sync that was never issued). So .tolist() is
+        not the root cause; the AMD side-stream collapse is.
+        see https://github.com/meta-pytorch/torchrec/pull/4299 for more details
     """
 
-    serialized: bool = False
-    all_rank_traces: bool = True
-    # request a dedicated all-reduce process group (passed to func as ar_pg)
-    needs_ar_pg: bool = True
-    func: Callable[..., None] = benchmark_competing_comms
+    num_comms_rounds: int = 5
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def competing_comms(arg: CompetingCommsConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_tolist_overlap_comms(
+@register_benchmark(TolistOverlapCommsConfig)
+def tolist_overlap_comms(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -736,34 +759,34 @@ def benchmark_tolist_overlap_comms(
 
 
 @dataclass
-class TolistOverlapCommsConfig(CommsConfig):
+class CudaEventWaitConfig(CommsConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_comms tolist_overlap_comms
+    1. blocking (default): Event.synchronize() sleeps the calling thread, leaving
+       the CPU core free for the side thread
+    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
+        --name=blocking
+
+    2. spin: the default cuda Event busy-waits inside synchronize(), burning a
+       CPU core that contends with the side thread
+    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
+        --name=spin \
+        --blocking=False
 
     use case:
-        probe how .tolist() (a CPU-blocking D2H sync) interacts with in-flight async
-        comms across streams, used to investigate an AMD NCCL hang. .tolist() only
-        blocks the CPU thread; it should not stall comms already enqueued on other
-        streams -- which holds on NVIDIA, and on AMD too once the streams stay separate.
-        The real divergence is comm-stream allocation: on AMD a side stream can collapse
-        into the main stream, serializing comm+compute and making .tolist() appear to
-        wait on the comms (a device-wide sync that was never issued). So .tolist() is
-        not the root cause; the AMD side-stream collapse is.
-        see https://github.com/meta-pytorch/torchrec/pull/4299 for more details
+        measure how a blocking vs busy-waiting cuda Event.synchronize() affects a
+        concurrent CPU-side workload. Compare the ## side-thread matmul ## slice
+        of the two runs in the chrome trace.
     """
 
-    num_comms_rounds: int = 5
-    func: Callable[..., None] = benchmark_tolist_overlap_comms
+    blocking: bool = True
+    num_profiles: int = 10
+    # capture the raw Python side thread in the chrome trace
+    profile_all_threads: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def tolist_overlap_comms(arg: TolistOverlapCommsConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_cuda_event_wait(
+@register_benchmark(CudaEventWaitConfig)
+def cuda_event_wait(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -871,40 +894,6 @@ def benchmark_cuda_event_wait(
             f"{n_side_matmuls} matmuls ({cpu_mat_dim}x{cpu_mat_dim}); compare the "
             f"## side-thread matmul ## slices against the spin variant in the trace"
         )
-
-
-@dataclass
-class CudaEventWaitConfig(CommsConfig):
-    """
-    run commands:
-    1. blocking (default): Event.synchronize() sleeps the calling thread, leaving
-       the CPU core free for the side thread
-    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
-        --name=blocking
-
-    2. spin: the default cuda Event busy-waits inside synchronize(), burning a
-       CPU core that contends with the side thread
-    > python -m torchrec.distributed.benchmark.benchmark_comms cuda_event_wait \
-        --name=spin \
-        --blocking=False
-
-    use case:
-        measure how a blocking vs busy-waiting cuda Event.synchronize() affects a
-        concurrent CPU-side workload. Compare the ## side-thread matmul ## slice
-        of the two runs in the chrome trace.
-    """
-
-    blocking: bool = True
-    num_profiles: int = 10
-    # capture the raw Python side thread in the chrome trace
-    profile_all_threads: bool = True
-    func: Callable[..., None] = benchmark_cuda_event_wait
-
-
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def cuda_event_wait(arg: CudaEventWaitConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 
 if __name__ == "__main__":

--- a/torchrec/distributed/benchmark/benchmark_data_transfer.py
+++ b/torchrec/distributed/benchmark/benchmark_data_transfer.py
@@ -82,13 +82,6 @@ def _validate(x: torch.Tensor, ctx: MultiProcessContext) -> torch.Tensor:
 
 
 ################################# framework components #################################
-
-
-def _unset_benchmark(*_args: Any, **_kwargs: Any) -> None:
-    # placeholder default for DataCopyConfig.func; each benchmark config sets its own
-    raise NotImplementedError("DataCopyConfig.func must be set by a subclass")
-
-
 @dataclass
 class DataCopyConfig(BenchFuncConfig):
     name: str = ""
@@ -101,11 +94,15 @@ class DataCopyConfig(BenchFuncConfig):
     num_concat: int = 100
     debug_mode: bool = False
     backend: str = "nccl"
-    func: Callable[..., None] = _unset_benchmark
 
 
 # single-rank runner
-def single_rank_runner(rank: int, world_size: int, arg: DataCopyConfig) -> None:
+def single_rank_runner(
+    rank: int,
+    world_size: int,
+    arg: DataCopyConfig,
+    bench_func: Callable[..., None],
+) -> None:
     if arg.backend == "nccl":
         # Ensure GPUs are available and we have enough of them
         assert (
@@ -125,9 +122,7 @@ def single_rank_runner(rank: int, world_size: int, arg: DataCopyConfig) -> None:
         f.name for f in fields(DataCopyConfig)
     }
     new_kwargs = {k: getattr(arg, k) for k in new_keys}
-    func_name = getattr(arg.func, "__name__", arg.name)
-    if func_name.startswith("benchmark_"):
-        func_name = func_name[len("benchmark_") :]
+    func_name = getattr(bench_func, "__name__", arg.name)
     name: str = f"{func_name}_{arg.name}" if arg.name else func_name
 
     torch.autograd.set_detect_anomaly(True)
@@ -147,7 +142,7 @@ def single_rank_runner(rank: int, world_size: int, arg: DataCopyConfig) -> None:
                 "num_concat": arg.num_concat,
             }
             | new_kwargs,
-            func_to_benchmark=arg.func,
+            func_to_benchmark=bench_func,
             rank=rank,
             # Input is empty, actual traffic is determined by the benchmark function
             sample_count=0,
@@ -158,8 +153,60 @@ def single_rank_runner(rank: int, world_size: int, arg: DataCopyConfig) -> None:
             print(result)
 
 
+def register_benchmark(
+    config: type[DataCopyConfig],
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """
+    Decorator factory: register a benchmark function with the CLI, bound to the
+    given config class. The decorated function is the per-iteration benchmark and
+    its name is the CLI subcommand. Define the config class first, then:
+
+    @register_benchmark(LazyAwaitableConfig)
+    def lazyawaitable(_batch_inputs, ..., ctx, **_kwargs): ...
+    """
+
+    def decorator(func: Callable[..., None]) -> Callable[..., None]:
+        def dispatch(arg: DataCopyConfig) -> None:
+            run_multi_process_func(
+                func=single_rank_runner,
+                world_size=arg.world_size,
+                arg=arg,
+                bench_func=func,
+            )
+
+        # CLI subcommand key = benchmark function name; the annotation must be the
+        # concrete config subclass so cmd_conf builds its argparse from its fields
+        dispatch.__name__ = func.__name__
+        dispatch.__annotations__ = {"arg": config, "return": None}
+        # pyrefly: ignore[missing-attribute]
+        _cc.register(dispatch)
+        return func
+
+    return decorator
+
+
 ###################################### benchmarks ######################################
-def benchmark_lazyawaitable(
+@dataclass
+class LazyAwaitableConfig(DataCopyConfig):
+    """
+    run commands:
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer lazyawaitable
+
+    use case:
+        demonstrate the use of the device-to-host lazy awaitable. The
+        DeviceToHostTensorAwaitable wraps a non-blocking device-to-host transfer
+        together with a CUDA event and defers the cudaEventSync until the value is
+        actually read on the host. This removes a CPU-blocking sync point, so the
+        post-comms compute can be scheduled ahead of the host-side assertion --
+        useful for sync-point removal in training optimization.
+        see https://github.com/meta-pytorch/torchrec/pull/3477 for more details
+    """
+
+    name: str = "lazyawaitable"
+
+
+@register_benchmark(LazyAwaitableConfig)
+def lazyawaitable(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -201,32 +248,40 @@ def benchmark_lazyawaitable(
 
 
 @dataclass
-class LazyAwaitableConfig(DataCopyConfig):
+class H2DCopyConfig(DataCopyConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer lazyawaitable
+    1. non-blocking (default): host-to-device data copy, w/o pre-allocated memory
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy
+
+    2. pre-allocated: non-blocking host-to-device data copy, w/ pre-allocated memory
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
+        --name=preallocated \
+        --preallocated=True
+
+    3. blocking: blocking host-to-device data copy
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
+        --name=blocking \
+        --use_data_copy_stream=False
 
     use case:
-        demonstrate the use of the device-to-host lazy awaitable. The
-        DeviceToHostTensorAwaitable wraps a non-blocking device-to-host transfer
-        together with a CUDA event and defers the cudaEventSync until the value is
-        actually read on the host. This removes a CPU-blocking sync point, so the
-        post-comms compute can be scheduled ahead of the host-side assertion --
-        useful for sync-point removal in training optimization.
-        see https://github.com/meta-pytorch/torchrec/pull/3477 for more details
+        study the CUDA cached-memory footprint of host-to-device copies. A
+        non-blocking copy on a side stream inflates that stream's reserved
+        memory: the copied tensor is allocated on the side stream and is not
+        shared back with the main stream by the caching allocator.
+        Pre-allocating on the main stream and doing an in-place copy on the side
+        stream keeps the footprint as low as a blocking copy.
+        see https://github.com/meta-pytorch/torchrec/pull/3485 and
+        https://github.com/meta-pytorch/torchrec/pull/3510 for more details
     """
 
-    name: str = "lazyawaitable"
-    func: Callable[..., None] = benchmark_lazyawaitable
+    memory_snapshot: bool = True
+    preallocated: bool = False
+    use_data_copy_stream: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def lazyawaitable(arg: LazyAwaitableConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_h2d_data_copy(
+@register_benchmark(H2DCopyConfig)
+def h2d_data_copy(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -278,46 +333,38 @@ def benchmark_h2d_data_copy(
 
 
 @dataclass
-class H2DCopyConfig(DataCopyConfig):
+class StreamMemoryConfig(DataCopyConfig):
     """
     run commands:
-    1. non-blocking (default): host-to-device data copy, w/o pre-allocated memory
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy
+    1. single stream: copy + a2a on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
+        --name=single \
+        --multi_stream=False
 
-    2. pre-allocated: non-blocking host-to-device data copy, w/ pre-allocated memory
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
-        --name=preallocated \
+    2. multi stream (default): copy on a side stream, a2a on a dedicated dist stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory
+
+    3. optimized: pre-allocated in-place copy on a side stream, a2a on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
+        --name=optimized \
         --preallocated=True
 
-    3. blocking: blocking host-to-device data copy
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_data_copy \
-        --name=blocking \
-        --use_data_copy_stream=False
-
     use case:
-        study the CUDA cached-memory footprint of host-to-device copies. A
-        non-blocking copy on a side stream inflates that stream's reserved
-        memory: the copied tensor is allocated on the side stream and is not
-        shared back with the main stream by the caching allocator.
-        Pre-allocating on the main stream and doing an in-place copy on the side
-        stream keeps the footprint as low as a blocking copy.
-        see https://github.com/meta-pytorch/torchrec/pull/3485 and
-        https://github.com/meta-pytorch/torchrec/pull/3510 for more details
+        study the CUDA memory footprint when overlapping an H2D copy and an
+        all-to-all with compute across streams. A side-stream copy/comm overlaps
+        well but inflates that stream's reserved memory; pre-allocating on the main
+        stream + in-place copy, and letting all_to_all_single use NCCL's own async
+        stream, keeps the overlap while avoiding the extra footprint.
+        see https://github.com/meta-pytorch/torchrec/pull/3480 for more details
     """
 
     memory_snapshot: bool = True
+    multi_stream: bool = True
     preallocated: bool = False
-    use_data_copy_stream: bool = True
-    func: Callable[..., None] = benchmark_h2d_data_copy
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def h2d_data_copy(arg: H2DCopyConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_stream_memory(
+@register_benchmark(StreamMemoryConfig)
+def stream_memory(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -440,44 +487,36 @@ def benchmark_stream_memory(
 
 
 @dataclass
-class StreamMemoryConfig(DataCopyConfig):
+class ThreadingCopyConfig(DataCopyConfig):
     """
     run commands:
-    1. single stream: copy + a2a on the main stream
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
-        --name=single \
-        --multi_stream=False
+    1. multi-threaded (default): issue the H2D copies from a worker thread
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy
 
-    2. multi stream (default): copy on a side stream, a2a on a dedicated dist stream
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory
-
-    3. optimized: pre-allocated in-place copy on a side stream, a2a on the main stream
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer stream_memory \
-        --name=optimized \
-        --preallocated=True
+    2. single-threaded: run the copies inline on the main thread
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy \
+        --name=single_thread \
+        --multithreading=False
 
     use case:
-        study the CUDA memory footprint when overlapping an H2D copy and an
-        all-to-all with compute across streams. A side-stream copy/comm overlaps
-        well but inflates that stream's reserved memory; pre-allocating on the main
-        stream + in-place copy, and letting all_to_all_single use NCCL's own async
-        stream, keeps the overlap while avoiding the extra footprint.
-        see https://github.com/meta-pytorch/torchrec/pull/3480 for more details
+        in production models the input batch has 500+ tensors copied host-to-device
+        one by one; even though each copy is non-blocking, the per-call CPU overhead
+        (Python loop + CUDA driver dispatch) accumulates and blocks the main thread
+        from dispatching forward-pass kernels. This benchmark simulates that with many
+        small pinned tensors and checks whether issuing the copies from a separate
+        Python thread (via concurrent.futures.ThreadPoolExecutor, on a side CUDA
+        stream) frees the main thread and lets the copies overlap main-stream compute.
+        CUDA calls release the GIL so the background thread does not block the main
+        thread, though the Python copy loop itself still contends on the GIL.
+        see https://github.com/meta-pytorch/torchrec/pull/3774 for more details
     """
 
     memory_snapshot: bool = True
-    multi_stream: bool = True
-    preallocated: bool = False
-    func: Callable[..., None] = benchmark_stream_memory
+    multithreading: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def stream_memory(arg: StreamMemoryConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_threading_copy(
+@register_benchmark(ThreadingCopyConfig)
+def threading_copy(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -545,42 +584,34 @@ def benchmark_threading_copy(
 
 
 @dataclass
-class ThreadingCopyConfig(DataCopyConfig):
+class DataCopyRecordStreamConfig(DataCopyConfig):
     """
     run commands:
-    1. multi-threaded (default): issue the H2D copies from a worker thread
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy
+    1. with record_stream (correct, default)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream
 
-    2. single-threaded: run the copies inline on the main thread
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer threading_copy \
-        --name=single_thread \
-        --multithreading=False
+    2. without record_stream (reproduces the bug)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream \
+        --name=no_record_stream \
+        --use_record_stream=False
 
     use case:
-        in production models the input batch has 500+ tensors copied host-to-device
-        one by one; even though each copy is non-blocking, the per-call CPU overhead
-        (Python loop + CUDA driver dispatch) accumulates and blocks the main thread
-        from dispatching forward-pass kernels. This benchmark simulates that with many
-        small pinned tensors and checks whether issuing the copies from a separate
-        Python thread (via concurrent.futures.ThreadPoolExecutor, on a side CUDA
-        stream) frees the main thread and lets the copies overlap main-stream compute.
-        CUDA calls release the GIL so the background thread does not block the main
-        thread, though the Python copy loop itself still contends on the GIL.
-        see https://github.com/meta-pytorch/torchrec/pull/3774 for more details
+        reproduce the NaN corruption bug fixed by D102202725 in EMS memory stashing.
+        record_stream() tells the CUDA caching allocator to defer reuse of a tensor's
+        memory until the recording stream catches up. Without it, freeing the source
+        via untyped_storage().resize_(0) on the main stream lets the allocator hand the
+        block to a new allocation while an async D2H copy on a side stream is still
+        reading it, corrupting the copied data (NaN / wrong values). With
+        use_record_stream the copy validates correctly; without it validation fails.
+        see https://github.com/meta-pytorch/torchrec/pull/4231 for more details
     """
 
     memory_snapshot: bool = True
-    multithreading: bool = True
-    func: Callable[..., None] = benchmark_threading_copy
+    use_record_stream: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def threading_copy(arg: ThreadingCopyConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_data_copy_record_stream(
+@register_benchmark(DataCopyRecordStreamConfig)
+def data_copy_record_stream(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -643,40 +674,46 @@ def benchmark_data_copy_record_stream(
 
 
 @dataclass
-class DataCopyRecordStreamConfig(DataCopyConfig):
+class CopyEngineContentionConfig(DataCopyConfig):
     """
     run commands:
-    1. with record_stream (correct, default)
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream
+    1. default: back-to-back trunked H2D vs small copies on the main stream
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention
 
-    2. without record_stream (reproduces the bug)
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer data_copy_record_stream \
-        --name=no_record_stream \
-        --use_record_stream=False
+    2. dummy compute between trunks
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention \
+        --name=dummy_compute \
+        --dummy_compute=True
+
+    3. dummy compute + 10x trunks (smaller trunks, compute fires more often)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention \
+        --name=dummy_compute_10x_trunk \
+        --dummy_compute=True \
+        --trunk_count=30
 
     use case:
-        reproduce the NaN corruption bug fixed by D102202725 in EMS memory stashing.
-        record_stream() tells the CUDA caching allocator to defer reuse of a tensor's
-        memory until the recording stream catches up. Without it, freeing the source
-        via untyped_storage().resize_(0) on the main stream lets the allocator hand the
-        block to a new allocation while an async D2H copy on a side stream is still
-        reading it, corrupting the copied data (NaN / wrong values). With
-        use_record_stream the copy validates correctly; without it validation fails.
-        see https://github.com/meta-pytorch/torchrec/pull/4231 for more details
+        reproduce and mitigate CUDA copy-engine contention. A bulk H2D copy (e.g. EMS
+        embedding restore) saturates the GPU's single same-direction DMA copy engine,
+        blocking small H2D copies -- and the dependent compute -- on other streams. The
+        copy engine is priority-blind and current-stream-first, so consecutive
+        same-stream trunks run back-to-back and chunking alone never yields. Here the
+        h2d_stream runs one bulk H2D split into trunk_count trunks via chunked_copy_,
+        while the main stream interleaves a small D2H and two small H2D copies with
+        compute. With dummy_compute a tiny op is inserted between trunks, forcing the
+        engine to yield so the main stream's small H2D copies slip into the gaps (the
+        D2H is unaffected -- it uses a separate copy engine). Smaller trunks (larger
+        trunk_count) tighten the contention latency at a small bandwidth cost.
+        see https://github.com/meta-pytorch/torchrec/pull/4303 and
+        https://github.com/meta-pytorch/torchrec/pull/4339 for more details
     """
 
     memory_snapshot: bool = True
-    use_record_stream: bool = True
-    func: Callable[..., None] = benchmark_data_copy_record_stream
+    dummy_compute: bool = False
+    trunk_count: int = 3
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def data_copy_record_stream(arg: DataCopyRecordStreamConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_copy_engine_contention(
+@register_benchmark(CopyEngineContentionConfig)
+def copy_engine_contention(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -802,52 +839,27 @@ def benchmark_copy_engine_contention(
 
 
 @dataclass
-class CopyEngineContentionConfig(DataCopyConfig):
+class H2DExecutionOrderConfig(DataCopyConfig):
     """
     run commands:
-    1. default: back-to-back trunked H2D vs small copies on the main stream
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention
-
-    2. dummy compute between trunks
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention \
-        --name=dummy_compute \
-        --dummy_compute=True
-
-    3. dummy compute + 10x trunks (smaller trunks, compute fires more often)
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer copy_engine_contention \
-        --name=dummy_compute_10x_trunk \
-        --dummy_compute=True \
-        --trunk_count=30
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_execution_order
 
     use case:
-        reproduce and mitigate CUDA copy-engine contention. A bulk H2D copy (e.g. EMS
-        embedding restore) saturates the GPU's single same-direction DMA copy engine,
-        blocking small H2D copies -- and the dependent compute -- on other streams. The
-        copy engine is priority-blind and current-stream-first, so consecutive
-        same-stream trunks run back-to-back and chunking alone never yields. Here the
-        h2d_stream runs one bulk H2D split into trunk_count trunks via chunked_copy_,
-        while the main stream interleaves a small D2H and two small H2D copies with
-        compute. With dummy_compute a tiny op is inserted between trunks, forcing the
-        engine to yield so the main stream's small H2D copies slip into the gaps (the
-        D2H is unaffected -- it uses a separate copy engine). Smaller trunks (larger
-        trunk_count) tighten the contention latency at a small bandwidth cost.
-        see https://github.com/meta-pytorch/torchrec/pull/4303 and
-        https://github.com/meta-pytorch/torchrec/pull/4339 for more details
+        observe the copy engine's execution order across three streams that reach their
+        H2D copies at different times (controlled by different pre-copy compute).
+        Reverse-engineered model: the engine uses readiness-based dispatch (it runs
+        whichever copy becomes ready next, regardless of CPU issue order) with
+        current-stream-first scheduling (consecutive same-stream copies run back-to-back
+        unless a dummy op breaks their readiness). The CPU issues the long-compute
+        stream first but its copy reaches the engine last -- check the trace to confirm.
+        see https://github.com/meta-pytorch/torchrec/pull/4315 for more details
     """
 
     memory_snapshot: bool = True
-    dummy_compute: bool = False
-    trunk_count: int = 3
-    func: Callable[..., None] = benchmark_copy_engine_contention
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def copy_engine_contention(arg: CopyEngineContentionConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_h2d_execution_order(
+@register_benchmark(H2DExecutionOrderConfig)
+def h2d_execution_order(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -980,33 +992,33 @@ def benchmark_h2d_execution_order(
 
 
 @dataclass
-class H2DExecutionOrderConfig(DataCopyConfig):
+class A2AD2HContentionConfig(DataCopyConfig):
     """
     run commands:
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer h2d_execution_order
+    1. concurrent (default): a2a and D2H run on separate streams simultaneously
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer a2a_d2h_contention
+
+    2. sequential: D2H waits for the a2a to finish (contention-free baseline)
+    > python -m torchrec.distributed.benchmark.benchmark_data_transfer a2a_d2h_contention \
+        --name=sequential \
+        --concurrent=False
 
     use case:
-        observe the copy engine's execution order across three streams that reach their
-        H2D copies at different times (controlled by different pre-copy compute).
-        Reverse-engineered model: the engine uses readiness-based dispatch (it runs
-        whichever copy becomes ready next, regardless of CPU issue order) with
-        current-stream-first scheduling (consecutive same-stream copies run back-to-back
-        unless a dummy op breaks their readiness). The CPU issues the long-compute
-        stream first but its copy reaches the engine last -- check the trace to confirm.
-        see https://github.com/meta-pytorch/torchrec/pull/4315 for more details
+        measure whether a device-to-host copy (PCIe copy engine) contends with
+        all_to_all_single (NVLink/NVSwitch) when overlapped. Running both concurrently
+        vs sequentially (the contention-free baseline) shows comparable a2a latency:
+        D2H and NCCL collectives use largely independent data paths, so they are safe to
+        overlap. The concurrent variant surfaces any shared-resource contention (copy
+        engine, memory controller, L2 bandwidth) as increased latency in the trace.
+        see https://github.com/meta-pytorch/torchrec/pull/4292 for more details
     """
 
     memory_snapshot: bool = True
-    func: Callable[..., None] = benchmark_h2d_execution_order
+    concurrent: bool = True
 
 
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def h2d_execution_order(arg: H2DExecutionOrderConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
-
-
-def benchmark_a2a_d2h_contention(
+@register_benchmark(A2AD2HContentionConfig)
+def a2a_d2h_contention(
     _batch_inputs: List[Dict[str, Any]],
     dim: int,
     num_mul: int,
@@ -1081,39 +1093,6 @@ def benchmark_a2a_d2h_contention(
     with record_function("## assert ##"):
         assert checks_a2a.item()
         assert d2h_correct, f"D2H copy validation failed on rank {ctx.rank}"
-
-
-@dataclass
-class A2AD2HContentionConfig(DataCopyConfig):
-    """
-    run commands:
-    1. concurrent (default): a2a and D2H run on separate streams simultaneously
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer a2a_d2h_contention
-
-    2. sequential: D2H waits for the a2a to finish (contention-free baseline)
-    > python -m torchrec.distributed.benchmark.benchmark_data_transfer a2a_d2h_contention \
-        --name=sequential \
-        --concurrent=False
-
-    use case:
-        measure whether a device-to-host copy (PCIe copy engine) contends with
-        all_to_all_single (NVLink/NVSwitch) when overlapped. Running both concurrently
-        vs sequentially (the contention-free baseline) shows comparable a2a latency:
-        D2H and NCCL collectives use largely independent data paths, so they are safe to
-        overlap. The concurrent variant surfaces any shared-resource contention (copy
-        engine, memory controller, L2 bandwidth) as increased latency in the trace.
-        see https://github.com/meta-pytorch/torchrec/pull/4292 for more details
-    """
-
-    memory_snapshot: bool = True
-    concurrent: bool = True
-    func: Callable[..., None] = benchmark_a2a_d2h_contention
-
-
-# pyrefly: ignore[missing-attribute]
-@_cc.register
-def a2a_d2h_contention(arg: A2AD2HContentionConfig) -> None:
-    run_multi_process_func(func=single_rank_runner, world_size=arg.world_size, arg=arg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The comms and data-transfer benchmark drivers each repeated the same registration boilerplate for every benchmark: a `func` field on the config dataclass pointing at the per-iteration function, plus a hand-written `_cc.register def <name>(arg): run_multi_process_func(...)` dispatch wrapper. This made adding a benchmark a three-part dance (impl function, config field, dispatch function) and left the CLI subcommand name implicit.

This diff introduces a `register_benchmark(config)` decorator factory that is applied directly to the benchmark function. The decorator binds the function to its config class, builds the `run_multi_process_func` dispatch closure, and registers it with `cmd_conf` under the function's own name (which becomes the CLI subcommand). The per-iteration function is threaded explicitly into `single_rank_runner` via a new `bench_func` parameter instead of living on the config.

Concretely:
- `CommsConfig` / `DataCopyConfig` no longer carry a `func` field; the `_unset_benchmark` placeholder is removed.
- `single_rank_runner` takes an explicit `bench_func: Callable[..., None]` (forwarded through `run_multi_process_func`'s `**kwargs`) and uses it for both the trace name and `func_to_benchmark`. The now-dead `benchmark_` prefix-strip is gone.
- Each benchmark is now declared as `dataclass` config first, then `register_benchmark(Config)` on the function. The function name is the CLI subcommand, so the `benchmark_` prefix is dropped from the impls (e.g. `benchmark_all_to_all_base` -> `all_to_all_base`).
- Removed all hand-written `_cc.register` dispatch functions.

No behavior change for users: every CLI subcommand keeps its existing name, and all flags/configs are unchanged. This is a pure refactor that removes ~10 lines of boilerplate per benchmark across the two files.

Differential Revision: D108771335


