### PR TITLE
Port backward hook integration to TrainPipelineSparseDistEmbStash

### DIFF
--- a/torchrec/distributed/train_pipeline/experimental_pipelines.py
+++ b/torchrec/distributed/train_pipeline/experimental_pipelines.py
@@ -1141,6 +1141,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         free_features_storage_early: bool = False,
         delay_stash: bool = False,
         stash_site_fqn: Optional[str] = None,
+        stash_hook_position: float = 0.01,
         clear_data_dist_inputs: bool = False,
     ) -> None:
         super().__init__(
@@ -1168,7 +1169,7 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
             self._injection_site = site_fqn
         self._delay_stash = delay_stash
         self._stash_site_fqn = stash_site_fqn
-        self._stash_hook_handle: Optional[torch.utils.hooks.RemovableHandle] = None
+        self._stash_hook_position = stash_hook_position
 
         MemoryStashingManager.set_streams(
             self._memcpy_stream,  # pyrefly: ignore[bad-argument-type]
@@ -1214,35 +1215,6 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
         except Exception:
             logger.debug("EMS config logging failed", exc_info=True)
 
-    def _try_hook_stash(self) -> None:
-        """Register a forward pre-hook on ``stash_site_fqn`` to execute
-        pending stashes right before that module's forward pass.
-
-        This follows the same pattern used by
-        ``TrainPipelineCustomizedOrderSparseDist`` to hook SDD steps into
-        specific module forwards.  The hook frees HBM (D2H copy +
-        ``resize_(0)``) just before peak-memory modules run, avoiding PCIe
-        contention with ``start_sparse_data_dist``'s H2D copy.
-        """
-        if self._stash_site_fqn is None or self._stash_hook_handle is not None:
-            return
-
-        model = self._model
-        if isinstance(model, DistributedModelParallel):
-            model = model.module
-
-        target = model.get_submodule(self._stash_site_fqn)
-
-        def _execute_stash_hook(module: torch.nn.Module, args: Any) -> None:
-            with record_function("## execute_pending_stashes ##"):
-                MemoryStashingManager.execute_pending_stashes()
-
-        self._stash_hook_handle = target.register_forward_pre_hook(_execute_stash_hook)
-        logger.info(
-            f"MemoryStashingManager: hooked execute_pending_stashes "
-            f"as forward pre-hook on {self._stash_site_fqn}"
-        )
-
     def _pipeline_model(
         self,
         batch: Optional[In],
@@ -1251,18 +1223,22 @@ class TrainPipelineSparseDistEmbStash(TrainPipelineSparseDist[In, Out]):
     ) -> None:
         super()._pipeline_model(batch, context, pipelined_forward)
 
-        if self._delay_stash and self._stash_site_fqn is None:
-            # No forward hook site specified — fall back to executing
-            # pending stashes via backward hook at the injection site.
+        if self._delay_stash:
+
             def execute_work(_pipeline: Any) -> None:
                 with record_function("## execute_pending_stashes ##"):
                     MemoryStashingManager.execute_pending_stashes()
 
-            self.register_backward_hook(self._injection_site, execute_work)
-
-        # Hook stash execution into the target module's forward if configured.
-        if self._delay_stash:
-            self._try_hook_stash()
+            if self._stash_site_fqn is not None:
+                stash_site = InjectionSite(
+                    fqn=self._stash_site_fqn,
+                    tensor_finder=FirstGradTensorFinder(),
+                    target_type=InjectionTargetType.PARAM_GRAD,
+                    hook_position=self._stash_hook_position,
+                )
+                self.register_backward_hook(stash_site, execute_work)
+            elif self._injection_site is not None:
+                self.register_backward_hook(self._injection_site, execute_work)
 
         def work(_pipeline: Any) -> None:
             with record_function("## restore_embedding_weights ##"):

--- a/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
+++ b/torchrec/distributed/train_pipeline/tests/test_backward_injection.py
@@ -9,7 +9,8 @@
 
 import copy
 import unittest
-from typing import cast, List, Optional, Tuple
+from typing import Any, cast, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
 
 import torch
 from hypothesis import given, settings, strategies as st
@@ -32,6 +33,10 @@ from torchrec.distributed.train_pipeline.backward_injection import (
     OutputDistTensorFinder,
     register_backward_hook,
 )
+from torchrec.distributed.train_pipeline.experimental_pipelines import (
+    TrainPipelineSparseDistEmbStash,
+)
+from torchrec.distributed.train_pipeline.train_pipelines import TrainPipelineSparseDist
 from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingType
 from torchrec.modules.embedding_configs import EmbeddingBagConfig
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor
@@ -363,6 +368,142 @@ class InjectionSiteTest(unittest.TestCase):
         model.zero_grad()
         model(torch.randn(2, 4)).sum().backward()
         self.assertEqual(call_count[0], 3)
+
+
+_EMS_MODULE = "torchrec.distributed.train_pipeline.experimental_pipelines"
+
+
+def _mock_embstash_parent_init(self_inner: Any, *args: Any, **kwargs: Any) -> None:
+    """Minimal stand-in for ``TrainPipelineSparseDist.__init__`` so that
+    ``TrainPipelineSparseDistEmbStash`` can be constructed without GPU or
+    distributed setup."""
+    self_inner._memcpy_stream = MagicMock()
+    self_inner._model = MagicMock()
+
+
+class TrainPipelineSparseDistEmbStashHookTest(unittest.TestCase):
+    """Unit tests for the delayed-stash backward-hook wiring in
+    ``TrainPipelineSparseDistEmbStash._pipeline_model`` (no GPU/distributed
+    required). Delayed stash execution must use ``register_backward_hook`` with a
+    ``PARAM_GRAD`` ``InjectionSite`` rather than a forward pre-hook, so that it is
+    compile-safe and FSDP2-safe."""
+
+    @patch(f"{_EMS_MODULE}.MemoryStashingManager")
+    @patch(f"{_EMS_MODULE}.torch.cuda.Stream")
+    @patch.object(TrainPipelineSparseDist, "__init__", _mock_embstash_parent_init)
+    def test_with_stash_site_fqn_registers_param_grad_backward_hook(
+        self, mock_cuda_stream: MagicMock, mock_msm: MagicMock
+    ) -> None:
+        pipeline = TrainPipelineSparseDistEmbStash(
+            model=MagicMock(),
+            optimizer=MagicMock(),
+            device=torch.device("cpu"),
+            site_fqn="shared_arch",
+            delay_stash=True,
+            stash_site_fqn="dense",
+            stash_hook_position=0.25,
+        )
+
+        with patch.object(TrainPipelineSparseDist, "_pipeline_model"), patch.object(
+            pipeline, "register_backward_hook"
+        ) as register_backward_hook:
+            pipeline._pipeline_model(MagicMock(), MagicMock())
+
+        # Two backward hooks: execute_pending_stashes (at stash_site_fqn) and
+        # restore_embedding_weights (at restore site). No forward pre-hook.
+        self.assertEqual(register_backward_hook.call_count, 2)
+
+        # First hook executes pending stashes on a PARAM_GRAD InjectionSite
+        # built from stash_site_fqn / stash_hook_position, distinct from the
+        # restore site.
+        stash_site = register_backward_hook.call_args_list[0][0][0]
+        self.assertEqual(stash_site.fqn, "dense")
+        self.assertEqual(stash_site.target_type, InjectionTargetType.PARAM_GRAD)
+        self.assertEqual(stash_site.hook_position, 0.25)
+        self.assertIsNot(stash_site, pipeline._injection_site)
+
+        execute_fn = register_backward_hook.call_args_list[0][0][1]
+        mock_msm.reset_mock()
+        execute_fn(pipeline)
+        mock_msm.execute_pending_stashes.assert_called_once()
+
+        # Second hook restores embedding weights at the restore injection site.
+        restore_site = register_backward_hook.call_args_list[1][0][0]
+        self.assertIs(restore_site, pipeline._injection_site)
+        self.assertEqual(restore_site.fqn, "shared_arch")
+
+        restore_fn = register_backward_hook.call_args_list[1][0][1]
+        mock_msm.reset_mock()
+        restore_fn(pipeline)
+        mock_msm.restore_embedding_weights.assert_called_once()
+
+    @patch(f"{_EMS_MODULE}.MemoryStashingManager")
+    @patch(f"{_EMS_MODULE}.torch.cuda.Stream")
+    @patch.object(TrainPipelineSparseDist, "__init__", _mock_embstash_parent_init)
+    def test_delay_stash_without_stash_site_fqn_falls_back_to_injection_site(
+        self, mock_cuda_stream: MagicMock, mock_msm: MagicMock
+    ) -> None:
+        pipeline = TrainPipelineSparseDistEmbStash(
+            model=MagicMock(),
+            optimizer=MagicMock(),
+            device=torch.device("cpu"),
+            site_fqn="shared_arch",
+            delay_stash=True,
+            stash_site_fqn=None,
+        )
+
+        with patch.object(TrainPipelineSparseDist, "_pipeline_model"), patch.object(
+            pipeline, "register_backward_hook"
+        ) as register_backward_hook:
+            pipeline._pipeline_model(MagicMock(), MagicMock())
+
+        # Two backward hooks; the execute hook falls back to the restore
+        # injection site (still a backward hook, never a forward pre-hook).
+        self.assertEqual(register_backward_hook.call_count, 2)
+        self.assertIs(
+            register_backward_hook.call_args_list[0][0][0], pipeline._injection_site
+        )
+
+        execute_fn = register_backward_hook.call_args_list[0][0][1]
+        mock_msm.reset_mock()
+        execute_fn(pipeline)
+        mock_msm.execute_pending_stashes.assert_called_once()
+
+        restore_fn = register_backward_hook.call_args_list[1][0][1]
+        mock_msm.reset_mock()
+        restore_fn(pipeline)
+        mock_msm.restore_embedding_weights.assert_called_once()
+
+    @patch(f"{_EMS_MODULE}.MemoryStashingManager")
+    @patch(f"{_EMS_MODULE}.torch.cuda.Stream")
+    @patch.object(TrainPipelineSparseDist, "__init__", _mock_embstash_parent_init)
+    def test_defaults_no_delay_stash_registers_only_restore_hook(
+        self, mock_cuda_stream: MagicMock, mock_msm: MagicMock
+    ) -> None:
+        pipeline = TrainPipelineSparseDistEmbStash(
+            model=MagicMock(),
+            optimizer=MagicMock(),
+            device=torch.device("cpu"),
+            site_fqn="shared_arch",
+        )
+
+        # Defaults: delayed stash disabled, stash_hook_position 0.01.
+        self.assertFalse(pipeline._delay_stash)
+        self.assertIsNone(pipeline._stash_site_fqn)
+        self.assertEqual(pipeline._stash_hook_position, 0.01)
+        mock_msm.set_delay_stash.assert_not_called()
+
+        with patch.object(TrainPipelineSparseDist, "_pipeline_model"), patch.object(
+            pipeline, "register_backward_hook"
+        ) as register_backward_hook:
+            pipeline._pipeline_model(MagicMock(), MagicMock())
+
+        # Only the restore hook is registered when delayed stash is disabled.
+        self.assertEqual(register_backward_hook.call_count, 1)
+        restore_fn = register_backward_hook.call_args_list[0][0][1]
+        mock_msm.reset_mock()
+        restore_fn(pipeline)
+        mock_msm.restore_embedding_weights.assert_called_once()
 
 
 def _create_sharded_model(


### PR DESCRIPTION
Summary:
Ports the backward-hook integration for delayed stash execution from the APF pipeline to the TorchRec benchmark pipeline (TrainPipelineSparseDistEmbStash).

Replaces the forward pre-hook approach (register_forward_pre_hook) with the compile-safe, FSDP2-safe backward hook API (register_backward_hook + InjectionSite(PARAM_GRAD) + register_post_accumulate_grad_hook). Mirrors the restore pattern exactly.

Changes:
- experimental_pipelines.py: Added stash_hook_position param, removed _try_hook_stash() and _stash_hook_handle, replaced with register_backward_hook(InjectionSite(PARAM_GRAD)) in _pipeline_model()
- tests/test_backward_injection.py: Added 3 new tests for stash-site backward hook, fallback, and defaults
- tests/BUCK: Added deps for new test imports

TrainPipelinePrefetchEMS subclass verified — inherits correctly with no changes needed.

Differential Revision: D109374651


