### PR TITLE
Gate ZORM defensive model_out clone; default off, callers that reuse the buffer opt in

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -203,6 +203,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         update_queue_size: int = 100,
         compute_queue_size: int = 100,
         update_batch_size: int = 10,
+        clone_model_out: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -226,6 +227,12 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         super().__init__(*args, **kwargs)
         self._model_out_device = model_out_device
         self._update_batch_size: int = max(1, update_batch_size)
+        # Defaults to False: the enqueued job holds references to model_out and
+        # the source-stream guard on the async DtoH keeps the tensors valid, so
+        # the per-step GPU clone is pure overhead. Set True only when the caller
+        # reuses the model_out buffer across steps (e.g. Pyper memcpy_compute),
+        # where the worker would otherwise read mutated data.
+        self._clone_model_out: bool = clone_model_out
         self._shutdown_event: threading.Event = threading.Event()
         self._compute_shutdown_event: threading.Event = threading.Event()
         self._shutdown_complete: bool = False
@@ -344,8 +351,14 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             assert self._captured_exception is not None
             raise self._captured_exception
 
-        snapshot_model_out = _foreach_clone_dict(model_out)
-        snapshot_kwargs = _foreach_clone_kwargs(kwargs)
+        if self._clone_model_out:
+            snapshot_model_out = _foreach_clone_dict(model_out)
+            snapshot_kwargs = _foreach_clone_kwargs(kwargs)
+        else:
+            # Shallow-copy the containers (cheap; no tensor copy) so dict-level
+            # mutation by the caller is isolated; tensor refs are shared.
+            snapshot_model_out = dict(model_out)
+            snapshot_kwargs = dict(kwargs)
 
         try:
             self.update_queue.put_nowait(

--- a/torchrec/metrics/deferrable_metrics.py
+++ b/torchrec/metrics/deferrable_metrics.py
@@ -33,17 +33,51 @@ def device_supports_async(device: torch.device) -> bool:
     return device.type == "cuda"
 
 
+# Dedicated per-device CUDA stream pool for metric DtoH transfers, so ZORM
+# transfers do not serialize with training kernels (and NCCL collectives,
+# and main-thread pageable DtoH) on the default stream. Lazily created on
+# first use, lives for process lifetime. ZORM has a single update worker
+# and a single compute worker per module, so one stream per device suffices.
+_metric_dtoh_streams: dict[torch.device, torch.cuda.Stream] = {}
+
+
+def _get_metric_dtoh_stream(device: torch.device) -> torch.cuda.Stream:
+    # Fast path: already initialized.
+    stream = _metric_dtoh_streams.get(device)
+    if stream is not None:
+        return stream
+    # Slow path: create-and-publish. Explicit `device=device` so the stream
+    # is bound to the source tensors' device regardless of the caller's
+    # current device context. setdefault makes insertion atomic under CPython's
+    # GIL so concurrent first-time callers from the update- and compute-worker
+    # threads agree on a single canonical stream; the losing stream is dropped.
+    new_stream = torch.cuda.Stream(device=device)
+    return _metric_dtoh_streams.setdefault(device, new_stream)
+
+
 def transfer_tensors_to_cpu(
     tensors: dict[str, Any],
 ) -> tuple[dict[str, Any], torch.cuda.Event | None]:
-    """Transfer GPU tensors to CPU using non-blocking copies.
+    """Transfer GPU tensors to pinned CPU using non-blocking copies on a
+    dedicated CUDA stream.
 
-    Returns the CPU tensor dict and a CUDA event that tracks completion.
-    For CPU-only inputs, returns the dict as-is with None event.
-    Non-tensor values are preserved unchanged.
+    Two changes from the default `.to("cpu", non_blocking=True)` pattern:
 
-    Records the CUDA event on the source tensor's device stream (not the
-    default device) to avoid metric corruption on non-rank-0 processes.
+    1. Issues the copies on a dedicated per-device CUDA stream rather than
+       the caller's current stream. The caller's current stream is normally
+       the default training stream, where ZORM's large DtoH would queue
+       behind training kernels and block any subsequent operation submitted
+       there (training kernels, NCCL collectives, main-thread pageable DtoH).
+       The dedicated stream is independent, so ZORM transfers run in parallel.
+    2. Allocates pinned CPU destinations so cudaMemcpyAsync is truly async
+       on the host (no staging buffer wait on the caller side).
+
+    `wait_stream(producer_stream)` preserves the data-dependency on the
+    producer's last write to the source tensors before the transfer starts.
+
+    Returns the CPU tensor dict and a CUDA event recorded on the dedicated
+    stream that tracks completion. For CPU-only inputs, returns the dict
+    as-is with None event. Non-tensor values are preserved unchanged.
     All tensors are assumed to be on the same device.
     """
     source_device: torch.device | None = None
@@ -54,17 +88,33 @@ def transfer_tensors_to_cpu(
     if source_device is None:
         return tensors, None
 
+    dtoh_stream = _get_metric_dtoh_stream(source_device)
+
     with torch.cuda.device(source_device):
-        cpu_tensors: dict[str, Any] = {}
-        for k, v in tensors.items():
-            if isinstance(v, torch.Tensor):
-                dst = torch.empty(v.shape, dtype=v.dtype, device="cpu", pin_memory=True)
-                dst.copy_(v, non_blocking=True)
-                cpu_tensors[k] = dst
-            else:
-                cpu_tensors[k] = v
-        event = torch.cuda.Event()
-        event.record()
+        # Make our transfer wait for the producer's pending writes to drain
+        # (the producer is whatever stream the source tensors were last
+        # written on, typically the default training stream).
+        dtoh_stream.wait_stream(torch.cuda.current_stream())
+
+        with torch.cuda.stream(dtoh_stream):
+            cpu_tensors: dict[str, Any] = {}
+            for k, v in tensors.items():
+                if isinstance(v, torch.Tensor):
+                    dst = torch.empty(
+                        v.shape, dtype=v.dtype, device="cpu", pin_memory=True
+                    )
+                    dst.copy_(v, non_blocking=True)
+                    # The source was allocated on the producer stream; the
+                    # caching allocator would otherwise recycle its memory as
+                    # soon as the producer stream frees it, racing our in-flight
+                    # async copy on dtoh_stream. record_stream holds the block
+                    # until dtoh_stream passes this point.
+                    v.record_stream(dtoh_stream)
+                    cpu_tensors[k] = dst
+                else:
+                    cpu_tensors[k] = v
+            event = torch.cuda.Event()
+            event.record()
 
     return cpu_tensors, event
 

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -208,6 +208,46 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             self.cpu_module.compute,
         )
 
+    def test_clone_model_out_false_skips_clone(self) -> None:
+        """clone_model_out=False must not call the defensive _foreach_clone."""
+        module = self._make_module(clone_model_out=False)
+        src = torch.tensor([0.5, 0.7])
+        model_out = {"task1-prediction": src}
+        captured: list[MetricUpdateJob] = []
+        try:
+            # Intercept at enqueue so the worker thread can't drain it first.
+            with patch.object(
+                module.update_queue, "put_nowait", side_effect=captured.append
+            ), patch(
+                "torchrec.metrics.cpu_offloaded_metric_module._foreach_clone_dict"
+            ) as mock_clone_dict, patch(
+                "torchrec.metrics.cpu_offloaded_metric_module._foreach_clone_kwargs"
+            ) as mock_clone_kwargs:
+                module._update_rec_metrics(model_out)
+                mock_clone_dict.assert_not_called()
+                mock_clone_kwargs.assert_not_called()
+            # No clone -> the enqueued tensor is the same object.
+            self.assertIs(captured[0].model_out["task1-prediction"], src)
+        finally:
+            module.shutdown()
+
+    def test_clone_model_out_true_clones(self) -> None:
+        """Default clone_model_out=True must defensively clone model_out."""
+        module = self._make_module(clone_model_out=True)
+        src = torch.tensor([0.5, 0.7])
+        model_out = {"task1-prediction": src}
+        captured: list[MetricUpdateJob] = []
+        try:
+            with patch.object(
+                module.update_queue, "put_nowait", side_effect=captured.append
+            ):
+                module._update_rec_metrics(model_out)
+            # Cloned -> distinct object, equal values.
+            self.assertIsNot(captured[0].model_out["task1-prediction"], src)
+            torch.testing.assert_close(captured[0].model_out["task1-prediction"], src)
+        finally:
+            module.shutdown()
+
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -630,6 +630,20 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 "weights": torch.ones(1024, device="cuda:1") * 2.0,
             }
 
+            # Warm the pinned-memory cache and the dedicated DtoH stream first.
+            # The first pinned allocation triggers a synchronizing cudaHostAlloc;
+            # if that ran during the measured transfer it would drain the busy
+            # matmuls and complete the event immediately, masking the cuda:0 bug
+            # this test guards against. Warming up lets the measured transfer
+            # reuse cached pinned blocks with no host-alloc sync.
+            warmup_cpu, warmup_event = transfer_tensors_to_cpu(
+                {k: torch.ones_like(v) for k, v in source_tensors.items()}
+            )
+            if warmup_event is not None:
+                warmup_event.synchronize()
+            del warmup_cpu, warmup_event
+            torch.cuda.synchronize("cuda:1")
+
             busy = torch.randn(8192, 8192, device="cuda:1")
             for _ in range(50):
                 busy = busy @ busy
@@ -657,6 +671,68 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
                 cpu_tensors["weights"],
                 torch.ones(1024) * 2.0,
             )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "Not enough GPUs, this test requires at least one GPU",
+    )
+    def test_transfer_tensors_to_cpu_source_not_recycled_during_copy(self) -> None:
+        """
+        Regression test for a cross-stream use-after-free on the SOURCE tensor.
+
+        transfer_tensors_to_cpu copies on a dedicated DtoH stream while the
+        source was produced on the default stream. Without record_stream, the
+        caching allocator may recycle the source's GPU block as soon as the
+        default stream frees it — racing the still-in-flight async copy and
+        corrupting the CPU result. record_stream must hold the block until the
+        DtoH stream is done.
+
+        We force the race: queue slow producer work so the copy is delayed,
+        drop the source, then immediately reallocate the same byte size on the
+        default stream and poison it. With the bug, the recycled block's poison
+        is read by the copy and lands in the CPU tensor; with the fix, the
+        block stays reserved and the CPU tensor holds the original value.
+        """
+        device = torch.device("cuda:0")
+        numel = 4 * 1024 * 1024  # 16 MB block, large enough to get its own slab
+        good_value = 3.14
+        poison_value = -1.0
+
+        for _ in range(8):
+            source_tensors = {
+                "predictions": torch.full(
+                    (numel,), good_value, device=device, dtype=torch.float32
+                ),
+            }
+
+            # Delay the DtoH so it is still queued (not yet reading) when we
+            # recycle the source block below.
+            busy = torch.randn(8192, 8192, device=device)
+            for _ in range(30):
+                busy = busy @ busy
+
+            cpu_tensors, event = transfer_tensors_to_cpu(source_tensors)
+            assert event is not None
+
+            # Drop the source ref and force the allocator to hand the freed
+            # block to a default-stream allocation, then overwrite with poison.
+            del source_tensors
+            recycler = torch.empty(numel, device=device, dtype=torch.float32)
+            recycler.fill_(poison_value)
+
+            event.synchronize()
+            torch.testing.assert_close(
+                cpu_tensors["predictions"],
+                torch.full((numel,), good_value),
+                msg=(
+                    "Source GPU block was recycled and overwritten while the "
+                    "DtoH copy was in flight — missing record_stream on the "
+                    "source tensor."
+                ),
+            )
+            del recycler, cpu_tensors, event
+            torch.cuda.synchronize(device)
 
     # pyre-ignore[56]
     @unittest.skipIf(

--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import torch
 from torchrec.metrics.deferrable_metrics import (
+    _get_metric_dtoh_stream,
     DeferrableMetrics,
     device_supports_async,
     transfer_tensors_to_cpu,
@@ -358,6 +359,52 @@ class TransferTensorsToCpuTest(unittest.TestCase):
         cpu_tensors, event = transfer_tensors_to_cpu({})
         self.assertEqual(len(cpu_tensors), 0)
         self.assertIsNone(event)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+    def test_cuda_transfer_uses_dedicated_stream(self) -> None:
+        """Regression test: transfer_tensors_to_cpu must enqueue copies on the
+        dedicated DtoH stream, not the caller's current (default) stream.
+        Default-stream DtoH serializes with training kernels and NCCL
+        collectives, causing severe regressions (validated in
+        fbsource//fbcode/torchrec/distributed/benchmark/yaml/stress/zorm_stream_repro.yml
+        — without this guard, NCCL SendRecv inflates 15x and probe stalls
+        reach 1.3 seconds).
+        """
+        device = torch.device("cuda:0")
+        default_stream = torch.cuda.current_stream(device)
+        dtoh_stream = _get_metric_dtoh_stream(device)
+        self.assertNotEqual(default_stream, dtoh_stream)
+
+        # Block the dedicated stream with a long synthetic op BEFORE calling
+        # transfer_tensors_to_cpu. The returned event must be ordered behind
+        # this blocker because it was recorded on the same (dedicated) stream.
+        # If a future change regressed to recording on the default stream,
+        # the event would be independent of dtoh_stream's queue and
+        # event.query() would return True immediately (default stream idle).
+        with torch.cuda.stream(dtoh_stream):
+            torch.cuda._sleep(int(1e8))  # ~100ms of GPU stall on dtoh_stream
+        tensors: dict[str, Any] = {"x": torch.randn(128, device=device)}
+
+        _cpu, event = transfer_tensors_to_cpu(tensors)
+
+        self.assertIsNotNone(event)
+        self.assertFalse(
+            event.query(),
+            "event must be pending behind the blocker on the dedicated stream; "
+            "if event.query() is True the copy was queued on the wrong stream",
+        )
+        dtoh_stream.synchronize()
+        self.assertTrue(event.query())
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+    def test_cuda_transfer_destination_is_pinned(self) -> None:
+        """The CPU destination must be pinned so cudaMemcpyAsync is truly
+        non-blocking on the host. Without pinning, the driver stages
+        through an internal pinned buffer and the host call blocks."""
+        device = torch.device("cuda:0")
+        tensors: dict[str, Any] = {"x": torch.randn(128, device=device)}
+        cpu_tensors, _event = transfer_tensors_to_cpu(tensors)
+        self.assertTrue(cpu_tensors["x"].is_pinned())
 
 
 class DeviceSupportsAsyncTest(unittest.TestCase):


### PR DESCRIPTION
Summary: CPUOffloadedRecMetricModule cloned model_out (and kwargs) on the trainer thread every step before offloading the metric update, which is a full per-step GPU deep-copy on the critical path. Gate it behind a clone_model_out flag, default False: the offloaded job holds references to model_out and the source-stream guard on the async device-to-host copy keeps the tensors valid, so the clone is unnecessary when the caller produces fresh model_out per step. Callers that reuse the model_out buffer across steps set clone_model_out=True (via the metrics config) to keep the defensive copy.

Differential Revision: D109466865


