### PR TITLE
Implement DryRunRequest frozen dataclass (#4384)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+from typing import Dict, List, Mapping, Optional
+
+import torch.distributed as dist
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ShardingPlannerAPI(abc.ABC):
+    """Abstract base for sharding planner orchestrators.
+
+    Owns the shared per-target planning loop as a template method (``plan``):
+    for each target it delegates to the injected PlannerExecutor — which builds
+    the topology, resolves the storage reservation, and constructs and runs the
+    planner for that SKU — aggregating per-target ShardingPlanResults onto
+    ``ctx.results`` and into the returned map.
+
+    Subclasses supply only what differs — the set of targets — via ``_targets``:
+    ``ProductionPlannerOrchestrator`` resolves launcher_hardware -> concrete SKU;
+    ``DryRunOrchestrator`` expands the request's SKU list. The executor is
+    injected (its PlannerProvider selects OSS vs Meta topology/storage/planner),
+    and the broadcast process group is owned here.
+
+    (There is intentionally no separate concrete "orchestrator" class beyond the
+    prod/dry-run subclasses — the shared loop lives here, so the subclasses stay
+    thin and there is a single contract.)
+    """
+
+    def __init__(
+        self,
+        executor: PlannerExecutor,
+        broadcast_pg: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        self._executor = executor
+        # Optional caller-injected process group for the rank-0 plan + broadcast.
+        # APF passes its Gloo control group (cpu_ctl_dist_pg) here to avoid NCCL
+        # object-broadcast corruption on some SKUs (e.g. GB300). When None,
+        # _get_broadcast_pg falls back to the default WORLD group (offline -> None).
+        self._broadcast_pg = broadcast_pg
+
+    def plan(
+        self,
+        request: ShardingPlanRequest,
+        ctx: PlannerSessionContext,
+    ) -> Mapping[str, ShardingPlanResult]:
+        """Run the shared per-target planning loop and aggregate the results.
+
+        Returns a Mapping (read-only, covariant in the value type) keyed by SKU,
+        so subclasses may narrow the result type — e.g. DryRunOrchestrator
+        returns Mapping[str, DryRunResult].
+
+        Invariant: ``request`` must be the same object carried by ``ctx``
+        (``ctx.request``). This method reads only the target set from ``request``
+        (via ``_targets``); the executor reads model/sharders/constraints/config
+        from ``ctx.request``. Callers build ``ctx = PlannerSessionContext(request=
+        request, ...)`` so the two never diverge.
+
+        Distributed transfer: only the ShardingPlan is broadcast to all ranks —
+        that is all a rank needs to build DMP. The rich ShardingPlanResult
+        metadata (sharding_options, peak estimates, solve time) is produced only
+        on the planning rank (rank 0) and is intentionally NOT broadcast; it is
+        for logging/observability, which is a rank-0 concern. So on non-zero
+        ranks the result carries the plan with empty metadata.
+        """
+        # request is ctx.request by construction (see the invariant above); the
+        # executor reads model/sharders/constraints/config from ctx.request and
+        # builds the topology, storage reservation, and planner for each SKU.
+        # Enforce it so a caller passing a divergent request fails fast rather
+        # than silently planning targets from one request against another. A raise
+        # (not assert) so the check survives ``python -O``.
+        if request is not ctx.request:
+            raise ValueError("request must be the same object as ctx.request")
+        pg = self._get_broadcast_pg()
+        results: Dict[str, ShardingPlanResult] = {}
+        # dict.fromkeys dedups while preserving order: a subclass returning a
+        # duplicate SKU would otherwise trigger a redundant executor.run and
+        # silently overwrite the earlier result.
+        for sku in dict.fromkeys(self._targets(request)):
+            try:
+                result = self._executor.run(sku=sku, ctx=ctx, pg=pg)
+                result = self._finalize_result(sku, result, request)
+            except Exception as e:
+                # Fail-fast by default (production plans a single SKU: a broken
+                # plan must surface, not be swallowed). ``DryRunOrchestrator``
+                # opts into collect-and-continue so one bad SKU (model factory,
+                # enum coercion, HUM lookup, ...) does not lose the rest of the
+                # what-if sweep -- it is recorded as an unsuccessful result and
+                # the loop keeps going. (``PlannerError`` is already turned into a
+                # success=False result inside the executor; this governs only the
+                # unexpected errors that would otherwise propagate.)
+                if not self._isolate_target_errors():
+                    raise
+                logger.warning(
+                    "[planner] target sku=%s failed; recording as unsuccessful "
+                    "and continuing the sweep",
+                    sku,
+                    exc_info=True,
+                )
+                result = self._finalize_result(
+                    sku, self._failed_result(sku, ctx, e), request
+                )
+            ctx.results[sku] = result
+            results[sku] = result
+        return results
+
+    def _isolate_target_errors(self) -> bool:
+        """Whether a single target's unexpected failure is isolated to that target.
+
+        Base returns False: production fails fast (it plans one SKU and any
+        unexpected error must surface). ``DryRunOrchestrator`` overrides to True
+        so a multi-SKU sweep returns partial results instead of aborting on the
+        first bad SKU. Governs only non-``PlannerError`` exceptions; the executor
+        already converts ``PlannerError`` into a success=False result on both paths.
+        """
+        return False
+
+    def _failed_result(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        error: Exception,
+    ) -> ShardingPlanResult:
+        """Build a success=False result for a target that raised an unexpected error.
+
+        Used only on the collect-and-continue path so the failing SKU is surfaced
+        (with its error as ``planner_failure_reason``) rather than lost.
+        """
+        return ShardingPlanResult(
+            sku=sku,
+            success=False,
+            sharding_plan=None,
+            planner_failure_reason=f"{type(error).__name__}: {error}",
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+            request_hash=ctx.request.request_hash,
+            request_id=ctx.request.request_id,
+        )
+
+    def _finalize_result(
+        self,
+        sku: str,
+        result: ShardingPlanResult,
+        request: ShardingPlanRequest,
+    ) -> ShardingPlanResult:
+        """Post-process the per-SKU result before it is aggregated.
+
+        Base implementation returns the result unchanged. Subclasses may enrich
+        it — e.g. DryRunOrchestrator returns a DryRunResult that adds the per-SKU
+        request fingerprint. The return type is covariant, so a subclass returning
+        a ShardingPlanResult subclass narrows the whole result map accordingly.
+        """
+        return result
+
+    @abc.abstractmethod
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        """Concrete GPU-SKUs to plan for.
+
+        Each value becomes a ShardingPlanResult.sku and a key in the result map,
+        so it must be a GPU-SKU (e.g. "H100"/"GB200") — not a launcher_hardware
+        value ("ZIONEX"/"TC_ANY"). ProductionPlannerOrchestrator resolves
+        launcher_hardware -> SKU; DryRunOrchestrator returns the request's
+        sku_list.
+        """
+        ...
+
+    def _get_broadcast_pg(self) -> Optional[dist.ProcessGroup]:
+        """Process group for the plan broadcast, owned by the API.
+
+        Returns a group in a distributed context so the executor runs
+        ``collective_plan`` (rank-0 plan + broadcast); returns None offline /
+        single-rank so the executor runs a local ``plan``.
+
+        Process-group *initialization* is intentionally NOT done here — it is the
+        caller's (trainer/framework's) responsibility, via
+        ``torch.distributed.init_process_group`` during training setup, before
+        planning. This method never initializes ``dist`` (doing so would clash
+        with the trainer's own PG/backend/timeout); it only detects whether a
+        distributed context already exists via ``dist.is_initialized()``. When it
+        is not initialized (offline / dry-run / single process) it returns None
+        and the executor plans locally.
+
+        The plan is broadcast as a pickled Python object, and NCCL
+        object-broadcast is known to corrupt on some SKUs (e.g. GB300). To avoid
+        that, a caller in a distributed context should inject a dedicated Gloo/CPU
+        group via the constructor (``broadcast_pg``) — APF passes its existing Gloo
+        control group (``cpu_ctl_dist_pg``), validated to span the same ranks as
+        WORLD. When an injected group is present it is used; otherwise this falls
+        back to the default (NCCL) WORLD group when distributed is initialized, and
+        None offline (single-rank / dry-run -> local plan).
+        """
+        if self._broadcast_pg is not None:
+            return self._broadcast_pg
+        if dist.is_available() and dist.is_initialized():
+            return dist.group.WORLD
+        return None
+
+
+class ProductionPlannerOrchestrator(ShardingPlannerAPI):
+    """Production orchestrator: plans for the single concrete SKU the job runs on.
+
+    The concrete GPU-SKU is resolved by the caller and passed at construction;
+    ``_targets`` simply returns it. Resolving launcher_hardware -> SKU goes through
+    HUM hardware detection, which is fb-only, so it happens outside this OSS class:
+    the Meta ``create_sharding_plan`` entrypoint resolves the SKU via
+    ``get_training_hardware`` before constructing this orchestrator, keeping the
+    OSS layer free of any fb/HUM import.
+    """
+
+    def __init__(
+        self,
+        executor: PlannerExecutor,
+        sku: str,
+        broadcast_pg: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        super().__init__(executor, broadcast_pg=broadcast_pg)
+        self._sku = sku
+
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        return [self._sku]

--- a/torchrec/distributed/planner/dry_run/__init__.py
+++ b/torchrec/distributed/planner/dry_run/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/distributed/planner/dry_run/tests/__init__.py
+++ b/torchrec/distributed/planner/dry_run/tests/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/distributed/planner/dry_run/tests/test_types.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_types.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, Dict
+
+import torch.nn as nn
+from torchrec.distributed.planner.dry_run.types import (
+    CacheConfig,
+    DryRunRequest,
+    SkuOverride,
+)
+from torchrec.distributed.planner.types import ParameterConstraints, ShardingPlanRequest
+
+
+class DryRunRequestTest(unittest.TestCase):
+    def _create_request(self, **kwargs: Any) -> DryRunRequest:
+        defaults: Dict[str, Any] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "sku_list": ["H100"],
+            "training_framework": "apf",
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return DryRunRequest(**defaults)
+
+    def test_valid_request_construction(self) -> None:
+        override = SkuOverride(hbm_gb=80.0, ddr_gb=512.0)
+        cache = CacheConfig(enabled=True, ttl_seconds=3600, manifold_bucket="test")
+        request = self._create_request(
+            pod_size=8,
+            hbm_gb=80.0,
+            ddr_gb=512.0,
+            per_sku_overrides={"H100": override},
+            cache_config=cache,
+        )
+        self.assertEqual(request.world_size, 8)
+        self.assertEqual(request.hbm_gb, 80.0)
+        self.assertIsNotNone(request.per_sku_overrides)
+        self.assertIsNotNone(request.cache_config)
+        self.assertTrue(request.cache_config.enabled)
+
+    def test_empty_sku_list_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sku_list must not be empty"):
+            self._create_request(sku_list=[])
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"world_size": 0}, "world_size must be positive"),
+            ({"world_size": -1}, "world_size must be positive"),
+            ({"local_world_size": 0}, "local_world_size must be positive"),
+            ({"batch_size": 0}, "batch_size must be positive"),
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -10.0}, "ddr_gb must be non-negative"),
+            ({"pod_size": 0}, "pod_size must be positive"),
+            ({"pod_size": -1}, "pod_size must be positive"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_request(**overrides)
+
+    def test_cross_field_validation(self) -> None:
+        with self.subTest("local exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "local_world_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=4, local_world_size=8)
+        with self.subTest("world not divisible by local"):
+            with self.assertRaisesRegex(
+                ValueError, "world_size.*must be divisible by local_world_size"
+            ):
+                self._create_request(world_size=10, local_world_size=3)
+
+    def test_zero_hbm_gb_allowed(self) -> None:
+        request = self._create_request(hbm_gb=0.0)
+        self.assertEqual(request.hbm_gb, 0.0)
+
+    def test_model_callable_factory(self) -> None:
+        constructed = nn.Linear(10, 10)
+        factory = lambda: constructed  # noqa: E731
+        request = self._create_request(model=factory)
+        self.assertNotIsInstance(request.model, nn.Module)
+        # pyre-ignore[29]: factory is callable
+        self.assertIs(request.model(), constructed)
+
+    def test_model_module_vs_factory_disambiguation(self) -> None:
+        module = nn.Linear(10, 10)
+        factory = lambda: module  # noqa: E731
+        req_module = self._create_request(model=module)
+        req_factory = self._create_request(model=factory)
+        self.assertIsInstance(req_module.model, nn.Module)
+        self.assertNotIsInstance(req_factory.model, nn.Module)
+
+    def test_multi_sku_with_per_sku_overrides(self) -> None:
+        request = self._create_request(
+            sku_list=["H100", "GB200"],
+            per_sku_overrides={
+                "H100": SkuOverride(hbm_gb=80.0),
+                "GB200": SkuOverride(hbm_gb=192.0),
+            },
+        )
+        self.assertEqual(len(request.sku_list), 2)
+        assert request.per_sku_overrides is not None
+        self.assertEqual(request.per_sku_overrides["H100"].hbm_gb, 80.0)
+        self.assertEqual(request.per_sku_overrides["GB200"].hbm_gb, 192.0)
+
+    def test_fingerprint_deterministic(self) -> None:
+        req = self._create_request()
+        self.assertEqual(req.fingerprint("H100"), req.fingerprint("H100"))
+
+    def test_fingerprint_differs_by_sku(self) -> None:
+        req = self._create_request(sku_list=["H100", "GB200"])
+        self.assertNotEqual(req.fingerprint("H100"), req.fingerprint("GB200"))
+
+    def test_fingerprint_differs_by_config(self) -> None:
+        req1 = self._create_request(batch_size=512)
+        req2 = self._create_request(batch_size=1024)
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_includes_per_sku_override(self) -> None:
+        req_no_override = self._create_request()
+        req_with_override = self._create_request(
+            per_sku_overrides={"H100": SkuOverride(hbm_gb=80.0)},
+        )
+        self.assertNotEqual(
+            req_no_override.fingerprint("H100"),
+            req_with_override.fingerprint("H100"),
+        )
+
+    def test_fingerprint_differs_by_constraints(self) -> None:
+        # Constraints change the resulting plan, so they must change the
+        # fingerprint. They participate via the composed request_hash; before
+        # that composition, constraint-only differences collided.
+        req1 = self._create_request()
+        req2 = self._create_request(
+            constraints={"t1": ParameterConstraints(min_partition=8)},
+        )
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_differs_by_launcher_hardware(self) -> None:
+        req1 = self._create_request(launcher_hardware="ZIONEX")
+        req2 = self._create_request(launcher_hardware="GRANDTETON")
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_length(self) -> None:
+        req = self._create_request()
+        self.assertEqual(len(req.fingerprint("H100")), 16)
+
+    def test_inherits_sharding_plan_request(self) -> None:
+        req = self._create_request()
+        self.assertIsInstance(req, ShardingPlanRequest)
+
+    def test_empty_training_framework_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "training_framework is required for dry-run"
+        ):
+            self._create_request(training_framework="")
+
+    def test_base_fields_accessible(self) -> None:
+        req = self._create_request(
+            launcher_hardware="ZIONEX",
+        )
+        self.assertEqual(req.launcher_hardware, "ZIONEX")
+        self.assertEqual(req.training_framework, "apf")
+
+
+class SkuOverrideTest(unittest.TestCase):
+    def test_negative_value_rejected(self) -> None:
+        cases = [
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -512.0}, "ddr_gb must be non-negative"),
+            ({"intra_host_bw": -100.0}, "intra_host_bw must be non-negative"),
+            ({"inter_host_bw": -50.0}, "inter_host_bw must be non-negative"),
+        ]
+        for kwargs, expected_msg in cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    SkuOverride(**kwargs)
+
+    def test_zero_values_allowed(self) -> None:
+        override = SkuOverride(hbm_gb=0.0, ddr_gb=0.0)
+        self.assertEqual(override.hbm_gb, 0.0)
+        self.assertEqual(override.ddr_gb, 0.0)
+
+
+class CacheConfigTest(unittest.TestCase):
+    def test_enabled_requires_manifold_bucket(self) -> None:
+        with self.assertRaisesRegex(ValueError, "manifold_bucket is required"):
+            CacheConfig(enabled=True, manifold_bucket="")
+
+    def test_enabled_with_bucket_valid(self) -> None:
+        config = CacheConfig(
+            enabled=True, ttl_seconds=3600, manifold_bucket="dry_run_cache"
+        )
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.manifold_bucket, "dry_run_cache")
+
+    def test_disabled_without_bucket_valid(self) -> None:
+        config = CacheConfig(enabled=False)
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.manifold_bucket, "")
+
+    def test_invalid_ttl_rejected(self) -> None:
+        for ttl in (0, -1):
+            with self.subTest(ttl=ttl):
+                with self.assertRaisesRegex(ValueError, "ttl_seconds must be positive"):
+                    CacheConfig(ttl_seconds=ttl)

