### PR TITLE
Add HardwareConfig validation and TopologyFactory override warnings (#4374)

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -16,6 +16,7 @@ import torch
 from torch import multiprocessing
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.logger import static_logger
 from torchrec.distributed.planner import EmbeddingShardingPlanner
 from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
 from torchrec.distributed.planner.perf_models import NoopPerfModel
@@ -1312,6 +1313,162 @@ class TestHardwareConfig(unittest.TestCase):
             self.assertIsNone(config.hbm_cap_bytes)
             self.assertIsNone(config.ddr_cap_bytes)
 
+        # --- get_validation_issues(): pure detection-failure logic (no logger) ---
+        with self.subTest("issues_all_valid_empty"):
+            self.assertEqual(
+                HardwareConfig(
+                    hbm_cap_bytes=80 * 1024**3,
+                    ddr_cap_bytes=512 * 1024**3,
+                    ssd_cap_bytes=1024 * 1024**3,
+                    intra_host_bw=900.0,
+                    inter_host_bw=25.0,
+                    hbm_mem_bw=1000.0,
+                    ddr_mem_bw=100.0,
+                    hbm_to_ddr_mem_bw=50.0,
+                    ssd_mem_bw=10.0,
+                ).get_validation_issues(compute_device="cuda"),
+                [],
+            )
+
+        with self.subTest("issues_hbm_zero_cuda_flagged"):
+            issues = HardwareConfig(hbm_cap_bytes=0).get_validation_issues(
+                compute_device="cuda"
+            )
+            self.assertTrue(any("hbm_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_hbm_negative_cuda_flagged"):
+            issues = HardwareConfig(hbm_cap_bytes=-1).get_validation_issues(
+                compute_device="cuda"
+            )
+            self.assertTrue(any("hbm_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_hbm_zero_mtia_flagged"):
+            # MTIA is an HBM-bearing accelerator; hbm=0 is a detection failure.
+            issues = HardwareConfig(hbm_cap_bytes=0).get_validation_issues(
+                compute_device="mtia"
+            )
+            self.assertTrue(any("hbm_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_hbm_zero_cpu_skipped"):
+            # CPU host has no HBM device; hbm=0 must not be flagged there.
+            self.assertEqual(
+                HardwareConfig(hbm_cap_bytes=0).get_validation_issues(
+                    compute_device="cpu"
+                ),
+                [],
+            )
+
+        with self.subTest("issues_hbm_zero_meta_skipped"):
+            # "meta" (and any non-HBM-bearing device) has no real HBM; hbm=0
+            # must not be flagged there (allowlist is cuda/mtia only).
+            self.assertEqual(
+                HardwareConfig(hbm_cap_bytes=0).get_validation_issues(
+                    compute_device="meta"
+                ),
+                [],
+            )
+
+        with self.subTest("issues_hbm_zero_no_device_hint_skipped"):
+            # No device hint -> cannot confirm the device has HBM -> not flagged.
+            self.assertEqual(
+                HardwareConfig(hbm_cap_bytes=0).get_validation_issues(),
+                [],
+            )
+
+        with self.subTest("issues_hbm_large_ok"):
+            self.assertEqual(
+                HardwareConfig(hbm_cap_bytes=1024 * 1024**3).get_validation_issues(
+                    compute_device="cuda"
+                ),
+                [],
+            )
+
+        with self.subTest("issues_hbm_none_ok"):
+            self.assertEqual(
+                HardwareConfig().get_validation_issues(compute_device="cuda"), []
+            )
+
+        with self.subTest("issues_ddr_zero_flagged"):
+            issues = HardwareConfig(ddr_cap_bytes=0).get_validation_issues()
+            self.assertTrue(any("ddr_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_ddr_negative_flagged"):
+            issues = HardwareConfig(ddr_cap_bytes=-5).get_validation_issues()
+            self.assertTrue(any("ddr_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_ddr_large_ok"):
+            self.assertEqual(
+                HardwareConfig(ddr_cap_bytes=8 * 1024**4).get_validation_issues(), []
+            )
+
+        with self.subTest("issues_ssd_zero_ok"):
+            # 0 SSD is legitimate (host may have no SSD tier).
+            self.assertEqual(
+                HardwareConfig(ssd_cap_bytes=0).get_validation_issues(), []
+            )
+
+        with self.subTest("issues_ssd_negative_flagged"):
+            issues = HardwareConfig(ssd_cap_bytes=-1).get_validation_issues()
+            self.assertTrue(any("ssd_cap_bytes" in i for i in issues))
+
+        with self.subTest("issues_bandwidths_nonpositive_flagged"):
+            # Explicit per-field configs (not **{field: 0.0}) so the float value
+            # is type-checked against each float bandwidth param.
+            bandwidth_cases = [
+                ("intra_host_bw", HardwareConfig(intra_host_bw=0.0)),
+                ("inter_host_bw", HardwareConfig(inter_host_bw=0.0)),
+                ("hbm_mem_bw", HardwareConfig(hbm_mem_bw=0.0)),
+                ("ddr_mem_bw", HardwareConfig(ddr_mem_bw=0.0)),
+                ("hbm_to_ddr_mem_bw", HardwareConfig(hbm_to_ddr_mem_bw=0.0)),
+                ("ssd_mem_bw", HardwareConfig(ssd_mem_bw=0.0)),
+            ]
+            for field, config in bandwidth_cases:
+                issues = config.get_validation_issues()
+                self.assertTrue(
+                    any(field in i for i in issues),
+                    f"{field}=0 should be flagged; got {issues}",
+                )
+
+        with self.subTest("issues_intra_lt_inter_flagged"):
+            issues = HardwareConfig(
+                intra_host_bw=10.0, inter_host_bw=20.0
+            ).get_validation_issues()
+            self.assertTrue(any("inter_host_bw" in i for i in issues))
+
+        with self.subTest("issues_intra_eq_inter_ok"):
+            self.assertEqual(
+                HardwareConfig(
+                    intra_host_bw=20.0, inter_host_bw=20.0
+                ).get_validation_issues(),
+                [],
+            )
+
+        with self.subTest("issues_multiple_problems_all_listed"):
+            issues = HardwareConfig(
+                hbm_cap_bytes=0, ddr_cap_bytes=-1, ssd_cap_bytes=-1
+            ).get_validation_issues(compute_device="cuda")
+            self.assertTrue(any("hbm_cap_bytes" in i for i in issues))
+            self.assertTrue(any("ddr_cap_bytes" in i for i in issues))
+            self.assertTrue(any("ssd_cap_bytes" in i for i in issues))
+
+        # --- validate(): warning-only shell over get_validation_issues() ---
+        with self.subTest("validate_emits_warning_for_bad_config"):
+            with self.assertLogs(static_logger, "WARNING") as cm:
+                HardwareConfig(hbm_cap_bytes=0).validate(compute_device="cuda")
+            self.assertTrue(any("HardwareConfig validation" in m for m in cm.output))
+            self.assertTrue(any("hbm_cap_bytes" in m for m in cm.output))
+
+        with self.subTest("validate_silent_for_good_config"):
+            with self.assertNoLogs(static_logger, "WARNING"):
+                HardwareConfig(
+                    hbm_cap_bytes=80 * 1024**3,
+                    ddr_cap_bytes=512 * 1024**3,
+                ).validate(compute_device="cuda")
+
+        with self.subTest("validate_cpu_zero_hbm_silent"):
+            with self.assertNoLogs(static_logger, "WARNING"):
+                HardwareConfig(hbm_cap_bytes=0).validate(compute_device="cpu")
+
 
 class TestTrainerConfig(unittest.TestCase):
     """Tests for TrainerConfig dataclass."""
@@ -1583,6 +1740,57 @@ class TestTopologyFactory(unittest.TestCase):
 
             self.assertEqual(topology.devices[0].storage.hbm, 40 * 1024**3)
             self.assertEqual(topology.devices[1].storage.hbm, 80 * 1024**3)
+
+        with self.subTest("override_above_threshold_warns"):
+            with self.assertLogs(static_logger, "WARNING") as cm:
+                topology = TopologyFactory.create_topology(
+                    trainer_config=TrainerConfig(
+                        world_size=8,
+                        local_world_size=8,
+                        hbm_cap_bytes=80 * 1024**3,
+                    ),
+                    hardware_config=HardwareConfig(hbm_cap_bytes=40 * 1024**3),
+                )
+            # Trainer value still wins...
+            self.assertEqual(topology.devices[0].storage.hbm, 80 * 1024**3)
+            # ...and the >5% divergence is flagged.
+            self.assertTrue(any("TrainerConfig hbm_cap" in m for m in cm.output))
+
+        with self.subTest("override_within_threshold_no_warning"):
+            with self.assertNoLogs(static_logger, "WARNING"):
+                TopologyFactory.create_topology(
+                    trainer_config=TrainerConfig(
+                        world_size=8,
+                        local_world_size=8,
+                        hbm_cap_bytes=80 * 1024**3,
+                    ),
+                    hardware_config=HardwareConfig(hbm_cap_bytes=79 * 1024**3),
+                )
+
+        with self.subTest("dry_run_suppresses_override_warning"):
+            with self.assertNoLogs(static_logger, "WARNING"):
+                TopologyFactory.create_topology(
+                    trainer_config=TrainerConfig(
+                        world_size=8,
+                        local_world_size=8,
+                        hbm_cap_bytes=80 * 1024**3,
+                        is_dry_run=True,
+                        dry_run_hbm_bytes=40 * 1024**3,
+                    ),
+                    hardware_config=HardwareConfig(hbm_cap_bytes=40 * 1024**3),
+                )
+
+        with self.subTest("ddr_override_above_threshold_warns"):
+            with self.assertLogs(static_logger, "WARNING") as cm:
+                TopologyFactory.create_topology(
+                    trainer_config=TrainerConfig(
+                        world_size=8,
+                        local_world_size=8,
+                        ddr_cap_bytes=512 * 1024**3,
+                    ),
+                    hardware_config=HardwareConfig(ddr_cap_bytes=256 * 1024**3),
+                )
+            self.assertTrue(any("TrainerConfig ddr_cap" in m for m in cm.output))
 
     def test_topology_bandwidth_and_multipliers(self) -> None:
         """Test bandwidth and multiplier configurations."""

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -17,7 +17,11 @@ from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
-from torchrec.distributed.logger import one_time_logger, one_time_rank0_logger
+from torchrec.distributed.logger import (
+    one_time_logger,
+    one_time_rank0_logger,
+    static_logger,
+)
 from torchrec.distributed.planner.constants import (
     BATCH_SIZE,
     BWD_COMPUTE_MULTIPLIER,
@@ -48,6 +52,16 @@ from torchrec.modules.embedding_modules import (
     EmbeddingCollectionInterface,
 )
 from torchrec.modules.mc_embedding_modules import ManagedCollisionEmbeddingCollection
+
+
+# Fractional gap above which a TrainerConfig capacity is treated as a deliberate
+# override of the detected HardwareConfig value. Below this, the difference is
+# attributable to expected noise -- rounding, or the per-rank vs per-host DDR
+# basis (some callers divide the detected per-host DDR by local_world_size) --
+# and is not worth flagging. Above it, the trainer value is almost certainly a
+# static model config diverging from detected hardware, which is the common
+# cause of planner OOMs when a job lands on a different SKU than assumed.
+_CAP_OVERRIDE_THRESHOLD: float = 0.05
 
 
 # ---- Perf ---- #
@@ -450,11 +464,96 @@ class HardwareConfig(TopologyConfigBase):
     # pyrefly: ignore[bad-override]
     additional_params: Dict[str, Any] = field(default_factory=dict)
 
-    def validate(self) -> None:
-        """Validate hardware configuration parameters."""
-        # No strict validation required - values are optional and
-        # will use defaults from Topology class if not provided
-        pass
+    def get_validation_issues(self, compute_device: Optional[str] = None) -> List[str]:
+        """Return human-readable validation issues (pure: no logging, no raise).
+
+        Flags values that are definitively invalid -- detection failures
+        (non-positive capacities/bandwidths) and physical-invariant violations. A
+        detected HardwareConfig value may be legitimately overridden by TrainerConfig
+        precedence, so callers treat these as warnings, not errors; the
+        resolved/effective value is the one worth failing on, and is validated
+        separately post-precedence.
+
+        Exposed as a pure method (vs only logging) so a caller that evaluates
+        many configs in one process (building one topology per candidate
+        config) can report per-config without depending on logger
+        rate-limiting.
+
+        Args:
+            compute_device: optional device hint. The HBM check runs only for
+                HBM-bearing accelerators ("cuda"/"mtia"), where a non-positive
+                HBM (incl. 0) is a detection failure. It is skipped for "cpu"
+                (no HBM device), "meta", None, or any other device, where a
+                0/None HBM is not a failure. (Using an allowlist rather than
+                "!= cpu" avoids false positives on meta/unknown devices.)
+        """
+        issues: List[str] = []
+
+        # HBM only exists on accelerators that have it (cuda/mtia), so a
+        # non-positive value there is a detection failure. Skipped for cpu
+        # (no HBM device), meta, None, or any other device.
+        if (
+            self.hbm_cap_bytes is not None
+            and compute_device in ("cuda", "mtia")
+            and self.hbm_cap_bytes <= 0
+        ):
+            issues.append(f"hbm_cap_bytes={self.hbm_cap_bytes} is non-positive")
+
+        # DDR: every host has DDR, so a non-positive value is a detection or
+        # per-rank-division failure.
+        if self.ddr_cap_bytes is not None and self.ddr_cap_bytes <= 0:
+            issues.append(f"ddr_cap_bytes={self.ddr_cap_bytes} is non-positive")
+
+        # SSD: 0 is legitimate (a host may have no SSD tier); only a negative
+        # value is invalid.
+        if self.ssd_cap_bytes is not None and self.ssd_cap_bytes < 0:
+            issues.append(f"ssd_cap_bytes={self.ssd_cap_bytes} is negative")
+
+        # Bandwidths are divisors in perf estimation; a set non-positive value
+        # is invalid (and is not replaced by a default downstream).
+        for name, value in (
+            ("intra_host_bw", self.intra_host_bw),
+            ("inter_host_bw", self.inter_host_bw),
+            ("hbm_mem_bw", self.hbm_mem_bw),
+            ("ddr_mem_bw", self.ddr_mem_bw),
+            ("hbm_to_ddr_mem_bw", self.hbm_to_ddr_mem_bw),
+            ("ssd_mem_bw", self.ssd_mem_bw),
+        ):
+            if value is not None and value <= 0:
+                issues.append(f"{name}={value} is non-positive")
+
+        # Physical invariant: intra-node bandwidth should be >= inter-node.
+        if (
+            self.intra_host_bw is not None
+            and self.inter_host_bw is not None
+            and self.intra_host_bw < self.inter_host_bw
+        ):
+            issues.append(
+                f"intra_host_bw ({self.intra_host_bw:.0f}) < "
+                f"inter_host_bw ({self.inter_host_bw:.0f}); intra-node "
+                f"bandwidth is typically much higher than inter-node"
+            )
+
+        return issues
+
+    def validate(self, compute_device: Optional[str] = None) -> None:
+        """Validate hardware configuration parameters (warning-only).
+
+        Thin shell over get_validation_issues(): emits a single combined
+        warning and never raises, to avoid breaking existing flows.
+
+        Logs via static_logger (rank 0, uncapped) rather than a per-location
+        rate-limited logger so that a caller building many topologies in one
+        process (one validate() call per candidate config) surfaces a warning
+        for every config instead of only the first.
+
+        Args:
+            compute_device: optional device hint forwarded to
+                get_validation_issues(); see that method.
+        """
+        issues = self.get_validation_issues(compute_device)
+        if issues:
+            static_logger.warning("HardwareConfig validation: " + "; ".join(issues))
 
 
 @dataclass(frozen=True)
@@ -644,6 +743,7 @@ class TopologyFactory:
 
             # Validate configs
             trainer_config.validate()
+            hardware.validate(compute_device=kernel.compute_device)
             kernel.validate()
 
             # Build topology kwargs with precedence resolution
@@ -662,11 +762,11 @@ class TopologyFactory:
             TopologyFactory._add_hardware_params(topology_kwargs, hardware, kernel)
             TopologyFactory._add_comms_params(topology_kwargs, hardware, kernel)
 
-            one_time_rank0_logger.info("TopologyFactor.create_topology called.")
+            one_time_rank0_logger.info("TopologyFactory.create_topology called.")
             topology_kwargs["created_by_factory"] = True
             return Topology(**topology_kwargs)
         except Exception as e:
-            one_time_logger.error(f"TopologyFactor.create_topology failed: {e}")
+            one_time_logger.error(f"TopologyFactory.create_topology failed: {e}")
             raise
 
     @staticmethod
@@ -698,6 +798,29 @@ class TopologyFactory:
             else hardware.ssd_cap_bytes
         )
 
+        # Warn when a TrainerConfig capacity overrides the detected HardwareConfig
+        # value by more than the noise threshold. Skipped in dry-run, where the
+        # effective caps come from the dry_run_* overrides below, not the
+        # trainer/hardware pair.
+        if not trainer.is_dry_run:
+            TopologyFactory._warn_if_cap_override(
+                "hbm_cap",
+                trainer.hbm_cap_bytes,
+                hardware.hbm_cap_bytes,
+                "This may indicate a static model config overriding detected "
+                "hardware.",
+            )
+            # Assumes both ddr values share the same per-rank/per-host basis;
+            # a mismatched basis (e.g. per-host trainer vs per-rank hardware)
+            # can inflate the reported delta.
+            # TODO: revisit once the per-rank/per-host DDR basis is unified so
+            # this can't false-positive.
+            TopologyFactory._warn_if_cap_override(
+                "ddr_cap",
+                trainer.ddr_cap_bytes,
+                hardware.ddr_cap_bytes,
+            )
+
         # Handle dry-run mode overrides
         if trainer.is_dry_run:
             if trainer.dry_run_hbm_bytes is not None:
@@ -716,6 +839,40 @@ class TopologyFactory:
         custom_topology_data = trainer.get_param("custom_topology_data")
         if custom_topology_data is not None:
             kwargs["custom_topology_data"] = custom_topology_data
+
+    @staticmethod
+    def _warn_if_cap_override(
+        name: str,
+        trainer_value: Optional[int],
+        hardware_value: Optional[int],
+        hint: str = "",
+    ) -> None:
+        """Warn when a trainer-supplied capacity deviates from the detected
+        hardware value by more than _CAP_OVERRIDE_THRESHOLD.
+
+        The trainer value takes precedence in topology construction; a large gap
+        usually means a stale static model config overriding detected hardware.
+        No-op when either value is missing or the hardware value is non-positive.
+
+        Logs via static_logger (rank 0, uncapped) for the same reason as
+        HardwareConfig.validate(): a caller building many topologies in one
+        process would otherwise have a per-location rate-limited logger
+        suppress every warning after the first.
+        """
+        if trainer_value is None or hardware_value is None or hardware_value <= 0:
+            return
+        ratio = abs(trainer_value - hardware_value) / hardware_value
+        if ratio > _CAP_OVERRIDE_THRESHOLD:
+            message = (
+                f"TopologyFactory: TrainerConfig {name} "
+                f"({trainer_value / 1024**3:.1f} GiB) differs from "
+                f"HardwareConfig {name} "
+                f"({hardware_value / 1024**3:.1f} GiB) by "
+                f"{ratio:.0%}. Using TrainerConfig value."
+            )
+            if hint:
+                message = f"{message} {hint}"
+            static_logger.warning(message)
 
     @staticmethod
     def _add_hardware_params(


### PR DESCRIPTION
Summary:

Two observability improvements to the TopologyFactory pipeline, both
warning-only with no behavior change (validate() never raises; precedence
is unchanged).

1. HardwareConfig.validate() now flags hardware values that are
   definitively invalid -- detection failures and physical-invariant
   violations -- rather than "implausible but valid" magnitudes. (An
   earlier version used arbitrary lower bounds of 16 GiB HBM / 8 GiB DDR;
   those magic floors are removed -- there is no principled basis for the
   exact numbers, and the meaningful signal is a non-positive value, not a
   sub-floor magnitude.)

   The logic lives in a pure get_validation_issues() that returns a list
   of issue strings; validate() is a thin shell that logs them. Checks,
   each only when the field is set:
   - hbm_cap_bytes <= 0 : detection failure, flagged only for HBM-bearing
     accelerators (cuda/mtia). Skipped for cpu, meta, None, or any other
     device, where a 0/None HBM is not a failure. (Allowlist, not
     "!= cpu", to avoid false positives on meta/unknown devices.)
   - ddr_cap_bytes <= 0 : every host has DDR, so 0 is a detection /
     per-rank-division failure.
   - ssd_cap_bytes < 0 : 0 is legitimate (a host may have no SSD tier).
   - each bandwidth (intra/inter_host_bw, hbm/ddr/hbm_to_ddr/ssd_mem_bw)
     <= 0 : they are divisors in perf estimation and are not defaulted
     away downstream.
   - intra_host_bw >= inter_host_bw : physical invariant.
   validate() takes an optional compute_device hint; create_topology()
   passes kernel.compute_device.

   get_validation_issues() is exposed as a pure method so a caller that
   evaluates many configs in one process (building one topology per
   candidate config) can report per-config without depending on logger
   rate-limiting.

2. TopologyFactory._add_trainer_params() warns when a TrainerConfig
   capacity overrides the detected HardwareConfig value by more than 5%
   (HBM or DDR). Small deltas (rounding, or the per-rank vs per-host DDR
   basis) are suppressed; large deltas indicate a static model config
   overriding detected hardware -- a common cause of planner OOMs when a
   job lands on a different hardware SKU than the static config assumed.

3. validate() and the override warning log once per process via a
   non-rate-limited rank-0 logger (static_logger) rather than the
   per-location-capped one_time_logger. A caller building many topologies
   in one process (one validate() call each) would otherwise have every
   warning after the first suppressed; static_logger emits one per config.
   Same logging destination; only the cap and rank scope change.

4. hardware.validate() is called in create_topology() alongside the
   existing trainer_config.validate() and kernel.validate() calls.

Also includes a typo fix in two create_topology() log strings
("TopologyFactor" -> "TopologyFactory").

Reviewed By: isururanawaka

Differential Revision: D107713801


