### PR TITLE
fix test_reduce_scatter_pooled failure

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -2767,7 +2767,7 @@ def reduce_scatter_tensor_backward(ctx, grad):
     if ctx.gradient_division:
         grad.div_(ctx.group_size)
 
-    return grad, None, None, None, None, None
+    return grad, None, None, None, None
 
 
 torch.library.register_autograd(


### PR DESCRIPTION
Summary:
reduce_scatter_tensor takes 5 inputs but the backward function returns 6 gradients. Trimming one off.

A recent pytorch change (https://github.com/pytorch/pytorch/pull/186226/changes#diff-5a6188e1da316e5ea1f9dc3e16fbfc2ba07fdb17fb661b6c7fbd3146f30ad731R97-R102) asserts that the backward pass returns a number of gradients equal to the number of forward inputs. Before this change, extra Nones were just truncated.

Differential Revision: D109341689