--- a/torchrec/distributed/planner/dry_run/types.py
+++ b/torchrec/distributed/planner/dry_run/types.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional
+
+from torchrec.distributed.planner.types import ShardingPlanRequest
+
+
+@dataclass(frozen=True)
+class SkuOverride:
+    """Per-SKU hardware overrides for dry-run topology building.
+
+    HARDWARE_CAPABILITIES registry values can be stale vs MAST runtime.
+    Overrides enable what-if exploration and stricter dry runs for APS,
+    and support TC_ANY multi-SKU validation with per-SKU tuning.
+    """
+
+    # Override HBM capacity (GB) when registry values are stale or for what-if testing
+    hbm_gb: Optional[float] = None
+    # Override DDR capacity (GB) — DDR varies inversely with HBM on many SKUs
+    ddr_gb: Optional[float] = None
+    # Override intra-host bandwidth (GB/s) for NVLink/NVSwitch topology modeling
+    intra_host_bw: Optional[float] = None
+    # Override inter-host bandwidth (GB/s) for cross-node communication modeling
+    inter_host_bw: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("hbm_gb", "ddr_gb", "intra_host_bw", "inter_host_bw"):
+            val = getattr(self, name)
+            if val is not None and val < 0:
+                raise ValueError(f"{name} must be non-negative, got {val}")
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Configuration for dry-run plan caching.
+
+    Same topology+model params produce the same sharding plan, so caching
+    avoids re-running the expensive ILP solver on repeated requests.
+    """
+
+    # Master switch — disabled by default to avoid stale plans during development
+    enabled: bool = False
+    # Cache TTL — None means entries never expire; set for production use
+    ttl_seconds: Optional[int] = None
+    # Manifold bucket for persistent cross-session caching
+    manifold_bucket: str = ""
+
+    def __post_init__(self) -> None:
+        if self.ttl_seconds is not None and self.ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive, got {self.ttl_seconds}")
+        if self.enabled and not self.manifold_bucket:
+            raise ValueError("manifold_bucket is required when caching is enabled")
+
+
+@dataclass(frozen=True)
+class DryRunRequest(ShardingPlanRequest):
+    """Immutable request for dry-run sharding plan validation across SKUs.
+
+    Extends ShardingPlanRequest with dry-run-specific fields for multi-SKU
+    validation, per-SKU hardware overrides, plan caching, and safety margins.
+    The planner runs offline (no GPU required) against each SKU in sku_list.
+
+    sku_list vs the inherited launcher_hardware -- why both exist:
+        - launcher_hardware (base ShardingPlanRequest): the single hardware the
+          job will actually launch on. It may be a *concrete* type ("ZIONEX",
+          "GRANDTETON") or an *abstract/fungible* umbrella ("TC_ANY"), which
+          means "could land on any of several SKUs".
+        - sku_list (here): the *concrete* set of SKUs to validate offline. When
+          launcher_hardware is abstract (e.g. TC_ANY), it expands one-to-many
+          into the candidate SKUs to check; when concrete it maps one-to-one.
+        They are different layers, not duplicates: launcher_hardware is the
+        upstream launch intent (one value, possibly abstract), while sku_list is
+        the dry-run sweep set (concrete, possibly many) the orchestrator iterates
+        over to produce one result per SKU. The abstract->concrete expansion is a
+        framework/resolver concern, so both are kept: the base carries the launch
+        intent; the dry-run request carries the resolved candidates.
+    """
+
+    # Concrete SKUs to validate offline, one ShardingPlanResult per SKU. This is
+    # the resolved/expanded form of the inherited launcher_hardware (see the
+    # class docstring): an abstract launcher_hardware like "TC_ANY" expands to
+    # many SKUs here; a concrete one maps to a single-element list. Enables
+    # multi-SKU (TC_ANY) and cartesian (AVT) validation.
+    sku_list: List[str] = field(default_factory=list)
+    # Per-SKU hardware overrides for topology tuning
+    per_sku_overrides: Optional[Dict[str, SkuOverride]] = None
+    # Plan caching configuration
+    cache_config: Optional[CacheConfig] = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.sku_list:
+            raise ValueError("sku_list must not be empty")
+        if not self.training_framework:
+            raise ValueError("training_framework is required for dry-run requests")
+        if self.per_sku_overrides:
+            unknown = set(self.per_sku_overrides) - set(self.sku_list)
+            if unknown:
+                raise ValueError(
+                    "per_sku_overrides references SKUs not in sku_list: "
+                    f"{sorted(unknown)}"
+                )
+
+    def fingerprint(self, sku: str) -> str:
+        """Stable hash identifying a single (request, SKU) planning unit.
+
+        Composes the request-level identity (ShardingPlanRequest.request_hash)
+        with the SKU and its per-SKU override. request_hash already covers every
+        base planner-affecting param -- world_size, local_world_size, batch_size,
+        pod_size, hbm_gb, ddr_gb, training_framework, launcher_hardware,
+        constraints, and the full PlannerConfig (including storage_reservation_policy
+        and storage_reservation_percentage) -- so this method only adds the
+        SKU-specific delta. Because storage reservation participates in
+        request_hash, two requests that differ only in storage-reservation policy
+        (which changes the plan) get different fingerprints -- no cache collision.
+        Building on request_hash (rather than re-listing the base params) keeps the
+        two in sync and ensures constraints/launcher_hardware/storage-reservation
+        participate in the hash; omitting them previously let configs that produce
+        different plans collide.
+
+        Used as the correlation key between request configs and results — enables
+        TUO iterative validation (same SKU, different configs), plan cache keys,
+        and debugging which config produced which result.
+        """
+        if sku not in self.sku_list:
+            raise ValueError(f"sku {sku!r} is not in sku_list {self.sku_list}")
+        override = None
+        if self.per_sku_overrides and sku in self.per_sku_overrides:
+            # asdict so a newly added SkuOverride field automatically enters the
+            # hash; hand-listing fields would silently drop it -> cache collisions.
+            override = asdict(self.per_sku_overrides[sku])
+        parts = {
+            "request_hash": self.request_hash,
+            "sku": sku,
+            "override": override,
+        }
+        canonical = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()[:16]

--- a/torchrec/distributed/planner/protocols.py
+++ b/torchrec/distributed/planner/protocols.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Extension-point protocols (structural interfaces) for the sharding planner.
+
+These live in their own module — separate from the data types (``types.py``) and
+the concrete implementations (``api.py``, ``executor.py``) — on purpose:
+
+- Dependency inversion / leaf module: a Protocol is the seam that consumers
+  depend on and implementers conform to. This module imports only ``types`` (and
+  torch), so both the consumer (``api.py`` takes these as constructor deps) and
+  the implementers (``executor.py`` conforms to ``PlannerExecutor``;
+  ``dry_run/protocols.py`` re-exports them) can import the contract without
+  pulling in the heavier api/executor modules — which keeps the import graph
+  acyclic (defining these in ``api.py`` would risk an api<->executor cycle).
+- Separation of concerns / discoverability: the planner's pluggable seams live
+  in one place, distinct from data (``types.py``) and behavior (``api``/``executor``).
+- Fine-grained build target: the ``:protocols`` Buck target depends only on
+  ``:types`` + torch, so consumers pull just the lightweight contract rather than
+  the concrete implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+import torch.distributed as dist
+from torchrec.distributed.planner.types import PlannerSessionContext, ShardingPlanResult
+
+
+@runtime_checkable
+class PlannerExecutor(Protocol):
+    """Protocol for building and running the planner for a single target (SKU).
+
+    Implementations construct the planner for ``ctx.request``'s variant (via an
+    injected PlannerProvider that also builds the topology and resolves the
+    storage reservation), run it, and return a ShardingPlanResult with the
+    sharding plan or failure details.
+    """
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        """Build and run the planner for one target (``sku``); return its result.
+
+        Only the per-target inputs are passed explicitly: ``sku`` (the target
+        being planned; it labels/keys the result) and ``pg``. Everything else is
+        read from ``ctx.request`` — model, sharders, constraints, batch size, and
+        planner config — rather than duplicated as parameters; the implementation
+        materializes ``ctx.request.model`` if it is a factory. The topology,
+        storage reservation, and planner for this SKU are all built inside ``run``
+        (the implementation owns a PlannerProvider), so no pre-built topology or
+        reservation is passed in.
+
+        ``pg`` is supplied and owned by the ShardingPlannerAPI, not the caller:
+        when provided (distributed prod) the implementation runs the planner
+        collectively (``collective_plan``); when None (offline/dry-run, single
+        rank) it runs locally (``plan``).
+        """
+        ...

--- a/torchrec/distributed/planner/tests/test_api.py
+++ b/torchrec/distributed/planner/tests/test_api.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, Dict, List, Optional
+
+import torch.distributed as dist
+import torch.nn as nn
+from torchrec.distributed.planner.api import (
+    ProductionPlannerOrchestrator,
+    ShardingPlannerAPI,
+)
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+
+class _RecordingExecutor:
+    """PlannerExecutor test double that records how the API invokes it.
+
+    The executor builds topology/storage/planner internally now, so the API only
+    hands it ``sku``/``ctx``/``pg``; the double records those.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, object]] = []
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        self.calls.append({"sku": sku, "pg": pg})
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=123,
+            estimated_max_ddr_bytes=456,
+        )
+
+
+class _RaisingExecutor:
+    """PlannerExecutor double that raises a non-PlannerError for one SKU.
+
+    Models an unexpected failure (model factory, enum coercion, HUM lookup, ...)
+    that is not a ``PlannerError`` and so is not already turned into a
+    success=False result inside the executor.
+    """
+
+    def __init__(self, fail_sku: str) -> None:
+        self.calls: List[str] = []
+        self._fail_sku = fail_sku
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        self.calls.append(sku)
+        if sku == self._fail_sku:
+            raise RuntimeError(f"boom for {sku}")
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=1,
+            estimated_max_ddr_bytes=1,
+        )
+
+
+class _FixedTargetsOrchestrator(ShardingPlannerAPI):
+    """Concrete ShardingPlannerAPI whose _targets is a fixed SKU list.
+
+    Exercises the shared template loop in ShardingPlannerAPI.plan without the
+    (pending) production launcher_hardware -> SKU resolution.
+    """
+
+    def __init__(self, executor: PlannerExecutor, targets: List[str]) -> None:
+        super().__init__(executor)
+        self._fixed_targets = targets
+
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        return self._fixed_targets
+
+
+class _IsolatingOrchestrator(_FixedTargetsOrchestrator):
+    """Orchestrator that opts into per-target error isolation (like dry-run)."""
+
+    def _isolate_target_errors(self) -> bool:
+        return True
+
+
+class ShardingPlannerAPITest(unittest.TestCase):
+    def _request(self, **kwargs: object) -> ShardingPlanRequest:
+        defaults: Dict[str, object] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanRequest(**defaults)  # pyre-ignore[6]
+
+    def _orchestrator(
+        self, executor: PlannerExecutor, targets: List[str]
+    ) -> _FixedTargetsOrchestrator:
+        return _FixedTargetsOrchestrator(executor, targets)
+
+    def test_plan_delegates_and_aggregates_each_target(self) -> None:
+        # The template loop delegates to the executor per target and aggregates
+        # into both the returned map and ctx.results.
+        executor = _RecordingExecutor()
+        request = self._request()
+        ctx = PlannerSessionContext(request=request, results={})
+
+        results = self._orchestrator(executor, ["H100", "GB200"]).plan(request, ctx)
+
+        self.assertEqual(set(results), {"H100", "GB200"})
+        self.assertEqual(results["H100"].sku, "H100")
+        self.assertEqual(results["GB200"].estimated_max_hbm_bytes, 123)
+        self.assertIs(ctx.results["GB200"], results["GB200"])
+        self.assertEqual(len(executor.calls), 2)
+        self.assertEqual({c["sku"] for c in executor.calls}, {"H100", "GB200"})
+
+    def test_plan_runs_local_when_not_distributed(self) -> None:
+        # Offline (no initialized process group) => API passes pg=None so the
+        # executor runs a local plan rather than collective_plan.
+        self.assertFalse(dist.is_available() and dist.is_initialized())
+        executor = _RecordingExecutor()
+        request = self._request()
+        self._orchestrator(executor, ["H100"]).plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertIsNone(executor.calls[0]["pg"])
+
+    def test_isolation_disabled_by_default(self) -> None:
+        # Base default is fail-fast (production must not swallow an unexpected error).
+        self.assertFalse(
+            self._orchestrator(_RecordingExecutor(), [])._isolate_target_errors()
+        )
+
+    def test_fail_fast_propagates_unexpected_error(self) -> None:
+        # Without isolation, an unexpected error aborts the whole sweep.
+        executor = _RaisingExecutor(fail_sku="H100")
+        request = self._request()
+        with self.assertRaises(RuntimeError):
+            self._orchestrator(executor, ["H100", "GB200"]).plan(
+                request, PlannerSessionContext(request=request, results={})
+            )
+
+    def test_isolate_errors_collects_and_continues(self) -> None:
+        # With isolation on, a failing SKU becomes a success=False result and the
+        # remaining SKUs still plan (collect-and-continue sweep).
+        executor = _RaisingExecutor(fail_sku="H100")
+        request = self._request()
+        ctx = PlannerSessionContext(request=request, results={})
+        results = _IsolatingOrchestrator(executor, ["H100", "GB200"]).plan(request, ctx)
+        self.assertEqual(set(results), {"H100", "GB200"})
+        self.assertFalse(results["H100"].success)
+        self.assertIn("RuntimeError", results["H100"].planner_failure_reason or "")
+        self.assertTrue(results["GB200"].success)
+        self.assertEqual(executor.calls, ["H100", "GB200"])
+
+    def test_injected_broadcast_pg_is_used(self) -> None:
+        # A caller-injected broadcast PG (e.g. APF's Gloo cpu_ctl_dist_pg) is
+        # preferred over the default WORLD group and threaded to the executor,
+        # so the rank-0 plan broadcast runs over the injected group.
+        fake_pg = cast(dist.ProcessGroup, object())
+        executor = _RecordingExecutor()
+        request = self._request()
+        ProductionPlannerOrchestrator(executor, "H100", broadcast_pg=fake_pg).plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertIs(executor.calls[0]["pg"], fake_pg)
+
+    def test_production_orchestrator_plans_resolved_sku(self) -> None:
+        # The SKU is resolved by the caller (the fb entrypoint via HUM) and passed
+        # at construction; the prod orchestrator plans for exactly that SKU.
+        executor = _RecordingExecutor()
+        request = self._request()
+        results = ProductionPlannerOrchestrator(executor, "GRANDTETON").plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertEqual(set(results), {"GRANDTETON"})
+        self.assertEqual(len(executor.calls), 1)
+        self.assertEqual(executor.calls[0]["sku"], "GRANDTETON")

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -9,10 +9,11 @@
 
 import unittest
 from copy import deepcopy
