### PR TITLE
Fix Pyre type-check failures in torchrec/metrics

### DIFF
--- a/torchrec/metrics/rec_metric.py
+++ b/torchrec/metrics/rec_metric.py
@@ -263,9 +263,14 @@ class RecMetricComputation(Metric, abc.ABC):
                 )
             kwargs["persistent"] = False
             window_state_name = self.get_window_state_name(name)
-            # Avoid pyre error
+            # `isinstance` does not narrow the `DefaultValueT` type variable, so
+            # cast to satisfy the type checker after the runtime guard.
             assert isinstance(default, torch.Tensor)
-            super().add_state(window_state_name, default.detach().clone(), **kwargs)
+            super().add_state(
+                window_state_name,
+                cast(torch.Tensor, default).detach().clone(),
+                **kwargs,
+            )
 
             self._batch_window_buffers[window_state_name] = WindowBuffer(
                 max_size=self._window_size,

--- a/torchrec/metrics/tests/test_gauc.py
+++ b/torchrec/metrics/tests/test_gauc.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import unittest
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import torch
 from torchrec.metrics.gauc import compute_gauc_3d, compute_window_auc, GAUCMetric
@@ -42,11 +42,12 @@ class TestGAUCMetric(TestMetric):
 
 class GAUCMetricValueTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.predictions = {"DefaultTask": None}
-        self.labels = {"DefaultTask": None}
-        self.weights = {"DefaultTask": None}
-        self.num_candidates = None
-        self.batches = {
+        self.predictions: Dict[str, Optional[torch.Tensor]] = {"DefaultTask": None}
+        self.labels: Dict[str, Optional[torch.Tensor]] = {"DefaultTask": None}
+        # Reassigned to None in some tests to exercise the no-weights path.
+        self.weights: Any = {"DefaultTask": None}
+        self.num_candidates: Optional[torch.Tensor] = None
+        self.batches: Dict[str, Any] = {
             "predictions": self.predictions,
             "labels": self.labels,
             "num_candidates": self.num_candidates,
@@ -136,7 +137,6 @@ class GAUCMetricValueTest(unittest.TestCase):
             "predictions": self.predictions,
             "labels": self.labels,
             "num_candidates": self.num_candidates,
-            # pyrefly: ignore[bad-typed-dict-key]
             "weights": None,
         }
 
@@ -170,7 +170,6 @@ class GAUCMetricValueTest(unittest.TestCase):
             "predictions": self.predictions,
             "labels": self.labels,
             "num_candidates": self.num_candidates,
-            # pyrefly: ignore[bad-typed-dict-key]
             "weights": None,
         }
 
@@ -200,13 +199,11 @@ class GAUCMetricValueTest(unittest.TestCase):
         self.labels["DefaultTask"] = torch.tensor([[1, 1, 0, 1, 0]])
         self.weights["DefaultTask"] = torch.tensor([[1, 1, 1, 1, 1]])
         self.num_candidates = torch.tensor([3, 2])
-        # pyrefly: ignore[bad-assignment]
         self.weights = None
         self.batches = {
             "predictions": self.predictions,
             "labels": self.labels,
             "num_candidates": self.num_candidates,
-            # pyrefly: ignore[bad-typed-dict-key]
             "weights": None,
         }
 


### PR DESCRIPTION
Summary:
Re-enables two disabled type-check tests in torchrec/metrics (test_ids 844425252492128 and 562950275772529).

Fixes by file:
- rec_metric.py: `isinstance(default, torch.Tensor)` does not narrow the `DefaultValueT` type variable under the newer checker, so `default.detach()` was rejected (`DefaultValueT` not assignable to `TensorBase.detach`). Added an explicit `cast(torch.Tensor, default)` after the runtime assert. `cast` is already imported.
- tests/test_gauc.py: in `setUp` the per-test attributes were inferred from their initial values (`None` / `dict[str, None]`), so reassigning real tensors in each test and rebuilding `self.batches` produced TypedDict-key mismatches. Added explicit annotations: `predictions`/`labels` as `Dict[str, Optional[torch.Tensor]]`, `num_candidates` as `Optional[torch.Tensor]`, `batches` as `Dict[str, Any]`, and `weights` as `Any` (it is reassigned to `None` in one test to exercise the no-weights path and is also index-assigned). Removed four stale `# pyrefly: ignore[...]` comments whose error codes no longer matched and which are now unnecessary.

Differential Revision: D109264179


