### PR TITLE
Fix MP-ZCH benchmark FP16_table buckets for world_size=8

### DIFF
--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -49,7 +49,7 @@ EmbeddingTablesConfig:
         data_type: FP16
         mc_config:
           mc_type: "mp-zch"
-          total_num_buckets: 5
+          total_num_buckets: 10      # must be >= world_size for row-wise sharding
           max_probe: 128
           input_hash_size: 0
           eviction_policy_name: "SINGLE_TTL_EVICTION"


### PR DESCRIPTION
Summary:
The `re_benchmark_train_pipeline` RE test forces `--world_size 8` (via the `BENCHMARK_WORLD_SIZE` env default), but `sparse_data_dist_mpzch.yml` configured `FP16_table` with `total_num_buckets: 5`. Row-wise MP-ZCH sharding requires `total_num_buckets >= world_size` (asserted in `rw_sharding.py`), so the run failed with `Number of buckets: 5 for a table cannot be less than the word_size: 8`.

Bump `FP16_table` to `total_num_buckets: 10`, which clears the assertion at `world_size=8`, evenly divides the table's `num_embeddings` (100,000), and stays uneven across 8 ranks so the config still exercises uneven-bucket sharding.

Differential Revision: D109270872


