### PR TITLE
Fix Pyre type-check failures in torchrec/sparse/tests/test_keyed_tensor

### DIFF
--- a/torchrec/sparse/tests/test_keyed_tensor.py
+++ b/torchrec/sparse/tests/test_keyed_tensor.py
@@ -664,12 +664,13 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
             for out, ref in zip(outputs, out_lengths):
                 self.assertEqual(out.shape, (batch_size, ref))
         else:
-            refs = [[] for _ in groups]
+            ref_groups: list[list[torch.Tensor]] = [[] for _ in groups]
             for i in range(permutes.size(0)):
                 in_idx, out, in_start, _, length, _ = permutes[i].tolist()
-                refs[out].append(values[in_idx][:, in_start : (in_start + length)])
-            # pyrefly: ignore[no-matching-overload]
-            refs = [torch.cat(ref, dim=1) for ref in refs]
+                ref_groups[out].append(
+                    values[in_idx][:, in_start : (in_start + length)]
+                )
+            refs = [torch.cat(ref, dim=1) for ref in ref_groups]
             for out, ref in zip(outputs, refs):
                 torch.testing.assert_close(out, ref)
 
@@ -708,12 +709,13 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
             for out, ref in zip(outputs, out_lengths):
                 self.assertEqual(out.shape, (batch_size, ref))
         else:
-            refs = [[] for _ in groups]
+            ref_groups: list[list[torch.Tensor]] = [[] for _ in groups]
             for i in range(permutes.size(0)):
                 in_idx, out, in_start, _, length, _ = permutes[i].tolist()
-                refs[out].append(values[in_idx][:, in_start : (in_start + length)])
-            # pyrefly: ignore[no-matching-overload]
-            refs = [torch.cat(ref, dim=1) for ref in refs]
+                ref_groups[out].append(
+                    values[in_idx][:, in_start : (in_start + length)]
+                )
+            refs = [torch.cat(ref, dim=1) for ref in ref_groups]
             for out, ref in zip(outputs, refs):
                 torch.testing.assert_close(out, ref)
                 self.assertEqual(out.dtype, ref.dtype)
@@ -747,12 +749,13 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
         permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
             values[0], keys, lengths, groups
         )
-        refs = [[] for _ in groups]
+        ref_groups: list[list[torch.Tensor]] = [[] for _ in groups]
         for i in range(permutes.size(0)):
             in_idx, out_idx, in_start, _, length, _ = permutes[i].tolist()
-            refs[out_idx].append(ref_values[in_idx][:, in_start : (in_start + length)])
-        # pyrefly: ignore[no-matching-overload]
-        refs = [torch.cat(ref, dim=1) for ref in refs]
+            ref_groups[out_idx].append(
+                ref_values[in_idx][:, in_start : (in_start + length)]
+            )
+        refs = [torch.cat(ref, dim=1) for ref in ref_groups]
         outputs = torch.ops.fbgemm.permute_multi_embedding(
             values, permutes, in_shapes, out_shapes, out_lengths
         )
@@ -943,12 +946,13 @@ class TestKeyedTensorRegroupOp(unittest.TestCase):
         permutes, in_shapes, out_shapes, out_lengths = _kt_regroup_arguments(
             values[0], keys, lengths, groups
         )
-        refs = [[] for _ in groups]
+        ref_groups: list[list[torch.Tensor]] = [[] for _ in groups]
         for i in range(permutes.size(0)):
             in_idx, out_idx, in_start, _, length, _ = permutes[i].tolist()
-            refs[out_idx].append(ref_values[in_idx][:, in_start : (in_start + length)])
-        # pyrefly: ignore[no-matching-overload]
-        refs = [torch.cat(ref, dim=1) for ref in refs]
+            ref_groups[out_idx].append(
+                ref_values[in_idx][:, in_start : (in_start + length)]
+            )
+        refs = [torch.cat(ref, dim=1) for ref in ref_groups]
         outputs = torch.ops.fbgemm.regroup_keyed_tensor(
             values,
             keys,


### PR DESCRIPTION
Summary:
Re-enables the disabled `fbcode//torchrec/sparse/tests:test_keyed_tensor-library-type-checking` test (test_id 281475298982630).

Four `torch.cat(ref, dim=1)` calls were rejected with `list[list[Unknown]] is not assignable to parameter tensors with type list[Tensor]`. The accumulator was created as `refs = [[] for _ in groups]`, which the checker infers as `list[list[Unknown]]`; appending tensors in the loop does not refine the empty-list element type, so each `ref` passed to `torch.cat` stayed `list[Unknown]`.

Gave the accumulator a distinct, explicitly typed name `ref_groups: list[list[torch.Tensor]]` and built the final `refs` from it. This declares the real element type so `torch.cat` sees `list[Tensor]`, while keeping `refs` as the resulting `list[Tensor]`. Removed four stale `# pyrefly: ignore[no-matching-overload]` comments whose error code no longer matched.

Differential Revision: D109264192


