### PR TITLE
Add expandable_segments toggle to train pipeline benchmark (#4375)

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -461,6 +461,28 @@ def write_report(
     logger.info(f"Report written to {report_file}:\n{report_str}")
 
 
+def set_expandable_segments_env(enabled: bool) -> None:
+    """Merge ``expandable_segments:True`` into ``PYTORCH_CUDA_ALLOC_CONF``.
+
+    No-op when ``enabled`` is False. Merges with any pre-existing config (e.g.
+    ``max_split_size_mb`` / ``roundup_power2_divisions`` set by the launch
+    environment) instead of clobbering it. Must run before the process
+    initializes CUDA, since the caching allocator parses this env var only once.
+    """
+    if not enabled:
+        return
+    existing = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    new_setting = "expandable_segments:True"
+    if "expandable_segments" not in existing:
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = (
+            f"{existing},{new_setting}" if existing else new_setting
+        )
+    logger.info(
+        "[expandable_segments] enabled; PYTORCH_CUDA_ALLOC_CONF=%s",
+        os.environ.get("PYTORCH_CUDA_ALLOC_CONF"),
+    )
+
+
 def multi_process_benchmark(
     callable: Callable[
         ...,
@@ -473,6 +495,11 @@ def multi_process_benchmark(
         if "MASTER_ADDR" not in os.environ:
             os.environ["MASTER_ADDR"] = str("localhost")
             os.environ["MASTER_PORT"] = str(get_free_port())
+        # Enable expandable_segments (if requested) in the parent before any
+        # child process is spawned below; spawned children inherit os.environ,
+        # so the setting lands before their CUDA init. Pop it so it is not
+        # forwarded as an unexpected kwarg to the per-rank callable.
+        set_expandable_segments_env(bool(kwargs.pop("expandable_segments", False)))
 
     assert "world_size" in kwargs
     world_size = kwargs["world_size"]
@@ -1279,6 +1306,27 @@ class BenchFuncConfig:
     profile_all_threads: bool = False
     loglevel: str = "WARNING"
     test_name: str = ""
+    # When True, enable PyTorch's CUDA ``expandable_segments`` caching-allocator
+    # mode for the benchmark process(es). expandable_segments reserves a growable
+    # virtual address range and maps physical pages on demand, so the allocator
+    # reserves close to what is actually used instead of rounding up into fixed
+    # segments. This reduces fragmentation: lower peak *reserved* GPU memory and
+    # fewer/zero malloc retries, with negligible impact on peak *allocated*
+    # memory or throughput.
+    #
+    # Run WITH it (treatment):
+    #   buck2 run @fbcode//mode/opt \
+    #     fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
+    #     --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
+    #     --expandable_segments=true --name=<run_name>
+    # Run WITHOUT it (baseline): the same command, omitting --expandable_segments=true.
+    # (Note: --expandable_segments needs an explicit value, e.g. =true; a bare
+    # flag is rejected because @cmd_conf bool fields parse a value.)
+    #
+    # NOTE: intentionally NOT forwarded via benchmark_func_kwargs() below — it is
+    # consumed at process setup time (before CUDA init), not by
+    # benchmark_func()/func_to_benchmark.
+    expandable_segments: bool = False
 
     def benchmark_func_kwargs(self, **kwargs_to_override) -> Dict[str, Any]:
         return {
@@ -1299,6 +1347,16 @@ class BenchFuncConfig:
     def set_log_level(self) -> None:
         loglevel = logging._nameToLevel[self.loglevel.upper()]
         logging.root.setLevel(loglevel)
+
+    def maybe_enable_expandable_segments(self) -> None:
+        """Enable CUDA expandable_segments if requested by this config.
+
+        Must be called in each worker process BEFORE CUDA is initialized (the
+        caching allocator reads ``PYTORCH_CUDA_ALLOC_CONF`` only once, at first
+        CUDA use). Safe to call unconditionally — it is a no-op when the flag is
+        unset.
+        """
+        set_expandable_segments_env(self.expandable_segments)
 
 
 def benchmark_func(
@@ -1348,6 +1406,21 @@ def benchmark_func(
     """
     if benchmark_func_kwargs is None:
         benchmark_func_kwargs = {}
+
+    if device_type == "cuda":
+        # Log the allocator settings that are actually active (CUDA is already
+        # initialized by this point) to confirm whether expandable_segments took
+        # effect — useful for A/B comparisons. Best-effort: the getter is a
+        # private binding that may be absent on older runtimes.
+        try:
+            active_settings = torch._C._accelerator_getAllocatorSettings()
+            logger.info(
+                "[expandable_segments] active PYTORCH_CUDA_ALLOC_CONF (rank %s): %s",
+                rank,
+                active_settings,
+            )
+        except Exception as e:  # pragma: no cover - best-effort diagnostics
+            logger.debug("could not read allocator settings: %s", e)
 
     run_iter_fn: Callable[[], None] = lambda: func_to_benchmark(
         bench_inputs, **benchmark_func_kwargs

--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -149,6 +149,11 @@ def runner(
     metric_config: RecMetricConfig,
     table_related_configs: Optional[TableExtendedConfigs] = None,
 ) -> BenchmarkResult:
+    # Enable expandable_segments (if requested) before any CUDA initialization
+    # in this worker, since the caching allocator reads PYTORCH_CUDA_ALLOC_CONF
+    # only once at first CUDA use. No-op when the flag is unset.
+    run_option.maybe_enable_expandable_segments()
+
     # Ensure GPUs are available and we have enough of them
     assert (
         torch.cuda.is_available() and torch.cuda.device_count() >= run_option.world_size


### PR DESCRIPTION
Summary:

Adds an opt-in `expandable_segments` toggle to the TorchRec train-pipeline
benchmark so we can A/B the CUDA caching allocator's expandable-segments mode
(`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`). expandable_segments
reserves a growable virtual address range and maps physical pages on demand, so
the allocator reserves close to what is actually used instead of rounding up
into fixed segments — reducing fragmentation (lower peak *reserved* memory and
fewer/zero malloc retries) with negligible impact on throughput. This is a first
step toward potentially enabling it as a TorchRec default.

What this does:
- Adds `expandable_segments: bool = False` to `BenchFuncConfig` (inherited by
  `RunOptions`). The `cmd_conf` decorator auto-generates a `--expandable_segments`
  CLI flag; it is also settable via the yaml/json config.
- Adds `set_expandable_segments_env()` which MERGES `expandable_segments:True`
  into any existing `PYTORCH_CUDA_ALLOC_CONF` (e.g. preserving `max_split_size_mb`
  / `roundup_power2_divisions`) rather than clobbering it, and must run before
  CUDA init (the allocator parses the env var only once).
- `runner()` in benchmark_train_pipeline.py calls
  `run_option.maybe_enable_expandable_segments()` as its first statement, before
  CUDA initializes. This is required because the train-pipeline path
  (run_multi_process_func -> runner) does not go through
  `multi_process_benchmark.setUp()`; the same call is also wired into setUp() so
  the generic multi-process helper supports the flag too.
- `benchmark_func()` logs the active allocator settings (via
  `torch._C._accelerator_getAllocatorSettings()`, best-effort) after CUDA init to
  confirm whether expandable_segments took effect.

How to run:
  # Treatment (with expandable_segments):
  buck2 run fbcode//mode/opt \
    fbcode//torchrec/distributed/benchmark:benchmark_train_pipeline -- \
    --yaml_config=fbcode/torchrec/distributed/benchmark/yaml/sparse_data_dist_heavy_dense.yml \
    --expandable_segments=true --name=<run_name>

  # Baseline (without): same command, omitting --expandable_segments=true.
  # Note: --expandable_segments requires an explicit value (=true); a bare flag
  # is rejected because cmd_conf bool fields parse a value.

A/B test results:
- Hardware: 8x A100-80GB; config sparse_data_dist_heavy_dense.yml; world_size=2.
- Single run per arm (n=1; P10=P50=P90), so throughput deltas are within noise.
 
| Metric | Baseline (off) |  Treatment (on) |  Change  |
| -- |
| Peak Reserved Memory   | 67.00 GB       | 59.75 GB       | -10.8%            |
| Peak Allocated Memory  | 53.04 GB       | 53.04 GB       | identical         |
| Fragmentation gap       | 13.95 GB       | 6.72 GB        | -52%              |
| Malloc retries (P50/90/100) | 0 / 0 / 0  | 0 / 0 / 0      | unchanged         |
| QPS                     | 6744           | 6585           | -2.4% (n=1 noise) |

Takeaway: expandable_segments cut peak reserved GPU memory by ~7.25 GB (-10.8%)
at an identical allocated working set, halving the reserved-but-unallocated
fragmentation headroom, with no throughput regression beyond single-run noise.
This config never hit allocator pressure (0 baseline malloc retries), so it does
not exercise the retry/OOM-reduction benefit — a memory-pressured config would be
needed to demonstrate that.

Reviewed By: TroyGarden

Differential Revision: D109372184


