### PR TITLE
INT4 Support in tgif (#4378)

### DIFF
--- a/torchrec/modules/utils.py
+++ b/torchrec/modules/utils.py
@@ -22,6 +22,44 @@ from torchrec.types import CacheMixin
 torch.fx.wrap("len")
 
 
+@torch.fx.wrap
+def _maybe_quint4x2_to_int8(
+    embedding: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reinterpret a quint4x2 tensor as packed uint8.
+
+    Why this is needed: quint4x2 is a sub-byte quantized dtype that most tensor
+    ops reject -- e.g. torch.split()/torch.cat() and the downstream host-to-device
+    copy and dequant kernels cannot operate on a quint4x2 tensor directly.
+    Reinterpreting the packed 4-bit payload as uint8 (which all of those ops do
+    support) lets the INT4 embedding output flow through the rest of the graph.
+
+    This OSS variant uses int_repr(), a core aten op that is available and
+    TorchScript-compatible in every build (it copies the packed bytes). The
+    Meta-internal torchrec.fb.modules.utils._maybe_quint4x2_to_int8 is a zero-copy
+    variant used on the TGIF inference path.
+
+    NOTE: despite the name, the returned dtype is torch.uint8, not int8. The
+    function name is load-bearing -- downstream fx graph passes detect this op
+    by name in the traced graph to enable the on-device INT4 dequant dispatch
+    shape. Do not rename it without updating those detectors.
+
+    quint4x2 is a tensor of uint8 values in the range [0, 15], interpreted as
+    two 4-bit values packed into each byte. The first 4-bit value is in the
+    lower 4 bits of the byte, and the second is in the upper 4 bits.
+    """
+    if embedding.dtype == torch.quint4x2:
+        assert embedding.dim() == 2, (
+            "_maybe_quint4x2_to_int8 expects a 2-D quint4x2 tensor, "
+            f"got a {embedding.dim()}-D tensor"
+        )
+        return embedding.int_repr().reshape(
+            [embedding.shape[0], int((embedding.shape[1] + 1) // 2)]
+        )
+    return embedding
+
+
 @dataclass
 class SequenceVBEContext(Multistreamable):
     recat: torch.Tensor

--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -63,6 +63,7 @@ from torchrec.modules.mc_embedding_modules import (
 from torchrec.modules.mc_modules import ManagedCollisionCollection
 from torchrec.modules.utils import (
     _get_batching_hinted_output,
+    _maybe_quint4x2_to_int8,
     construct_jagged_tensors_inference,
 )
 from torchrec.sparse.jagged_tensor import (
@@ -76,6 +77,7 @@ from torchrec.types import ModuleNoCopyMixin
 
 torch.fx.wrap("_get_batching_hinted_output")
 torch.fx.wrap("len")
+torch.fx.wrap("_maybe_quint4x2_to_int8")
 
 try:
     torch.ops.load_library("//deeplearning/fbgemm/fbgemm_gpu:sparse_ops")
@@ -963,6 +965,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 if self.register_tbes
                 else emb_module.forward(indices=indices, offsets=offsets)
             )
+            lookup = _maybe_quint4x2_to_int8(lookup)
             if getattr(self, MODULE_ATTR_USE_UNFLATTENED_LENGTHS_FOR_BATCHING, False):
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
                 lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)


### PR DESCRIPTION
Summary:

Add end-to-end INT4 (quint4x2) quantized embedding support for the inference pipeline, removing the previous restriction that required Distributed Inference (DI) sharding for INT4 sparse output.

Key changes:
- Add `_quint4x2_to_int8()` zero-copy conversion utility in torchrec/modules/utils.py that reinterprets packed quint4x2 tensors as uint8 via `torch.ops.gr.quantized_to_uint8_view`
- Call `_quint4x2_to_int8(lookup)` after TBE forward in both quantized embedding module paths (EmbeddingBagCollection and the fb/quant arch) so INT4 output flows through the graph as uint8
- Extend TensorsToDeviceModule with a `quant_dtype` hint; when set to quint4x2, use the 4-bit dequant kernel (`FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf`) instead of the 8-bit path
- Refactor TensorsToDeviceModule forward: unify duplicated to_half/to_bfloat16 list comprehensions into a single loop with shared logic
- Remove the guard in dense_quantization_pass that forced sparse_output_dtype to None when DI was not enabled, since INT4 is now supported universally
- Consolidate TGIF-specific `add_to_device_module_for_input_tensors_tgif` into the common `add_to_device_module_for_input_tensors` path with sparse_dtype support

Depends on D84015365 (zero-copy reinterpret op), D82366293 (split dispatcher fix).

Reviewed By: kausv

Differential Revision: D99737694


