### PR TITLE
Fix Pyre type-check failure in torchrec/modules/object_pool_lookups

### DIFF
--- a/torchrec/modules/object_pool_lookups.py
+++ b/torchrec/modules/object_pool_lookups.py
@@ -58,7 +58,6 @@ class KeyedJaggedTensorPoolLookup(abc.ABC, torch.nn.Module):
     _key_lengths: torch.Tensor
     _jagged_lengths: torch.Tensor
     _jagged_offsets: torch.Tensor
-    _device: torch.device
 
     def __init__(
         self,


### PR DESCRIPTION
Summary:
Re-enables the disabled `fbcode//torchrec/modules:object_pool_lookups-type-checking` test (test_id 562950275769918), which had 76+ consecutive continuous failures.

Pyrefly reported:
`Attribute _device of class KeyedJaggedTensorPoolLookup is a read-only descriptor with no __set__ and cannot be set`

Root cause: a bare class-level annotation `_device: torch.device` on an `nn.Module` subclass is treated by the newer type checker as a read-only descriptor, so the `self._device = device` assignment in `__init__` is rejected. The annotation is redundant — `_device` is unconditionally assigned in `__init__`, so its type is inferred. This matches the sibling `ShardedTensorPool` class, which declares no class-level `_device` annotation and type-checks cleanly. This file is not TorchScript-exported, so the annotation is not required for scripting.

Differential Revision: D109264161


