### PR TITLE
fix type failures (#4359)

### DIFF
--- a/torchrec/distributed/keyed_jagged_tensor_pool.py
+++ b/torchrec/distributed/keyed_jagged_tensor_pool.py
@@ -488,7 +488,6 @@ class ShardedInferenceKeyedJaggedTensorPool(
 ):
     _local_kjt_pool_shards: torch.nn.ModuleList
     _world_size: int
-    _device: torch.device
 
     def __init__(
         self,
@@ -507,7 +506,7 @@ class ShardedInferenceKeyedJaggedTensorPool(
         self._values_dtype = values_dtype
         self._sharding_env = sharding_env
         self._world_size = self._sharding_env.world_size
-        self._device = device or torch.device("cuda")
+        self._device: torch.device = device or torch.device("cuda")
         self._sharding_plan = sharding_plan
 
         self._is_weighted = is_weighted

--- a/torchrec/distributed/sharding/rw_pool_sharding.py
+++ b/torchrec/distributed/sharding/rw_pool_sharding.py
@@ -179,7 +179,6 @@ class InferRwObjectPoolInputDist(torch.nn.Module):
     """
 
     _world_size: int
-    _device: torch.device
     _block_size: torch.Tensor
     _block_bucketize_row_pos: list[torch.Tensor]
 
@@ -192,7 +191,7 @@ class InferRwObjectPoolInputDist(torch.nn.Module):
     ) -> None:
         super().__init__()
         self._world_size = env.world_size
-        self._device = device
+        self._device: torch.device = device
         self._block_size = block_size
         self._block_bucketize_row_pos: list[torch.Tensor] = (
             [] if block_bucketize_row_pos is None else block_bucketize_row_pos

--- a/torchrec/distributed/utils.py
+++ b/torchrec/distributed/utils.py
@@ -491,7 +491,7 @@ def add_params_from_parameter_sharding(
         and parameter_sharding.key_value_params is not None
     ):
         kv_params = parameter_sharding.key_value_params
-        key_value_params_dict = asdict(kv_params)
+        key_value_params_dict: Dict[str, Any] = asdict(kv_params)
         key_value_params_dict = {
             k: v for k, v in key_value_params_dict.items() if v is not None
         }


### PR DESCRIPTION
Summary:

moving `_device` annotations from class bodies to instance variables so pyre treats the fields as writable instance attributes instead of read-only descriptors

Reviewed By: Ali-Tehrani

Differential Revision: D108774483


