### PR TITLE
Enable only even sharding and add just knobs to enumerator (#4377)

### DIFF
--- a/torchrec/distributed/planner/enumerators.py
+++ b/torchrec/distributed/planner/enumerators.py
@@ -11,6 +11,7 @@ import copy
 import logging
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+import torch
 from torch import nn
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.planner.constants import (
@@ -321,7 +322,23 @@ class EmbeddingEnumerator(Enumerator):
             embedding_configs = module.embedding_configs()
         elif isinstance(module, BaseManagedCollisionEmbeddingCollection):
             all_buckets = module._managed_collision_collection.table_to_number_buckets()
-            return all_buckets[parameter] if parameter in all_buckets else None
+            num_buckets = all_buckets.get(parameter)
+            if num_buckets is None:
+                return None
+            if num_buckets % self._world_size == 0:
+                return None
+            if not torch._utils_internal.justknobs_check(
+                "pytorch/torchrec:enable_uneven_buckets_mpzch",
+                default=False,
+            ):
+                raise ValueError(
+                    f"Table '{parameter}' has uneven buckets per rank "
+                    f"({num_buckets} buckets across {self._world_size} ranks), but "
+                    "uneven-bucket planning is disabled. Enable JK "
+                    "'pytorch/torchrec:enable_uneven_buckets_mpzch' to shard "
+                    "tables with uneven buckets per rank."
+                )
+            return num_buckets
         else:
             # Module does not utilize buckets
             return None

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from hypothesis import given, settings, strategies as st, Verbosity
+from hypothesis import assume, given, settings, strategies as st, Verbosity
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.mc_embedding import (
     KJTList,
@@ -1228,6 +1228,7 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
             backend=backend,
         )
 
+    @unittest.skip("Temporarily disabled")
     @unittest.skipIf(
         torch.cuda.device_count() <= 2,
         "Not enough GPUs, this test requires at least two GPUs",
@@ -1467,6 +1468,8 @@ class ShardedMCEmbeddingCollectionParallelTest(MultiProcessTestBase):
     @given(backend=st.sampled_from(["nccl"]), uneven_buckets=st.booleans())
     @settings(deadline=None)
     def test_sharding_zch_mc_ec_dedup(self, backend: str, uneven_buckets: bool) -> None:
+        # Temporarily disabled for the uneven buckets case
+        assume(not uneven_buckets)
         WORLD_SIZE = 2
         total_num_buckets = [4, 4]
         if uneven_buckets:

--- a/torchrec/distributed/tests/test_mc_embedding_write.py
+++ b/torchrec/distributed/tests/test_mc_embedding_write.py
@@ -14,7 +14,7 @@ from typing import cast, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from hypothesis import given, settings, strategies as st
+from hypothesis import assume, given, settings, strategies as st
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torchrec.distributed.embedding import EmbeddingCollectionSharder
 from torchrec.distributed.mc_embedding import (
@@ -703,6 +703,8 @@ class ShardedMCECInputDist2DWeightsTest(MultiProcessTestBase):
     def test_input_dist_2d_weights_mapping(
         self, backend: str, uneven_buckets: bool
     ) -> None:
+        # Temporarily disabled for the uneven buckets case
+        assume(not uneven_buckets)
         total_buckets = 3 if uneven_buckets else 4
 
         embedding_config = [


### PR DESCRIPTION
Summary:

Context
---------

Uneven buckets per rank was implemented for MP-ZCH. It was found that when even buckets per rank was used, it still routed to the bucket-based partitioning. This diff restores the round-robin for evenly-divisible buckets.



Implementation
------------------

- Within planner if there is even buckets, then it returns None (traditional original path)
- If not, then uneven buckets per rank is enabled, and the just knob (which is set to False) will return  a ValueError

All unit tests that had uneven buckets per rank is temporarily disabled.

Reviewed By: kausv

Differential Revision: D108890874


