### PR TITLE
Fix backward gradient count for torchrec::reduce_scatter_tensor (#4363)

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -2767,7 +2767,7 @@ def reduce_scatter_tensor_backward(ctx, grad):
     if ctx.gradient_division:
         grad.div_(ctx.group_size)
 
-    return grad, None, None, None, None, None
+    return grad, None, None, None, None
 
 
 torch.library.register_autograd(


### PR DESCRIPTION
Summary:

## Problem

The autograd backward formula for the custom op `torchrec::reduce_scatter_tensor` returned 6 gradients, but the op only has 5 positional inputs (`input`, `reduceOp`, `group_size`, `group_name`, `gradient_division`). PyTorch's `register_autograd` requires the backward function to return exactly one gradient per forward input, so this raised at runtime on every backward pass:

```
RuntimeError: The backward formula for torchrec.reduce_scatter_tensor.default returned an incorrect number of gradients (expected 5, got 6). Expected one gradient for each forward input, or for each positional input to the operator. Use None for inputs that do not require a gradient.
```

This disabled `test_reduce_scatter_pooled` (0/36 passing).

## Fix

Only `input` is differentiable, so the backward returns the computed gradient for `input` plus `None` for the four non-differentiable args (`reduceOp`, `group_size`, `group_name`, `gradient_division`) — five values total. Previously it returned a sixth, extra `None`. This matches the sibling op `all_gather_into_tensor_backward`, which has the same 5-input signature and correctly returns 5 values.

## Why it surfaced now

This is a latent bug, not new code. The op has returned 6 values since it was added in 2025-10 (`746fbf0f5918`), and `comm_ops.py` has not changed since May. For months the old custom-op autograd wrapper silently tolerated the extra `None` — it did no count validation, just appended its own trailing `None`.

PyTorch core commit `b35a705ff294` ("Fix custom op autograd gradient count errors", #186226), relanded 2026-06-12, added strict validation that the backward return count must equal the number of op inputs. This surfaced the long-standing arity mismatch. The change here brings the op into compliance with the new contract.

## Note

Authored with assistance from an AI coding agent.

Differential Revision: D109255890


