### PR TITLE
Add hard row-count cap for TTL-based ZCH eviction at publish (#4371)

### DIFF
--- a/torchrec/modules/embedding_configs.py
+++ b/torchrec/modules/embedding_configs.py
@@ -290,6 +290,9 @@ class TimestampBasedEvictionPolicy(VirtualTableEvictionPolicy):
     )
     eviction_ttl_mins: int = 24 * 60  # 1 day. 0 means no eviction
     inference_eviction_ttl_mins: Optional[int] = None  # 0 means no eviction
+    max_inference_id_num_per_rank: int = (
+        0  # if > 0, hard cap on rows kept per rank at publish on top of TTL; 0 means no cap (TTL is a soft cap only)
+    )
 
     def __post_init__(self) -> None:
         if self.inference_eviction_ttl_mins is None:


### PR DESCRIPTION
Summary:

CONTEXT: TTL-based ZCH eviction (FeatureScoreBasedEvictionPolicy with eviction_ttl_mins set, and TimestampBasedEvictionPolicy) is only a soft cap. At publish the SLIV row-pruning keeps every row whose last-access timestamp is within the TTL window, and that timestamp is refreshed on every training access, so the published per-table snapshot keeps the entire set of ids active within the rolling window. That set grows while the window fills after table creation and as the active id population grows, so snapshot size is effectively unbounded. We confirmed this on model 2125688805 where the 31-day-TTL tables flatten out exactly at table_creation + 31 days, then keep creeping up.

WHAT:
- torchrec/modules/embedding_configs.py: add max_inference_id_num_per_rank to TimestampBasedEvictionPolicy (additive, default 0 = no cap), mirroring FeatureScoreBasedEvictionPolicy.
- minimal_viable_ai/core/utils/kvzch_utils.py: add get_capped_inference_ttl_mins_from_metaheader_tensor(). When a TTL policy sets max_inference_id_num_per_rank=K, sort the per-rank timestamps, take the cutoff of the K most-recently-accessed rows, and tighten inference_eviction_ttl_mins to the equivalent shorter window (min of original and cap-derived). This reuses the existing TTL eviction mask unchanged, so SLIV pruning keeps at most ~K rows per rank. Wired into update_kvzch_eviction_policy_for_feature_score_eviction for both TTL policy types.
- minimal_viable_ai/core/ranking_common/utils.py: same wiring in the publish-path policy resolver (get_bucket_length_tensor_and_eviction_policy_for_kv_zch_table_global).
- aiplatform/modelstore/transformation/sliv/transformations/rowwise_filtering_and_{quantization,half_to_float,noop}.py: log per-rank kept/total/evicted row counts at the get_kv_zch_eviction_mask call sites so we can see how much each rank evicts at publish.
- Unit tests: GetCappedInferenceTtlMinsTest.

To enable on a table, set max_inference_id_num_per_rank on its eviction policy. Leaving it 0 preserves the existing soft-cap behavior (no functional change).

Differential Revision: D108795205


