### PR TITLE
Add persist_hash_zch_bucket opt-in for ZCH warm-load

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -216,6 +216,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         end_bucket: end bucket of the current rank, typically not provided by user
         opt_in_prob: the probability of an ID to be opted in from a statistical aspect
         percent_reserved_slots: percentage of slots to be reserved when opt-in is enabled, the value must be in [0, 100)
+        persist_hash_zch_bucket: when False, exclude the bucket-count buffer from state_dict. Useful for warm-loading checkpoints saved before this buffer existed.
 
     Example::
         module = HashZchManagedCollisionModule(...)
@@ -253,6 +254,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         enable_per_feature_lookups: bool = False,
         no_bag: bool = False,
         write_runtime_meta_dim: int = 0,
+        persist_hash_zch_bucket: bool = True,
     ) -> None:
         if output_segments is None:
             assert (
@@ -359,9 +361,11 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             )
         self._max_probe = max_probe
         self._buckets = total_num_buckets
+        self._persist_hash_zch_bucket: bool = persist_hash_zch_bucket
         self.register_buffer(
             HashZchManagedCollisionModule.BUCKET_BUFFER,
             torch.tensor([[total_num_buckets]]),
+            persistent=persist_hash_zch_bucket,
         )
         # Do not need to store in buffer since this is created and consumed
         # at each step https://fburl.com/code/axzimmbx
@@ -404,7 +408,8 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{inference_dispatch_div_train_world_size=}, "
             f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, "
             f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
-            f"{self._no_bag=}, {self._write_runtime_meta_dim=}"
+            f"{self._no_bag=}, {self._write_runtime_meta_dim=}, "
+            f"{self._persist_hash_zch_bucket=}"
         )
 
     def _create_zch_buffer(
@@ -839,6 +844,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             enable_per_feature_lookups=self._enable_per_feature_lookups,
             no_bag=self._no_bag,
             write_runtime_meta_dim=self._write_runtime_meta_dim,
+            persist_hash_zch_bucket=self._persist_hash_zch_bucket,
         )
 
     def lookup_runtime_meta(

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -35,6 +35,7 @@ from torchrec.modules.mc_modules import (
     ManagedCollisionCollection,
     ManagedCollisionModule,
 )
+from torchrec.modules.utils import make_hash_zch_buckets_non_persistent
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
 
 
@@ -2238,3 +2239,40 @@ class TestVBEWithManagedCollision(unittest.TestCase):
             rtol=0,
             atol=0,
         )
+
+
+class TestPersistHashZchBucket(unittest.TestCase):
+    def test_persist_hash_zch_bucket_default(self) -> None:
+        module = HashZchManagedCollisionModule(
+            zch_size=20,
+            device=torch.device("cpu"),
+            total_num_buckets=2,
+        )
+        self.assertIn("_hash_zch_bucket", module.state_dict())
+
+    def test_persist_hash_zch_bucket_false(self) -> None:
+        module = HashZchManagedCollisionModule(
+            zch_size=20,
+            device=torch.device("cpu"),
+            total_num_buckets=2,
+            persist_hash_zch_bucket=False,
+        )
+        # Excluded from state_dict, but still a live (queryable) buffer.
+        self.assertNotIn("_hash_zch_bucket", module.state_dict())
+        self.assertEqual(int(module.get_buffer("_hash_zch_bucket")[0][0].item()), 2)
+
+    def test_make_hash_zch_buckets_non_persistent_helper(self) -> None:
+        parent = torch.nn.Module()
+        parent.add_module(
+            "child",
+            HashZchManagedCollisionModule(
+                zch_size=20,
+                device=torch.device("cpu"),
+                total_num_buckets=2,
+            ),
+        )
+        self.assertIn("child._hash_zch_bucket", parent.state_dict())
+
+        count = make_hash_zch_buckets_non_persistent(parent)
+        self.assertGreaterEqual(count, 1)
+        self.assertNotIn("child._hash_zch_bucket", parent.state_dict())

--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -449,3 +449,33 @@ def _get_unbucketize_tensor_via_length_alignment(
     bucket_mapping_tensor: torch.Tensor,
 ) -> torch.Tensor:
     return bucketize_permute_tensor
+
+
+def make_hash_zch_buckets_non_persistent(module: torch.nn.Module) -> int:
+    """
+    Mark the bucket-count buffer non-persistent on every
+    ``HashZchManagedCollisionModule`` reachable from ``module``.
+
+    The bucket-count buffer (``_hash_zch_bucket``) is derived deterministically
+    from config at construction time, so excluding it from ``state_dict`` is
+    safe. This is useful for warm-loading checkpoints that were saved before the
+    buffer existed, which would otherwise fail on the missing key.
+
+    Args:
+        module: root module to walk (e.g. a sharded model parallel wrapper).
+
+    Returns:
+        The number of modules whose bucket buffer was made non-persistent.
+    """
+    # Name registered via HashZchManagedCollisionModule.BUCKET_BUFFER; referenced
+    # by literal here to avoid importing the module (and a potential import cycle).
+    bucket_buffer = "_hash_zch_bucket"
+    count = 0
+    for submodule in module.modules():
+        if (
+            bucket_buffer in submodule._buffers
+            and bucket_buffer not in submodule._non_persistent_buffers_set
+        ):
+            submodule._non_persistent_buffers_set.add(bucket_buffer)
+            count += 1
+    return count


### PR DESCRIPTION
Summary:
Adds a `persist_hash_zch_bucket` opt-in so a checkpoint saved before the `_hash_zch_bucket` buffer existed in `HashZchManagedCollisionModule` can be warm-loaded without the load failing on the missing key. The bucket-count buffer is derived deterministically from `total_num_buckets` at construction time, so excluding it from `state_dict` is safe. Every new field and kwarg defaults to current behavior, so this is a no-op unless a caller opts a table out.

torchrec (OSS): `HashZchManagedCollisionModule.__init__` takes a new `persist_hash_zch_bucket: bool = True` kwarg. It is stored and forwarded through `rebuild_with_output_id_range` so the setting survives sharding, and when `False` the `_hash_zch_bucket` buffer is registered with `persistent=False`. Also adds `torchrec.modules.utils.make_hash_zch_buckets_non_persistent(module)`, a helper that walks a (possibly sharded) module tree, marks every `_hash_zch_bucket` buffer non-persistent, and returns the count - a generic alternative to the per-table config when the modules are already constructed (e.g. a sharded model-parallel wrapper).

Config plumbing: adds `persist_hash_zch_bucket: bool = True` to both `EmbeddingTable` config dataclasses (`minimal_viable_ai.core.model_family_api.configs` and `torchrec.fb.distributed.sparsenn_configs`) and threads it through the shared ZCH builders: `create_embedding_bag_collections_itep` / `create_embedding_bag_collections_zch` / `create_embedding_collection_zch` in `configs.py`, `add_ZCH_ec_config` / `add_ZCH_ebc_config` in silvertorch `sparse_arch_utils.py` and the silvertorch UIH sampling builder, and the hammer `ECSparseArch` / `EBCECUIHSparseArch` UIH sampling builders.

Differential Revision: D108763151
