### PR TITLE
Migrate Tier-A TBE type imports to fbgemm_gpu.tbe.* leaves (Phase 3.1a)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_split_table_batched_embeddings.py
+++ b/torchrec/distributed/benchmark/benchmark_split_table_batched_embeddings.py
@@ -14,15 +14,29 @@ from typing import Dict, List
 import click
 import torch
 from fbgemm_gpu.split_embedding_configs import EmbOptimType as OptimType, SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    BoundsCheckMode,
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     ComputeDevice,
     SplitTableBatchedEmbeddingBagsCodegen,
 )
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import (
+        BoundsCheckMode,
+        EmbeddingLocation,
+        PoolingMode,
+    )
+except ImportError:
+    # Fallback for a base-layer fbgemm_gpu that predates the tbe.config leaf module
+    # (created 2026-05-06). Tracked via _log_api_usage_once so this can be removed
+    # once base layers roll forward (cf. D105254047 for the SSD analogue).
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.benchmark.benchmark_split_table_batched_embeddings.import_failure.tbe_config_types"
+    )
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        BoundsCheckMode,
+        EmbeddingLocation,
+        PoolingMode,
+    )
 from torchrec.distributed.benchmark.base import benchmark_func
 from torchrec.distributed.test_utils.test_model import ModelInput
 from torchrec.modules.embedding_configs import EmbeddingBagConfig

--- a/torchrec/distributed/embedding_types.py
+++ b/torchrec/distributed/embedding_types.py
@@ -28,7 +28,17 @@ from typing import (
 )
 
 import torch
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation
+except ImportError:
+    # Fallback for a base-layer fbgemm_gpu that predates the tbe.config leaf module
+    # (created 2026-05-06). Tracked via _log_api_usage_once so this can be removed
+    # once base layers roll forward (cf. D105254047 for the SSD analogue).
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.embedding_types.import_failure.tbe_config_types"
+    )
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import EmbeddingLocation
 from torch import fx, nn
 from torch.distributed._tensor import DeviceMesh
 from torch.distributed._tensor.placement_types import Placement

--- a/torchrec/distributed/test_utils/infer_utils.py
+++ b/torchrec/distributed/test_utils/infer_utils.py
@@ -17,13 +17,23 @@ import torch
 import torchrec
 from fbgemm_gpu import sparse_ops  # noqa: F401, E402
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
-    EmbeddingLocation,
-    PoolingMode,
-)
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import EmbeddingLocation, PoolingMode
+except ImportError:
+    # Fallback for a base-layer fbgemm_gpu that predates the tbe.config leaf module
+    # (created 2026-05-06). Tracked via _log_api_usage_once so this can be removed
+    # once base layers roll forward (cf. D105254047 for the SSD analogue).
+    torch._C._log_api_usage_once(
+        "torchrec.distributed.test_utils.infer_utils.import_failure.tbe_config_types"
+    )
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
+        EmbeddingLocation,
+        PoolingMode,
+    )
 from torch import nn, quantization as quant, Tensor
 from torch.distributed._shard.sharding_spec import ShardingSpec
 from torch.utils import _pytree as pytree

--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -15,7 +15,17 @@ from typing import Callable, Dict, List, NamedTuple, Optional
 
 import torch
 from fbgemm_gpu.split_embedding_configs import SparseType
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import PoolingMode
+
+try:
+    from fbgemm_gpu.tbe.config.embedding_config import PoolingMode
+except ImportError:
+    # Fallback for a base-layer fbgemm_gpu that predates the tbe.config leaf module
+    # (created 2026-05-06). Tracked via _log_api_usage_once so this can be removed
+    # once base layers roll forward (cf. D105254047 for the SSD analogue).
+    torch._C._log_api_usage_once(
+        "torchrec.modules.embedding_configs.import_failure.tbe_config_types"
+    )
+    from fbgemm_gpu.split_table_batched_embeddings_ops_common import PoolingMode
 from torchrec.types import DataType
 
 
@@ -244,7 +254,7 @@ class FeatureScoreBasedEvictionPolicy(VirtualTableEvictionPolicy):
     feature_score_default_value: Optional[float] = None  # default feature score value
     enable_auto_feature_score_collection: bool = False
     enable_eviction: bool = (
-        True  # Currently we only support using same eviction policy in one tbe for mutiple tables, if one table doesn't need eviction we can set this flag to False
+        True  # Currently we only support using same eviction policy in one tbe for multiple tables, if one table doesn't need eviction we can set this flag to False
     )
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Summary:
Phase 3.1a of the TBE type migration: point torchrec's Tier-A imports at the
canonical fbgemm_gpu.tbe.* leaf modules instead of the legacy
split_table_batched_embeddings_ops_common / _ops_training paths.

Tier-A types have existed for many releases and are now leaf-canonical; these are
identity-preserving switches (the legacy shim re-exports the same leaf class
object), so no behavior change and no fallback needed.

- embedding_types.py, test_utils/infer_utils.py,
  benchmark/benchmark_split_table_batched_embeddings.py,
  modules/embedding_configs.py, fb/ir/serializer.py: EmbeddingLocation /
  PoolingMode / BoundsCheckMode -> fbgemm_gpu.tbe.config.embedding_config.
- fb/distributed/tests/test_logging_handlers.py: CacheAlgorithm ->
  fbgemm_gpu.tbe.cache.cache_config.
- fb/optim/module_optimizer.py: CounterBasedRegularizationDefinition,
  WeightDecayMode -> fbgemm_gpu.tbe.config.optimizer_config (module_optimizer
  stores WeightDecayMode in a fused-optimizer config; identity preserved).
- autodeps updated the torchrec BUCK deps.

NOT included (follow-ups): the SSD/KVZCH/enrichment Tier-B imports that already use
a try/except ImportError fallback (types.py, batched_embedding_kernel.py,
embedding_lookup.py, sharding_config.py, test_embedding_sharding.py) -- those are
simplified in Phase 3.1b once the backend is guaranteed present.

LANDING ORDER: land only AFTER the fbgemm backend stack (D107684319..D107684314)
is in the prod fbpkg label (~1 week), so the leaf modules are guaranteed at runtime.

Reviewed By: xywang9334

Differential Revision: D107724582