-from typing import cast, Dict, Optional
+from typing import Any, Callable, cast, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import torch
+import torch.nn as nn
 from torch import multiprocessing
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
@@ -29,13 +30,19 @@ from torchrec.distributed.planner.types import (
     HardwareConfig,
     hash_planner_context_inputs,
     KernelConfig,
+    LpPlannerConfig,
     ParameterConstraints,
+    PlannerConfig,
+    PlannerVariant,
     Shard,
     ShardingOption,
+    ShardingPlanRequest,
     Storage,
+    StorageReservationPolicy,
     Topology,
     TopologyFactory,
     TrainerConfig,
+    TrainingFramework,
 )
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
@@ -1879,3 +1886,245 @@ class TestTopologyFactory(unittest.TestCase):
             self.assertEqual(topology.ddr_mem_bw, 200.0)
             self.assertEqual(topology.hbm_to_ddr_mem_bw, 50.0)
             self.assertEqual(topology.ssd_mem_bw, 10.0)
+
+
+class ShardingPlanRequestTest(unittest.TestCase):
+    def _create_request(self, **kwargs: Any) -> ShardingPlanRequest:
+        defaults: Dict[str, Any] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanRequest(**defaults)
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"world_size": 0}, "world_size must be positive"),
+            ({"world_size": -1}, "world_size must be positive"),
+            ({"local_world_size": 0}, "local_world_size must be positive"),
+            ({"batch_size": 0}, "batch_size must be positive"),
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -10.0}, "ddr_gb must be non-negative"),
+            ({"pod_size": 0}, "pod_size must be positive"),
+            ({"pod_size": -1}, "pod_size must be positive"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_request(**overrides)
+
+    def test_cross_field_validation(self) -> None:
+        with self.subTest("local exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "local_world_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=4, local_world_size=8)
+
+        with self.subTest("world not divisible by local"):
+            with self.assertRaisesRegex(
+                ValueError, "world_size.*must be divisible by local_world_size"
+            ):
+                self._create_request(world_size=10, local_world_size=3)
+
+        with self.subTest("pod_size exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "pod_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=8, pod_size=16)
+
+    def test_zero_hbm_gb_allowed(self) -> None:
+        request = self._create_request(hbm_gb=0.0)
+        self.assertEqual(request.hbm_gb, 0.0)
+
+    def test_training_framework_enum_accepted(self) -> None:
+        for framework in TrainingFramework:
+            with self.subTest(framework=framework):
+                request = self._create_request(training_framework=framework)
+                self.assertIs(request.training_framework, framework)
+
+    def test_training_framework_string_coerced_to_enum(self) -> None:
+        # A plain string value (e.g. from config) is normalized to the enum so
+        # downstream always reads a TrainingFramework.
+        request = self._create_request(training_framework="apf")
+        self.assertIs(request.training_framework, TrainingFramework.APF)
+
+    def test_invalid_training_framework_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "training_framework must be"):
+            self._create_request(training_framework="tensorflow")
+
+    def test_model_callable_factory(self) -> None:
+        constructed = nn.Linear(10, 10)
+
+        def factory() -> nn.Module:
+            return constructed
+
+        request = self._create_request(model=factory)
+        self.assertNotIsInstance(request.model, nn.Module)
+        # Not an nn.Module, so the Union holds the factory; cast to call it.
+        stored_factory = cast(Callable[[], nn.Module], request.model)
+        self.assertIs(stored_factory(), constructed)
+
+    def test_request_hash_is_deterministic_for_same_params(self) -> None:
+        # Content hash: identical planner-affecting params -> identical hash.
+        self.assertTrue(self._create_request().request_hash)
+        self.assertEqual(
+            self._create_request().request_hash,
+            self._create_request().request_hash,
+        )
+
+    def test_request_hash_differs_for_different_params(self) -> None:
+        base = self._create_request().request_hash
+        self.assertNotEqual(base, self._create_request(batch_size=1024).request_hash)
+        self.assertNotEqual(base, self._create_request(world_size=16).request_hash)
+        self.assertNotEqual(
+            base, self._create_request(training_framework="apf").request_hash
+        )
+
+    def test_default_planner_config(self) -> None:
+        cfg = self._create_request().planner_config
+        self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
+        self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
+
+    def test_request_hash_includes_planner_config(self) -> None:
+        # planner_config is plan-affecting, so it participates in the content hash.
+        base = self._create_request().request_hash
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    planner_variant=PlannerVariant.LINEAR_PROGRAMMING
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    storage_reservation_policy=StorageReservationPolicy.FIXED_PERCENTAGE
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    manifold_path="manifold://tree/sharding/plan.json"
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(planner_config=PlannerConfig(debug=True)).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(timeout_seconds=1200)
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    lp_config=LpPlannerConfig(objective="max_total_perf")
+                )
+            ).request_hash,
+        )
+        # The APF-reconstruction scalar knobs also participate in the hash.
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(pipeline_type="train_sparse_dist")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(partitioner_sort_by="storage")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(performance_model="table_size")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    use_batch_inputs_for_expected_cache_fetches=True
+                )
+            ).request_hash,
+        )
+
+    def test_request_hash_constraints_order_independent(self) -> None:
+        # constraints is a dict; two requests with the same entries inserted in
+        # different orders must share a hash (a dict's repr is insertion-ordered,
+        # so the hash normalizes by sorting keys).
+        first = self._create_request(
+            constraints={
+                "table_a": ParameterConstraints(sharding_types=["table_wise"]),
+                "table_b": ParameterConstraints(sharding_types=["row_wise"]),
+            }
+        )
+        second = self._create_request(
+            constraints={
+                "table_b": ParameterConstraints(sharding_types=["row_wise"]),
+                "table_a": ParameterConstraints(sharding_types=["table_wise"]),
+            }
+        )
+        self.assertEqual(first.request_hash, second.request_hash)
+
+    def test_request_id_is_unique_per_instance(self) -> None:
+        # request_id is per-instance (UUID); request_hash is per-content. Two
+        # requests with identical params therefore share a hash but get
+        # distinct ids.
+        first = self._create_request()
+        second = self._create_request()
+        self.assertTrue(first.request_id)
+        self.assertNotEqual(first.request_id, second.request_id)
+        self.assertEqual(first.request_hash, second.request_hash)
+
+
+class PlannerConfigTest(unittest.TestCase):
+    def test_defaults(self) -> None:
+        cfg = PlannerConfig()
+        self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
+        self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
+        self.assertIsNone(cfg.storage_reservation_percentage)
+        self.assertFalse(cfg.use_hardware_based_compute)
+        self.assertFalse(cfg.use_hardware_based_bandwidth)
+        # APF-reconstruction knobs default to "unset / planner default".
+        self.assertIsNone(cfg.pipeline_type)
+        self.assertFalse(cfg.use_batch_inputs_for_expected_cache_fetches)
+        self.assertFalse(cfg.use_linear_regression_prefetch_estimate)
+        self.assertFalse(cfg.balance_modules)
+        self.assertIsNone(cfg.partitioner_sort_by)
+        self.assertIsNone(cfg.memory_balanced_max_search_count)
+        self.assertIsNone(cfg.memory_balanced_tolerance)
+        self.assertIsNone(cfg.performance_model)
+
+    def test_percentage_range_validated(self) -> None:
+        for bad in (-0.1, 1.1):
+            with self.subTest(pct=bad):
+                with self.assertRaisesRegex(
+                    ValueError, "storage_reservation_percentage must be between"
+                ):
+                    PlannerConfig(storage_reservation_percentage=bad)
+        # Both boundaries are allowed.
+        for good in (0.0, 1.0):
+            with self.subTest(pct=good):
+                self.assertEqual(
+                    PlannerConfig(
+                        storage_reservation_percentage=good
+                    ).storage_reservation_percentage,
+                    good,
+                )
+
+    def test_negative_bwd_multiplier_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "bwd_compute_multiplier must be"):
+            PlannerConfig(bwd_compute_multiplier=-1.0)

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -32,11 +32,15 @@ from torchrec.distributed.planner.types import (
     KernelConfig,
     LpPlannerConfig,
     ParameterConstraints,
+    Perf,
     PlannerConfig,
     PlannerVariant,
     Shard,
+    ShardDetail,
     ShardingOption,
+    ShardingOptionDetail,
     ShardingPlanRequest,
+    ShardingPlanResult,
     Storage,
     StorageReservationPolicy,
     Topology,
@@ -2128,3 +2132,202 @@ class PlannerConfigTest(unittest.TestCase):
     def test_negative_bwd_multiplier_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "bwd_compute_multiplier must be"):
             PlannerConfig(bwd_compute_multiplier=-1.0)
