### PR TITLE
Lazy-import guard_or_false/guard_or_true in checks.py

### DIFF
--- a/torchrec/pt2/checks.py
+++ b/torchrec/pt2/checks.py
@@ -10,7 +10,37 @@
 from typing import List
 
 import torch
-from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+
+try:
+    from torch.fx.experimental.symbolic_shapes import guard_or_false, guard_or_true
+except ImportError:
+    # Forward-compatibility: older torch builds bundled in prod-pinned
+    # lowering/processing packages predate guard_or_false/guard_or_true.
+    #
+    # This fallback is never actually invoked in practice: older torch only
+    # exists in the deserialization/lowering backend, where is_pt2_compiling() is
+    # False, so the consuming pt2_guard_or_* functions return x before ever
+    # calling these. It exists only so the module can be imported against older
+    # torch (the forward-compat condition that was failing).
+    #
+    # guard_size_oblivious is the exact primitive these two helpers replaced in
+    # D100530526 and reproduces their behavior for the only call sites
+    # (jagged_tensor: numel() == 0 -> guard_or_false; numel() != 0 / > 0 ->
+    # guard_or_true), so it is faithful for the size predicates used here. It is
+    # intentionally not a general-purpose equivalent (guard_or_false biases
+    # False, guard_or_true biases True); that mismatch is moot given the above.
+    #
+    # Kept at module scope (not inlined) because pt2_guard_or_* are TorchScript
+    # compiled, and TorchScript rejects in-function import statements even in the
+    # dead is_scripting() branch.
+    from torch.fx.experimental.symbolic_shapes import guard_size_oblivious
+
+    def guard_or_false(x: bool) -> bool:
+        return guard_size_oblivious(x)
+
+    def guard_or_true(x: bool) -> bool:
+        return guard_size_oblivious(x)
+
 
 USE_TORCHDYNAMO_COMPILING_PATH: bool = False
 


### PR DESCRIPTION
Summary:
Fixes in-trainer publish failures (T276348446) where APS ads_vm cogwheel
release-gate jobs fail during GPU lowering (AOTINDUCTOR) torch.package
deserialization with:

  [USER_ERROR][VALIDATION_AND_LOWERING_INFRA] Forward compatibility issue
  detected, authoring package has deps that are not in the training or
  processing packages.
  ImportError: cannot import name 'guard_or_false' from
  'torch.fx.experimental.symbolic_shapes'

Root cause: D100530526 added an unconditional module-level import of
`guard_or_false` / `guard_or_true` to torchrec/pt2/checks.py. These helpers
exist only in newer torch builds. When a trunk-built authoring package
(aps_ads_vm) is deserialized inside a prod-pinned lowering/processing package
(ien.lower) that bundles an older torch, the top-level import fails and the
whole torch.package import chain (dper3.core.environment -> symbolic_tracing ->
torchrec.sparse.jagged_tensor -> torchrec.pt2.checks) breaks.

Fix: move the import into the two consumers (pt2_guard_or_false /
pt2_guard_or_true). Both already early-return unless is_pt2_compiling(), so the
new symbols are only resolved on the PT2 compile path where torch is guaranteed
new enough. Nothing re-exports these symbols, so this is behavior-preserving.
The module now imports cleanly against older torch, restoring forward
compatibility.

Reviewed By: guoding83128

Differential Revision: D109429297


