### PR TITLE
Remove `mig = "false"` references from docs

### DIFF
--- a/torchrec/.claude/skills/test-gen/SKILL.md
+++ b/torchrec/.claude/skills/test-gen/SKILL.md
@@ -132,7 +132,6 @@ python_unittest(
     name = "test_my_module",
     srcs = ["test_my_module.py"],
     remote_execution = re_test_utils.remote_execution(
-        mig = "false",
         platform = "gpu-remote-execution",
         resource_units = 2,
     ),

--- a/torchrec/.claude/skills/test-gen/test-patterns.md
+++ b/torchrec/.claude/skills/test-gen/test-patterns.md
@@ -314,7 +314,6 @@ python_unittest(
     name = "test_my_sharding",
     srcs = ["test_my_sharding.py"],
     remote_execution = re_test_utils.remote_execution(
-        mig = "false",
         platform = "gpu-remote-execution",
         resource_units = 2,
     ),
@@ -333,7 +332,6 @@ python_unittest(
     name = "test_my_sharding",
     srcs = ["test_my_sharding.py"],
     remote_execution = re_test_utils.remote_execution(
-        mig = "false",
         platform = "gpu-remote-execution",
         resource_units = 2,
     ),


### PR DESCRIPTION
Summary: Follow-up to the BUCK cleanup: drops `mig = "false"` from `remote_execution(...)` code examples in skills/KB/RE docs, and rewords the few prose/table mentions that described the now-removed argument.

Differential Revision: D109147933


