### PR TITLE
Fix Pyre type-check failures in torchrec/distributed

### DIFF
--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -375,8 +375,6 @@ class _MergePooledEmbeddingsModuleImpl(torch.nn.Module):
         device (torch.device): device for fbgemm.merge_pooled_embeddings
     """
 
-    current_device: torch.device
-
     def __init__(
         self,
         device: torch.device,

--- a/torchrec/distributed/tensor_pool.py
+++ b/torchrec/distributed/tensor_pool.py
@@ -288,8 +288,6 @@ class LocalShardPool(torch.nn.Module):
         # out is tensor([1,2,3]) i.e. first row of the shard
     """
 
-    current_device: torch.device
-
     def __init__(
         self,
         shard: torch.Tensor,
@@ -326,7 +324,6 @@ class ShardedInferenceTensorPool(
 ):
     _local_shard_pools: torch.nn.ModuleList
     _world_size: int
-    _device: torch.device
     _rank: int
 
     def __init__(

--- a/torchrec/distributed/tests/test_infer_shardings.py
+++ b/torchrec/distributed/tests/test_infer_shardings.py
@@ -88,6 +88,8 @@ torch.fx.wrap("len")
 
 
 class TimeGapPoolingCollectionModule(FeatureProcessorsCollection):
+    w: torch.Tensor
+
     def __init__(
         self,
         feature_pow: float,
@@ -119,7 +121,6 @@ class TimeGapPoolingCollectionModule(FeatureProcessorsCollection):
             )
             indices = torch.floor(torch.pow(scores, self.feature_pow))
             indices = indices.to(torch.int32)
-            # pyrefly: ignore[no-matching-overload]
             scores = torch.index_select(self.w, 0, indices)
             scores_list.append(scores)
 

--- a/torchrec/distributed/types.py
+++ b/torchrec/distributed/types.py
@@ -845,7 +845,7 @@ class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterShardin
         return out
 
     def _serialize(self) -> dict[str, Any]:
-        sharding_plan_dict = {}
+        sharding_plan_dict: dict[str, Any] = {}
         for param_name, param_sharding in self.items():
             sharding_plan_dict[param_name] = {
                 "sharding_type": param_sharding.sharding_type,
@@ -857,9 +857,8 @@ class EmbeddingModuleShardingPlan(ModuleShardingPlan, Dict[str, ParameterShardin
                 if shards is not None:
                     sharding_plan_dict[param_name]["shards"] = []
                     for shard in shards:
-                        shard_dict = asdict(shard)
+                        shard_dict: dict[str, Any] = asdict(shard)
                         shard_dict["placement"] = str(shard_dict["placement"])
-                        # pyrefly: ignore[missing-attribute]
                         sharding_plan_dict[param_name]["shards"].append(shard_dict)
 
         return sharding_plan_dict
@@ -1569,12 +1568,11 @@ class ObjectPoolShardingPlan(ModuleShardingPlan):
     memory_capacity_per_rank: Optional[list[int]] = None
 
     def _serialize(self) -> dict[str, Any]:
-        output = {
+        output: dict[str, Any] = {
             "sharding_type": self.sharding_type.name,
             "inference": self.inference,
         }
         if self.memory_capacity_per_rank is not None:
-            # pyrefly: ignore[bad-typed-dict-key]
             output["memory_capacity_per_rank"] = self.memory_capacity_per_rank
         return output
 


### PR DESCRIPTION
Summary:
Re-enables four disabled type-check tests in torchrec/distributed (test_ids 281475298988117, 562950275775499, 844425252495124, 844425252495287), each with 70+ consecutive continuous failures.

Fixes by file:
- dist_data.py / tensor_pool.py: removed bare class-level `current_device: torch.device` / `_device: torch.device` annotations on `nn.Module` subclasses. The newer type checker treats such an annotation as a read-only descriptor, so the `self.current_device = ...` / `self._device = ...` assignments in `__init__` were rejected. The attributes are unconditionally assigned in `__init__`, so the types are inferred. This matches the sibling `ShardedTensorPool`, which declares no class-level device annotation and type-checks cleanly.
- types.py: annotated the serialization locals (`sharding_plan_dict`, `shard_dict`, `output`) as `dict[str, Any]`. They are JSON-style serialization dicts; without the annotation the checker inferred narrow value types (TypedDict-like from `asdict`, or `str | bool`) and rejected the heterogeneous assignments. Removed two stale `# pyrefly: ignore[...]` comments whose error codes no longer matched.
- tests/test_infer_shardings.py: added a `w: torch.Tensor` class annotation so the registered buffer reads as `Tensor` rather than `Module | Tensor` in `torch.index_select`. Removed the stale `# pyrefly: ignore[no-matching-overload]`.

Differential Revision: D109264169


