### PR TITLE
use chunked_copy_ for memory stashing D2H/H2D copies

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -24,6 +24,11 @@ from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# Trunk size for the bulk stash (D2H) / restore (H2D) copies. ~32 MiB trunks
+# keep the copy engine yielding often enough for the main stream's small copies
+# to interleave, at a negligible bandwidth cost (see chunked copy design).
+_STASH_CHUNK_SIZE_BYTES: int = 32 * 1024**2
+
 
 def _tensor_size_text(tensor: Union[List[torch.Tensor], torch.Tensor]) -> str:
     """Return a human-readable size string (MB or GB) for a tensor."""
@@ -146,6 +151,10 @@ class MemoryStashingManager:
     # sites run on every batch; without this guard they would flood the event
     # logger. Intentionally NOT cleared in reset() to avoid re-flooding.
     _logged_event_keys: set[str] = set()
+    # Trunk size (bytes) for the bulk D2H stash / H2D restore copies, used as
+    # ``chunked_copy_``'s ``chunk_size_bytes``. Defaults to
+    # ``_STASH_CHUNK_SIZE_BYTES``; override via ``set_trunk_size``.
+    _stash_chunk_size_bytes: int = _STASH_CHUNK_SIZE_BYTES
 
     @classmethod
     def _log_ems_once(
@@ -202,6 +211,17 @@ class MemoryStashingManager:
         cls._log_ems_once("ems_streams_initialized")
 
     @classmethod
+    def set_trunk_size(cls, size_bytes: int) -> None:
+        """Set the trunk size (in bytes) for bulk stash/restore copies.
+
+        Controls how ``_stash_tensors`` splits each bulk D2H stash and H2D
+        restore via ``chunked_copy_``. Smaller trunks let the copy engine yield
+        to the main stream's small copies more often, at a small bandwidth cost;
+        values <= 0 disable chunking and fall back to a single ``copy_``.
+        """
+        cls._stash_chunk_size_bytes = size_bytes
+
+    @classmethod
     def set_delay_stash(cls, delay: bool) -> None:
         """Enable or disable delayed stashing.
 
@@ -235,6 +255,7 @@ class MemoryStashingManager:
         cls._optimizer_state_restore_callbacks.clear()
         cls._emo_cache_restore_callbacks.clear()
         cls._delay_stash = False
+        cls._stash_chunk_size_bytes = _STASH_CHUNK_SIZE_BYTES
         cls._pending_stash_callbacks.clear()
         if cls._stash_executor is not None:
             cls._stash_executor.shutdown(wait=False)
@@ -361,7 +382,14 @@ class MemoryStashingManager:
                             device="cpu",
                             pin_memory=True,
                         )
-                        cpu_buffer.copy_(tensor, non_blocking=True)
+                        # Chunk the bulk D2H copy so the copy engine yields
+                        # between trunks, letting other streams' small copies
+                        # interleave instead of waiting for the whole transfer.
+                        chunked_copy_(
+                            cpu_buffer,
+                            tensor,
+                            chunk_size_bytes=cls._stash_chunk_size_bytes,
+                        )
                         # Tell the caching allocator this tensor is in use on
                         # d2h_stream so the bytes are not reused by default-
                         # stream allocations until the async D2H copy completes.
@@ -454,7 +482,11 @@ class MemoryStashingManager:
                         stride=hbm_ref.stride(),
                     )
                     with torch.cuda.stream(h2d_stream):
-                        tmp.copy_(cpu_buf, non_blocking=True)
+                        # Chunk the bulk H2D restore so the copy engine yields
+                        # between trunks (see chunked_copy_).
+                        chunked_copy_(
+                            tmp, cpu_buf, chunk_size_bytes=cls._stash_chunk_size_bytes
+                        )
                     # Tell the caching allocator this storage is in use on
                     # h2d_stream so the bytes cannot be reused by main-stream
                     # allocations before the H2D copy completes.


### PR DESCRIPTION
Summary:
## Context

Memory-stashing features (EMS embedding stash/restore, optimizer-state stashing) move bulk payloads between HBM and host. As shown in the chunked-copy design, a single bulk `copy_` saturates the same-direction CUDA copy engine and stalls the main stream's small copies — and the dense compute that depends on them — until the whole transfer drains.

## Change

Route the two bulk transfers in `MemoryStashingManager._stash_tensors` through `chunked_copy_` instead of a single `copy_`:

1. **Stash (D2H)**: `cpu_buffer.copy_(tensor)` -> `chunked_copy_(cpu_buffer, tensor)`, run on the d2h_stream.
2. **Restore (H2D)**: `tmp.copy_(cpu_buf)` -> `chunked_copy_(tmp, cpu_buf)`, run on the h2d_stream.

`chunked_copy_` splits each transfer into ~32 MiB trunks (`_STASH_CHUNK_SIZE_BYTES`) and enqueues a tiny dummy compute op between trunks, so the copy engine yields and other streams' small copies interleave into the gaps. Both call sites stay inside their existing `with torch.cuda.stream(...)` blocks and `record_stream` accounting is unchanged. Non-contiguous tensors fall back to a single `copy_` inside `chunked_copy_`, so behavior is preserved for those.

## Configurable trunk size

The trunk size is no longer hard-wired. `MemoryStashingManager` holds it as a class variable `_stash_chunk_size_bytes` (defaulting to `_STASH_CHUNK_SIZE_BYTES`, ~32 MiB) and exposes a `set_trunk_size(size_bytes)` classmethod to override it at runtime. Both `chunked_copy_` call sites in `_stash_tensors` now read `cls._stash_chunk_size_bytes`, so a single `set_trunk_size` call retunes both the D2H stash and H2D restore. Passing `size_bytes <= 0` disables chunking and falls back to a single `copy_` (the existing `chunked_copy_` contract). `reset()` restores the default so training runs and tests start from a known value.

## Trunk size

At ~50 GB/s PCIe bandwidth, a 32 MiB trunk takes ~0.6 ms to copy. A main-stream copy that arrives while the bulk transfer is in flight therefore waits for at most one trunk (~0.6 ms) and ~0.3 ms on average (half a trunk) before the copy engine yields to it — versus stalling for the entire multi-GB transfer today. Smaller trunks tighten this bound further at a small bandwidth cost; ~32 MiB is a good default balance (see the chunked-copy design), and `set_trunk_size` lets callers tune it per workload.

Stacked on D92349217 (which adds `chunked_copy_`).

Reviewed By: aporialiao

Differential Revision: D108315471