+
+
+class ShardingPlanResultTest(unittest.TestCase):
+    def _create_result(self, **kwargs: Any) -> ShardingPlanResult:
+        defaults: Dict[str, Any] = {
+            "sku": "H100",
+            "success": True,
+            "sharding_plan": None,
+            "planner_failure_reason": None,
+            "estimated_max_hbm_bytes": 1_000_000,
+            "estimated_max_ddr_bytes": 2_000_000,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanResult(**defaults)
+
+    def test_success_result_holds_optional_metrics(self) -> None:
+        result = self._create_result(
+            estimated_qps=1000.0,
+            critical_path_ms=5.0,
+            validation_warnings=("close to HBM limit",),
+        )
+        self.assertTrue(result.success)
+        self.assertIsNone(result.planner_failure_reason)
+        self.assertEqual(result.estimated_qps, 1000.0)
+        self.assertEqual(result.critical_path_ms, 5.0)
+        self.assertEqual(result.validation_warnings, ("close to HBM limit",))
+
+    def test_failure_result_carries_reason(self) -> None:
+        result = self._create_result(success=False, planner_failure_reason="OOM_HBM")
+        self.assertFalse(result.success)
+        self.assertEqual(result.planner_failure_reason, "OOM_HBM")
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"sku": ""}, "sku must not be empty"),
+            ({"estimated_max_hbm_bytes": -1}, "estimated_max_hbm_bytes must be"),
+            ({"estimated_max_ddr_bytes": -1}, "estimated_max_ddr_bytes must be"),
+            ({"estimated_qps": -1.0}, "estimated_qps must be non-negative"),
+            ({"critical_path_ms": -1.0}, "critical_path_ms must be non-negative"),
+            ({"solve_time_ms": -1.0}, "solve_time_ms must be non-negative"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_result(**overrides)
+
+    def test_success_failure_reason_consistency(self) -> None:
+        with self.subTest("success with reason"):
+            with self.assertRaisesRegex(
+                ValueError, "planner_failure_reason must be None when success is True"
+            ):
+                self._create_result(success=True, planner_failure_reason="OOM")
+        with self.subTest("failure without reason"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "planner_failure_reason is required when success is False",
+            ):
+                self._create_result(success=False, planner_failure_reason=None)
+
+    def test_zero_memory_allowed(self) -> None:
+        result = self._create_result(
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+        )
+        self.assertEqual(result.estimated_max_hbm_bytes, 0)
+        self.assertEqual(result.estimated_max_ddr_bytes, 0)
+
+
+class ShardingOptionDetailTest(unittest.TestCase):
+    def test_from_sharding_option_projects_per_shard_detail(self) -> None:
+        # from_sharding_option captures the per-shard storage/perf the
+        # deployment-facing ShardingPlan drops, and aggregates the totals.
+        shards = [
+            Shard(
+                size=[5000, 80],
+                offset=[0, 0],
+                storage=Storage(hbm=600, ddr=10, ssd=5),
+                perf=Perf(
+                    fwd_compute=1.0, fwd_comms=2.0, bwd_compute=3.0, bwd_comms=4.0
+                ),
+                rank=0,
+            ),
+            Shard(
+                size=[5000, 80],
+                offset=[5000, 0],
+                storage=Storage(hbm=400, ddr=20, ssd=15),
+                perf=Perf(
+                    fwd_compute=0.5, fwd_comms=0.5, bwd_compute=0.5, bwd_comms=0.5
+                ),
+                rank=1,
+            ),
+        ]
+        sharding_option = ShardingOption(
+            name="table_0",
+            tensor=torch.empty(
+                (10000, 80), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.ROW_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=shards,
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertEqual(detail.fqn, "ebc.table_0")
+        self.assertEqual(detail.sharding_type, ShardingType.ROW_WISE.value)
+        self.assertEqual(detail.compute_kernel, EmbeddingComputeKernel.FUSED.value)
+        self.assertEqual(len(detail.shards), 2)
+        self.assertEqual(detail.shards[0].rank, 0)
+        self.assertEqual(detail.shards[0].size, (5000, 80))
+        self.assertEqual(detail.shards[0].offset, (0, 0))
+        self.assertEqual(detail.shards[0].hbm_bytes, 600)
+        self.assertEqual(detail.shards[0].ddr_bytes, 10)
+        self.assertEqual(detail.shards[0].ssd_bytes, 5)
+        self.assertEqual(detail.shards[0].perf_total, 10.0)
+        self.assertEqual(detail.total_hbm_bytes, 1000)
+        self.assertEqual(detail.total_ddr_bytes, 30)
+        self.assertEqual(detail.total_ssd_bytes, 20)
+        self.assertEqual(detail.total_perf, 12.0)
+
+    def test_from_sharding_option_without_estimates(self) -> None:
+        # Shards without storage/perf project to zero bytes and None perf.
+        sharding_option = ShardingOption(
+            name="table_1",
+            tensor=torch.empty(
+                (100, 16), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.TABLE_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[Shard(size=[100, 16], offset=[0, 0])],
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertEqual(detail.total_hbm_bytes, 0)
+        self.assertEqual(detail.total_ddr_bytes, 0)
+        self.assertEqual(detail.total_ssd_bytes, 0)
+        self.assertIsNone(detail.total_perf)
+        self.assertIsNone(detail.shards[0].perf_total)
+
+    def test_negative_values_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ssd_bytes must be non-negative"):
+            ShardDetail(
+                rank=0,
+                size=(1, 1),
+                offset=(0, 0),
+                hbm_bytes=0,
+                ddr_bytes=0,
+                ssd_bytes=-1,
+            )
+        with self.assertRaisesRegex(ValueError, "perf_total must be non-negative"):
+            ShardDetail(
+                rank=0,
+                size=(1, 1),
+                offset=(0, 0),
+                hbm_bytes=0,
+                ddr_bytes=0,
+                ssd_bytes=0,
+                perf_total=-1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "total_hbm_bytes must be non-negative"):
+            ShardingOptionDetail(
+                fqn="ebc.t0",
+                sharding_type="table_wise",
+                compute_kernel="fused",
+                total_hbm_bytes=-1,
+            )
+
+    def test_total_perf_none_when_any_shard_missing_perf(self) -> None:
+        # A partial perf sum would understate cost, so total_perf is None unless
+        # every shard has an estimate.
+        sharding_option = ShardingOption(
+            name="table_2",
+            tensor=torch.empty(
+                (200, 16), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.ROW_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[
+                Shard(
+                    size=[100, 16],
+                    offset=[0, 0],
+                    perf=Perf(
+                        fwd_compute=1.0, fwd_comms=1.0, bwd_compute=1.0, bwd_comms=1.0
+                    ),
+                ),
+                Shard(size=[100, 16], offset=[100, 0]),  # no perf estimate
+            ],
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertIsNone(detail.total_perf)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -10,6 +10,7 @@
 import abc
 import hashlib
 import logging
+import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1848,6 +1849,403 @@ class CriticalPathEstimate:
 
     def total(self) -> float:
         return self.comms_estimate + self.comp_estimate
+
+
+class TrainingFramework(str, Enum):
+    """Training framework that consumes the sharding plan.
+
+    Selects framework-specific topology behavior (DDR division logic,
+    JustKnob-gated detection, framework-specific adjustments) in downstream
+    consumers. ``UNSET`` is the sentinel for "not set", which yields
+    framework-agnostic defaults.
+
+    Defined here (rather than imported) because this open-source module cannot
+    import the equivalent framework enum that lives in internal code; the string
+    values are the contract that bridges the two.
+
+    Subclasses ``str`` so members behave as their string value: they JSON
+    serialize to the bare string, compare equal to it, and ``UNSET`` ("") is
+    falsy — keeping downstream string-based consumers (fingerprints, configs)
+    working without special-casing the enum.
+    """
+
+    UNSET = ""
+    APF = "apf"
+    PYPER = "pyper"
+    MVAI = "mvai"
+
+
+class PlannerVariant(str, Enum):
+    """Planner backend that produces the plan.
+
+    Why an enum rather than a bare string: the frameworks (Pyper/MVAI/APF) pass
+    the backend as a free-form config value today, but the set of backends is
+    small, closed, and fully owned here in OSS. Normalizing that config string
+    into an enum at the request boundary gives (1) a single source of truth for
+    the valid backends, (2) typo-safety and autocomplete at call sites, and (3)
+    exhaustive, checkable dispatch in the executor (which switches on this to
+    pick the planner). Contrast launcher_hardware, kept a ``str`` because its
+    value set is large, still growing, and resolved fb-side — the same rule that
+    keeps TrainingFramework an enum but launcher_hardware a string.
+
+    Where the string -> enum conversion (and validation) happens: at the framework
+    request boundary, via the enum constructor — ``PlannerVariant(cfg_str)`` both
+    converts and raises ``ValueError`` on an unknown value in one call. The field
+    is typed as the enum and ``PlannerConfig`` does no coercion, so every reader
+    sees a ``PlannerVariant`` without a redundant normalization step.
+
+    Subclasses ``str`` so a member serializes/compares as its bare value, keeping
+    it stable in the request content hash and in string-based configs.
+
+    ``UNSET`` ("") is the "not specified" sentinel and the default: the executor
+    treats it as the OSS backend, so callers that do not care get sensible
+    behavior without naming a backend.
+    """
+
+    UNSET = ""
+    OSS = "oss"
+    LINEAR_PROGRAMMING = "linear_programming"
+    MANIFOLD = "manifold"
+
+
+class StorageReservationPolicy(str, Enum):
+    """Policy for reserving non-sharded (dense/overhead) memory before planning.
+
+    An enum for the same reasons as ``PlannerVariant``: a small, closed,
+    OSS-owned set that the frameworks pass as config strings, normalized here for
+    one source of truth, typo-safety, and an exhaustive switch in the
+    storage-reservation resolver (which maps each value to a StorageReservation
+    implementation). As with ``PlannerVariant``, the string -> enum conversion and
+    validation happen at the framework boundary via the enum constructor
+    (``StorageReservationPolicy(cfg_str)``); the field is typed as the enum and
+    ``PlannerConfig`` does no coercion.
+
+    Subclasses ``str`` for the same serialization reasons as ``PlannerVariant``.
+
+    ``UNSET`` ("") is the "not specified" sentinel and the default: the
+    storage-reservation resolver treats it as its default policy (heuristical).
+
+    Only policies with a backing StorageReservation are listed. HEURISTICAL,
+    FIXED_PERCENTAGE, and INFERENCE map to Heuristical/FixedPercentage/Inference
+    StorageReservation respectively; SKU_AWARE is planned (SKUAwareStorageReservation
+    is designed but not yet implemented). "memory_balanced" is intentionally absent
+    — it is a partitioner strategy (MemoryBalancedPartitioner), not a reservation.
+    """
+
+    UNSET = ""
+    HEURISTICAL = "heuristical"
+    FIXED_PERCENTAGE = "fixed_percentage"
+    INFERENCE = "inference"
+    # Planned: SKUAwareStorageReservation (design done, not yet implemented).
+    SKU_AWARE = "sku_aware"
+
+
+@dataclass(frozen=True)
+class LpPlannerConfig:
+    """OSS-safe scalar knobs for the LINEAR_PROGRAMMING planner variant.
+
+    Carried as plain data so it stays serializable/hashable (part of the request
+    content hash) — the fb LinearProgrammingPlanner accepts these scalars (e.g.
+    MVAI already passes ``objective``/``shard_solver_type`` as plain strings). Each
+    field is Optional; None means "use the LP planner's own default", so the fb
+    builder only forwards the ones that are set. The fb-typed forms
+    (OptimObjective/ShardSolverType/EMOConfig) are never referenced from OSS.
+    """
+
+    # Optimization objective, e.g. "max_total_perf" (LP OptimObjective by value)
+    objective: Optional[str] = None
+    # Shard solver, e.g. "greedy" (LP ShardSolverType by value)
+    shard_solver_type: Optional[str] = None
+    # Whether to tune column dimensions
+    tune_col_dims: Optional[bool] = None
+    # Hybrid solver percentage (0-100)
+    hybrid_percentage: Optional[int] = None
+    # Allowed solution-quality worsening percentage (>= 0.0)
+    allowed_worsening_percentage: Optional[float] = None
+    # Whether to apply per-stage timeouts
+    stagewise_timeout: Optional[bool] = None
+    # Whether plan caching is enabled
+    caching_enabled: Optional[bool] = None
+    # Number of local-search cycles
+    num_cycles: Optional[int] = None
+    # Whether to auto-derive column dimensions
+    auto_col_dims: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class PlannerConfig:
+    """Plan-affecting knobs the trainer expresses per request.
+
+    These are *data* (serializable, hashable) that select how the planner runs;
+    the concrete PlannerExecutor maps them to enumerator/estimator/proposer/
+    partitioner/planner instances. Object-valued, framework-specific behavior
+    (custom proposer instances, stats sinks) is injected into the API instance as
+    a per-framework profile, not carried here — so this stays part of the
+    request's content hash and cache key.
+    """
+
+    # Planner backend to run; UNSET (default) resolves to the OSS backend
+    planner_variant: PlannerVariant = PlannerVariant.UNSET
+    # How non-sharded memory is reserved; UNSET (default) resolves to heuristical
+    storage_reservation_policy: StorageReservationPolicy = (
+        StorageReservationPolicy.UNSET
+    )
+    # Fraction (0.0-1.0) to reserve for the chosen policy; None = policy default
+    storage_reservation_percentage: Optional[float] = None
+    # Proposer selector (e.g. "greedy", "grid_search", "dynamic_col_dim"); None =
+    # executor default. Free-form: the proposer set is extensible and custom
+    # proposer instances are injected via the API profile, so it isn't validated.
+    proposer_type: Optional[str] = None
+    # Partitioner selector (e.g. "greedy_perf", "memory_balanced"); None =
+    # executor default. Free-form for the same reason as proposer_type.
+    partitioner_type: Optional[str] = None
+    # Use hardware-capability-based compute estimates instead of the default model
+    use_hardware_based_compute: bool = False
+    # Use hardware-capability-based bandwidths instead of default topology values
+    use_hardware_based_bandwidth: bool = False
+    # Backward-pass compute multiplier for the perf estimate; None = planner default
+    bwd_compute_multiplier: Optional[float] = None
+    # Manifold path to a pre-computed sharding plan, consumed only by the MANIFOLD
+    # planner_variant (ManifoldPlanner loads the plan from here instead of solving).
+    # Required when planner_variant is MANIFOLD; ignored by other variants.
+    manifold_path: Optional[str] = None
+    # Enable planner debug mode (extra logging/validation). Forwarded to the planner.
+    debug: bool = False
+    # Solver timeout in seconds; None = planner default. Forwarded to the planner.
+    timeout_seconds: Optional[int] = None
+    # Resolved PipelineType value for the storage estimator (e.g. "train_sparse_dist");
+    # None = estimator default. Mirrors APF's pipeline-aware storage estimation.
+    pipeline_type: Optional[str] = None
+    # Hardware-based perf-estimator flags (apply when use_hardware_based_compute).
+    use_batch_inputs_for_expected_cache_fetches: bool = False
+    use_linear_regression_prefetch_estimate: bool = False
+    # Partitioner knobs: balance shards across modules; GreedyPerf sort key
+    # ("perf"/"storage"); MemoryBalanced search bounds (None = partitioner default).
+    balance_modules: bool = False
+    partitioner_sort_by: Optional[str] = None
+    memory_balanced_max_search_count: Optional[int] = None
+    memory_balanced_tolerance: Optional[float] = None
+    # Noop performance-model selector ("storage"/"table_size"); None = no perf model.
+    performance_model: Optional[str] = None
+    # LINEAR_PROGRAMMING scalar knobs; None = LP planner defaults. Consumed only by
+    # the LP variant's fb builder (ignored by other variants).
+    lp_config: Optional[LpPlannerConfig] = None
+
+    def __post_init__(self) -> None:
+        # planner_variant / storage_reservation_policy are typed as enums, so
+        # callers pass a member (framework builders convert a config string with
+        # PlannerVariant(cfg_str), which validates). No coercion is done here.
+        if (
+            self.storage_reservation_percentage is not None
+            and not 0.0 <= self.storage_reservation_percentage <= 1.0
+        ):
+            raise ValueError(
+                "storage_reservation_percentage must be between 0.0 and 1.0, got "
+                f"{self.storage_reservation_percentage}"
+            )
+        if self.bwd_compute_multiplier is not None and self.bwd_compute_multiplier < 0:
+            raise ValueError(
+                "bwd_compute_multiplier must be non-negative, got "
+                f"{self.bwd_compute_multiplier}"
+            )
+
+
+@dataclass(frozen=True)
+class ShardingPlanRequest:
+    """Request for sharding plan generation.
+
+    Encapsulates the model, sharders, cluster topology parameters, and
+    optional overrides needed to produce a sharding plan. Base type for
+    both runtime and dry-run planning flows.
+
+    Immutability note: ``frozen=True`` only prevents rebinding the fields
+    themselves; it does not deep-freeze their contents. The ``sharders``
+    list and the ``constraints`` dict remain mutable in place (e.g.
+    ``request.sharders.append(...)``). They are kept as ``List``/``Dict``
+    because downstream planner APIs consume those concrete types; callers
+    must treat them as read-only by convention rather than relying on an
+    enforced guarantee.
+    """
+
+    # User-provided nn.Module or a factory for lazy construction;
+    # consumers should use isinstance(model, nn.Module) to distinguish
+    model: Union[nn.Module, Callable[[], nn.Module]]
+    # Code-derived from model architecture + training config via get_default_sharders()
+    sharders: List[ModuleSharder[nn.Module]]
+    # Total number of devices in the cluster
+    world_size: int
+    # Devices per host — determines intra-host vs inter-host communication split
+    local_world_size: int
+    # Batch size affects per-device memory estimates from the perf model
+    batch_size: int
+
+    # Pod size for multi-pod topologies (None = single pod)
+    pod_size: Optional[int] = None
+    # Derived from planner.storage_reservation_policy config
+    storage_reservation: Optional[StorageReservation] = None
+    # Code-derived from embedding tables + fused params + UVM cache stats
+    constraints: Optional[Dict[str, ParameterConstraints]] = None
+    # Training framework that consumes the plan. TrainingFramework.UNSET (the
+    # default) means "not set" and yields framework-agnostic defaults. Typed as
+    # an enum so downstream gets a checked value; a plain string (e.g. from
+    # config) is coerced to the enum in __post_init__ and an unknown value
+    # raises ValueError.
+    training_framework: TrainingFramework = TrainingFramework.UNSET
+    # Override HBM capacity (GB); None = auto-detect from CUDA or hardware registry
+    hbm_gb: Optional[float] = None
+    # Override DDR capacity (GB); None = auto-detect
+    ddr_gb: Optional[float] = None
+    # Launcher hardware identifier for topology creation (e.g. "ZIONEX",
+    # "TC_ANY"); None = auto-detect from the launch environment. Kept free-form:
+    # the recognized values mirror the hardware-type identifiers resolved by
+    # downstream consumers, and that set grows as new accelerators are onboarded,
+    # so it is intentionally not validated here.
+    launcher_hardware: Optional[str] = None
+    # Runtime compute device for the plan's topology ("cuda"/"cpu"/"mtia"); None =
+    # let the provider default (production mirrors the framework's real device so
+    # the plan's shard placements match the model's device; dry-run models "cuda").
+    # Plan-affecting (a cpu vs cuda topology changes placement), so it is hashed.
+    compute_device: Optional[str] = None
+    # Plan-affecting knobs (planner backend, reservation policy, proposer/
+    # partitioner selection, hardware-based flags). Data-only so it participates
+    # in request_hash; object-valued behavior is injected into the API instance.
+    planner_config: PlannerConfig = field(default_factory=PlannerConfig)
+    # Unique per-instance id for this request, used to correlate it with the
+    # ShardingPlanResult(s) it produces (see ShardingPlanResult.request_id).
+    # Complements request_hash: request_hash is a *content* hash shared by
+    # identical requests (cache/dedup key), whereas request_id is unique per
+    # request object — use it to tell two otherwise-identical requests apart.
+    # Auto-generated; override to thread an externally-supplied id.
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def __post_init__(self) -> None:
+        self._normalize_training_framework()
+        self._validate()
+
+    def _normalize_training_framework(self) -> None:
+        # Accept either a TrainingFramework or its string value (e.g. read from
+        # config) and normalize to the enum, so downstream always reads a
+        # TrainingFramework. Unknown strings raise ValueError.
+        if isinstance(self.training_framework, TrainingFramework):
+            return
+        try:
+            object.__setattr__(
+                self,
+                "training_framework",
+                TrainingFramework(self.training_framework),
+            )
+        except ValueError as e:
+            valid = [f.value for f in TrainingFramework]
+            raise ValueError(
+                f"training_framework must be a TrainingFramework or one of "
+                f"{valid}, got {self.training_framework!r}"
+            ) from e
+
+    def _validate(self) -> None:
+        # Positive-required scalars.
+        for name in ("world_size", "local_world_size", "batch_size"):
+            value = getattr(self, name)
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.pod_size is not None and self.pod_size <= 0:
+            raise ValueError(f"pod_size must be positive, got {self.pod_size}")
+        # Non-negative-optional scalars.
+        for name in ("hbm_gb", "ddr_gb"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+        # Cross-field constraints.
+        if self.local_world_size > self.world_size:
+            raise ValueError(
+                f"local_world_size ({self.local_world_size}) must not exceed "
+                f"world_size ({self.world_size})"
+            )
+        if self.world_size % self.local_world_size != 0:
+            raise ValueError(
+                f"world_size ({self.world_size}) must be divisible by "
+                f"local_world_size ({self.local_world_size})"
+            )
+        if self.pod_size is not None and self.pod_size > self.world_size:
+            raise ValueError(
+                f"pod_size ({self.pod_size}) must not exceed "
+                f"world_size ({self.world_size})"
+            )
+
+    @property
+    def request_hash(self) -> str:
+        """Stable content hash identifying this request.
+
+        Deterministic over the planner-affecting parameters, so two requests
+        with the same parameters share a hash. Used to correlate the request
+        with its ShardingPlanResult(s) and PlannerSessionContext, and as a
+        cache key.
+
+        Excludes, by design: `model` and `sharders` (not stably hashable);
+        `storage_reservation` (an injected behavior object, not plan-data); and
+        `request_id` (unique per instance — hashing it would defeat the
+        identical-params-share-a-hash guarantee). Callers needing model-level
+        uniqueness should scope by the context's model — mirroring
+        DryRunRequest.fingerprint().
+        """
+        return format(
+            hash_sha256_to_int(
+                [
+                    self.world_size,
+                    self.local_world_size,
+                    self.batch_size,
+                    self.pod_size,
+                    self.hbm_gb,
+                    self.ddr_gb,
+                    self.training_framework.value,
+                    self.launcher_hardware,
+                    self.compute_device,
+                    # Hash constraints order-independently: a dict's repr follows
+                    # insertion order, so sort by key for a stable hash across
+                    # semantically-equal requests built in different orders. Sort
+                    # by key only (ParameterConstraints is not rich-comparable).
+                    (
+                        [(k, self.constraints[k]) for k in sorted(self.constraints)]
+                        if self.constraints is not None
+                        else None
+                    ),
+                    self.planner_config.planner_variant.value,
+                    self.planner_config.storage_reservation_policy.value,
+                    self.planner_config.storage_reservation_percentage,
+                    self.planner_config.proposer_type,
+                    self.planner_config.partitioner_type,
+                    self.planner_config.use_hardware_based_compute,
+                    self.planner_config.use_hardware_based_bandwidth,
+                    self.planner_config.bwd_compute_multiplier,
+                    self.planner_config.manifold_path,
+                    self.planner_config.debug,
+                    self.planner_config.timeout_seconds,
+                    self.planner_config.pipeline_type,
+                    self.planner_config.use_batch_inputs_for_expected_cache_fetches,
+                    self.planner_config.use_linear_regression_prefetch_estimate,
+                    self.planner_config.balance_modules,
+                    self.planner_config.partitioner_sort_by,
+                    self.planner_config.memory_balanced_max_search_count,
+                    self.planner_config.memory_balanced_tolerance,
+                    self.planner_config.performance_model,
+                    (
+                        (
+                            lp.objective,
+                            lp.shard_solver_type,
+                            lp.tune_col_dims,
+                            lp.hybrid_percentage,
+                            lp.allowed_worsening_percentage,
+                            lp.stagewise_timeout,
+                            lp.caching_enabled,
+                            lp.num_cycles,
+                            lp.auto_col_dims,
+                        )
+                        if (lp := self.planner_config.lp_config) is not None
+                        else None
+                    ),
+                ]
+            ),
+            "x",
+        )[:16]
 
 
 # ---- Types Utils ---- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2248,6 +2248,208 @@ class ShardingPlanRequest:
         )[:16]
 
 
+@dataclass(frozen=True)
+class ShardDetail:
+    """Per-shard placement and cost breakdown for one shard of a table.
+
+    Serializable projection of a planner Shard: keeps the size/offset/rank and
+    the storage/perf estimates that the deployment-facing ShardingPlan drops,
+    without holding the live tensor/module references.
+    """
+
+    # Rank this shard is placed on; None if unassigned
+    rank: Optional[int]
+    # Shard tensor dimensions
+    size: Tuple[int, ...]
+    # Shard offset within the full table
+    offset: Tuple[int, ...]
+    # Estimated HBM for this shard (bytes)
+    hbm_bytes: int
+    # Estimated DDR for this shard (bytes)
+    ddr_bytes: int
+    # Estimated SSD for this shard (bytes)
+    ssd_bytes: int
+    # Total perf score for this shard; None if the perf model did not run
+    perf_total: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("hbm_bytes", "ddr_bytes", "ssd_bytes"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+        if self.perf_total is not None and self.perf_total < 0:
+            raise ValueError(f"perf_total must be non-negative, got {self.perf_total}")
+
+
+@dataclass(frozen=True)
+class ShardingOptionDetail:
+    """Per-table row of the chosen sharding plan with full cost detail.
+
+    Serializable projection of the ShardingOption selected for one embedding
+    table. Unlike the deployment-facing ShardingPlan (which keeps only
+    sharding_type/compute_kernel/ranks/shard geometry), this retains the
+    per-shard storage/perf estimates for OOM debugging and plan explainability,
+    while staying free of the live tensor/module references that make a raw
+    ShardingOption unserializable.
+    """
+
+    # Fully qualified name of the embedding table (module fqn + table name)
+    fqn: str
+    # Sharding type selected (e.g. "table_wise", "row_wise")
+    sharding_type: str
+    # Compute kernel selected (e.g. "fused", "dense")
+    compute_kernel: str
+    # Per-shard placement and cost breakdown
+    shards: Tuple[ShardDetail, ...] = ()
+    # HBM summed across shards (bytes)
+    total_hbm_bytes: int = 0
+    # DDR summed across shards (bytes)
+    total_ddr_bytes: int = 0
+    # SSD summed across shards (bytes)
+    total_ssd_bytes: int = 0
+    # Perf summed across shards; None unless every shard has a perf estimate, so
+    # the total is never a misleading partial sum
+    total_perf: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("total_hbm_bytes", "total_ddr_bytes", "total_ssd_bytes"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+    @classmethod
+    def from_sharding_option(
+        cls, sharding_option: "ShardingOption"
+    ) -> "ShardingOptionDetail":
+        """Build a serializable detail row from a selected ShardingOption."""
+        shards = tuple(
+            ShardDetail(
+                rank=shard.rank,
+                size=tuple(shard.size),
+                offset=tuple(shard.offset),
+                hbm_bytes=shard.storage.hbm if shard.storage is not None else 0,
+                ddr_bytes=shard.storage.ddr if shard.storage is not None else 0,
+                ssd_bytes=shard.storage.ssd if shard.storage is not None else 0,
+                perf_total=shard.perf.total if shard.perf is not None else None,
+            )
+            for shard in sharding_option.shards
+        )
+        # Only aggregate perf when every shard has an estimate; otherwise a
+        # partial sum would understate the true cost while looking complete.
+        if shards and all(s.perf_total is not None for s in shards):
+            total_perf: Optional[float] = sum(
+                s.perf_total for s in shards if s.perf_total is not None
+            )
+        else:
+            total_perf = None
+        return cls(
+            fqn=sharding_option.fqn,
+            sharding_type=sharding_option.sharding_type,
+            compute_kernel=sharding_option.compute_kernel,
+            shards=shards,
+            total_hbm_bytes=sum(s.hbm_bytes for s in shards),
+            total_ddr_bytes=sum(s.ddr_bytes for s in shards),
+            total_ssd_bytes=sum(s.ssd_bytes for s in shards),
+            total_perf=total_perf,
+        )
+
+
+@dataclass(frozen=True)
+class ShardingPlanResult:
+    """Immutable result of sharding plan generation for a single topology.
+
+    Captures the outcome of running the planner, including the sharding
+    plan (when available), failure reason on error, and memory estimates.
+    Base type for both runtime and dry-run result types.
+    """
+
+    # GPU-SKU identifier this result is for (e.g. "H100", "GB200"); also the key
+    # in the API's per-target result map. Distinct from Request.launcher_hardware
+    # (launcher-type vocabulary like "ZIONEX"/"TC_ANY"), which stays on the request.
+    sku: str
+    # Whether the planner found a valid sharding plan
+    success: bool
+    # The computed plan — how tables are distributed across devices. None on
+    # failure, and may also be None on a successful result that carries only
+    # metadata (e.g. cached-miss or estimate-only results).
+    sharding_plan: Optional[ShardingPlan]
+    # Why the plan failed — surfaces root cause (e.g. "OOM_HBM")
+    planner_failure_reason: Optional[str]
+    # Peak per-rank HBM of the sharded-embedding footprint (bytes): the max over
+    # ranks of the summed embedding-shard HBM placed on that rank. This is the
+    # embedding footprint only — it excludes the dense/optimizer/runtime overhead
+    # that StorageReservation carves out of the budget before planning (the
+    # reservation shrinks the HBM available for embeddings but is not added back
+    # into this figure).
+    estimated_max_hbm_bytes: int
+    # Peak per-rank DDR of the sharded-embedding footprint (bytes); same
+    # embedding-only semantics as estimated_max_hbm_bytes.
+    estimated_max_ddr_bytes: int
+
+    # Estimated throughput from perf model; None if perf model unavailable
+    estimated_qps: Optional[float] = None
+    # Latency of slowest path through sharded model (ms); None if unavailable
+    critical_path_ms: Optional[float] = None
+    # Non-fatal warnings even when plan succeeds
+    validation_warnings: Tuple[str, ...] = ()
+    # URL of the sharding plan persisted to Manifold (for sharing/debugging);
+    # None if the plan was not uploaded
+    sharding_plan_manifold_url: Optional[str] = None
+    # Correlates this result with the ShardingPlanRequest.request_hash that
+    # produced it (by content); "" if not set
+    request_hash: str = ""
+    # Correlates this result with the ShardingPlanRequest.request_id that
+    # produced it (by instance); "" if not set. Use this to tie a result to a
+    # specific request object; use request_hash to correlate by content.
+    request_id: str = ""
+    # Time spent in the planner's solver for this result (ms); None if unavailable
+    solve_time_ms: Optional[float] = None
+    # Per-table breakdown of the chosen sharding plan with per-shard storage/perf
+    # detail (the "sharding option table"); empty if the planner did not surface
+    # per-table detail. A serializable projection of the selected ShardingOptions
+    # (see ShardingOptionDetail.from_sharding_option) that explains the aggregate
+    # estimated_max_*_bytes at table/shard granularity.
+    sharding_options: Tuple[ShardingOptionDetail, ...] = ()
+    # Whether this result carries the authoritative plan breakdown/estimates.
+    # On the collective path only the planning rank (rank 0) populates the
+    # per-shard breakdown; other ranks return success=True with the broadcast
+    # plan but empty sharding_options and zero estimates. This flag makes that
+    # asymmetry explicit so an aggregator can filter to the trustworthy result
+    # instead of reading corrupt estimates off a non-planning rank. Defaults to
+    # True: the local path (pg=None) and dry-run always plan on the caller's rank.
+    is_planning_rank: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.sku:
+            raise ValueError("sku must not be empty")
+        if self.estimated_max_hbm_bytes < 0:
+            raise ValueError(
+                f"estimated_max_hbm_bytes must be non-negative, "
+                f"got {self.estimated_max_hbm_bytes}"
+            )
+        if self.estimated_max_ddr_bytes < 0:
+            raise ValueError(
+                f"estimated_max_ddr_bytes must be non-negative, "
+                f"got {self.estimated_max_ddr_bytes}"
+            )
+        if self.estimated_qps is not None and self.estimated_qps < 0:
+            raise ValueError(
+                f"estimated_qps must be non-negative, got {self.estimated_qps}"
+            )
+        if self.critical_path_ms is not None and self.critical_path_ms < 0:
+            raise ValueError(
+                f"critical_path_ms must be non-negative, got {self.critical_path_ms}"
+            )
+        if self.solve_time_ms is not None and self.solve_time_ms < 0:
+            raise ValueError(
+                f"solve_time_ms must be non-negative, got {self.solve_time_ms}"
+            )
+        if self.success and self.planner_failure_reason is not None:
+            raise ValueError("planner_failure_reason must be None when success is True")
+        if not self.success and self.planner_failure_reason is None:
+            raise ValueError("planner_failure_reason is required when success is False")
+
+
 # ---- Types Utils ---- #
 def hash_sha256_to_int(hashable_list: List[Any]) -> int:
     """

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2450,6 +2450,62 @@ class ShardingPlanResult:
             raise ValueError("planner_failure_reason is required when success is False")
 
 
+@dataclass
+class PlannerSessionContext:
+    """Mutable context accumulating state during a planner session.
+
+    Links the ShardingPlanRequest being planned and the per-SKU
+    ShardingPlanResult(s) it produces, plus session-only scratch state
+    (caches, timing, metadata). Fields that already live on the request or
+    its results are intentionally not duplicated here — read them through
+    ``request``/``results`` (e.g. ``request.request_id``, ``request.model``,
+    ``results[sku].validation_warnings``). Unlike the frozen request/result
+    types, this dataclass is mutable to allow incremental updates during
+    execution.
+    """
+
+    # The request this session is planning for (required). Populated once by the
+    # planner API when it constructs the context, before planning begins: it is
+    # the input being planned and the source of truth for model, sharders,
+    # request_id/request_hash, constraints, launcher_hardware, etc. — read those
+    # through `request` rather than duplicating them on the context.
+    request: ShardingPlanRequest
+    # Per-SKU results produced this session, keyed by SKU (required; the planner
+    # API passes an empty dict at session start). Populated incrementally: one
+    # entry is added as each ShardingPlanResult is produced while iterating the
+    # request's SKUs. Each result carries its sharding plan, memory estimates,
+    # validation_warnings, manifold url, and request_id/request_hash back-reference.
+    results: Dict[str, ShardingPlanResult]
+    # Unique session identifier; defaults to a UUID4
+    session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # Topology cache keyed by (sku, world_size, local_world_size) — one per SKU
+    topology_cache: Dict[Tuple[str, int, int], Topology] = field(default_factory=dict)
+    # Wall-clock timing for each session phase (e.g. "topology_creation", "solve").
+    # Session-level aggregate, not per-SKU.
+    timing: Dict[str, float] = field(default_factory=dict)
+    # Storage reservation strategy used per SKU
+    storage_reservations_used: Dict[str, StorageReservation] = field(
+        default_factory=dict
+    )
+    # Hardware overrides applied per SKU
+    hw_overrides_applied: Dict[str, HardwareConfig] = field(default_factory=dict)
+    # Plans retrieved from cache, keyed by request fingerprint (per request+SKU)
+    cached_plans: Dict[str, ShardingPlan] = field(default_factory=dict)
+    # Caller-provided session metadata (e.g. oncall, use_case, experiment_id)
+    client_metadata: Dict[str, str] = field(default_factory=dict)
+    # Whether each SKU's result came from cache — per SKU (SKU -> hit)
+    cache_hit: Dict[str, bool] = field(default_factory=dict)
+    # Source of resolved hardware-capability data per SKU (SKU -> source label,
+    # e.g. "static_registry", "live_detection", "mast", "psutil", "serf"). Kept a
+    # free-form string so it isn't restricted to a fixed set of detection
+    # mechanisms.
+    hw_source: Dict[str, str] = field(default_factory=dict)
+    # External trace / job identifier (e.g. the MAST Job ID) this planning session
+    # corresponds to. Links the request/session to the launching job for
+    # cross-system correlation. Session-level; None until associated with a job.
+    external_trace_id: Optional[str] = None
+
+
 # ---- Types Utils ---- #
 def hash_sha256_to_int(hashable_list: List[Any]) -> int:
     """


### PR DESCRIPTION
Summary:

Why this diff:
Dry-run planning needs a request that plans multiple candidate SKUs in one pass (a sweep), which the single-SKU base request cannot express.

Use cases:
- Offline capacity / what-if analysis across several SKUs before committing hardware.
- TUO-style iterative validation that re-plans the same model across SKUs.

How it is addressed / what is added:
- Adds DryRunRequest (extends ShardingPlanRequest) with sku_list and optional per-SKU overrides.
- Adds fingerprint(sku): composes the base request_hash with the SKU and its per-SKU override so each SKU gets a stable, unique key for the results map and cross-run correlation.

Reviewed By: mserturk, hammad45

Differential Revision: D109606846


