### PR TITLE
Support value gradient clipping for sharded params (FSDP/HSDP)

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -39,9 +39,13 @@ class GradientClippingOptimizer(OptimizerWrapper):
         max_gradient (float): max value for clipping
         norm_type (float or str): type of the used p-norm. Can be ``'inf'`` for infinity norm.
         enable_global_grad_clip (bool): whether to enable global gradient clipping.
+            Only affects ``NORM`` clipping, where it controls whether the gradient norm
+            is aggregated across shard process groups (via all-reduce) to form a global
+            norm. ``VALUE`` clipping is elementwise and needs no communication, so it
+            applies the same per-element clip regardless of this flag.
         param_to_pgs (Dict[torch.nn.Parameter, List[dist.ProcessGroup]], optional): Mapping of parameters
             to process groups. Used for global gradient clipping in n-D model parallelism case.
-            Defaults to None, local gradient clipping is used.
+            Defaults to None, local gradient clipping is used. Ignored by ``VALUE`` clipping.
         track_grad_norm (bool): track_grad_norm (bool): If set to True, the optimizer will also track the
             total gradient norm from the most recent step, which can be retrieved
             using the `last_total_grad_norm` property.
@@ -97,13 +101,6 @@ class GradientClippingOptimizer(OptimizerWrapper):
             f"Optimizer found {sharded_param_cnt} dist params and {len(self._replicate_params)} replicate params."
         )
 
-        # Sanity check: this path is currently not used in any production.
-        if self._clipping == GradientClipping.VALUE:
-            if sharded_param_cnt > 0:
-                raise NotImplementedError(
-                    "clip_grad_value_ for sharded parameters is not supported yet"
-                )
-
     def step(self, closure: Any = None) -> None:
         if self._check_meta:
             # skip gradient clipping and early return
@@ -153,9 +150,7 @@ class GradientClippingOptimizer(OptimizerWrapper):
         elif self._clipping == GradientClipping.VALUE:
             if self._track_grad_norm:
                 self._last_total_grad_norm, _ = self.compute_total_grad_norm()
-            torch.nn.utils.clip_grad_value_(
-                parameters=self._replicate_params, clip_value=self._max_gradient
-            )
+            self.clip_grad_value_()
 
         elif self._clipping == GradientClipping.NONE:
             if self._track_grad_norm:
@@ -195,6 +190,25 @@ class GradientClippingOptimizer(OptimizerWrapper):
         )
         return total_norm, all_grads
 
+    def clip_grad_value_(self) -> None:
+        """Clip the gradient values of all parameters elementwise.
+
+        Value clipping is elementwise, so each rank clips its local shard
+        independently and the result is identical to clipping the full
+        (unsharded) gradient -- no collective is needed. This holds for any
+        sharding (FSDP, HSDP, n-D parallelism) since ``max_gradient`` is a
+        user-provided constant that is the same on every rank. ``_get_grads``
+        unwraps DTensors to their local tensors and filters out None/empty
+        gradients, so replicate and sharded params share a single code path.
+        """
+        grads = _get_grads(
+            self._replicate_params
+            + [p for params in self._sharded_params.values() for p in params]
+        )
+        if grads:
+            torch._foreach_clamp_min_(grads, -self._max_gradient)
+            torch._foreach_clamp_max_(grads, self._max_gradient)
+
     def clip_grad_norm_(self) -> Optional[Union[float, torch.Tensor]]:
         """Clip the gradient norm of all parameters."""
 
@@ -210,12 +224,19 @@ class GradientClippingOptimizer(OptimizerWrapper):
 def _get_grads(
     param_list: List[torch.Tensor],
 ) -> List[torch.Tensor]:
-    """Get the gradients of a list of parameters. Converts DTensors to local tensors if needed."""
-    grads = [
-        p.grad._local_tensor if isinstance(p.grad, DTensor) else p.grad
-        for p in param_list
-        if p.grad is not None and p.grad.numel() > 0
-    ]
+    """Get the gradients of a list of parameters. Converts DTensors to local tensors if needed.
+
+    Uses the public ``DTensor.to_local()`` under ``torch.no_grad()``: in the
+    no-grad path ``to_local()`` returns the DTensor's local tensor itself (no
+    autograd graph), so in-place updates to the returned grads propagate back to
+    the original gradients.
+    """
+    with torch.no_grad():
+        grads = [
+            p.grad.to_local() if isinstance(p.grad, DTensor) else p.grad
+            for p in param_list
+            if p.grad is not None and p.grad.numel() > 0
+        ]
     return grads
 
 

--- a/torchrec/optim/tests/test_clipping.py
+++ b/torchrec/optim/tests/test_clipping.py
@@ -220,6 +220,104 @@ class TestGradientClippingOptimizer(unittest.TestCase):
             param_2.grad, expected_grad_2, rtol=1e-05, atol=1e-08
         )
 
+    def test_clip_gradients_value_with_sharded_params(self) -> None:
+        # Value clipping must clip both replicate and sharded params. It is
+        # elementwise, so no collective is required.
+        max_gradient = 1.0
+        param_1 = Variable(torch.tensor([2.0, -4.0]), requires_grad=True)
+        param_2 = Variable(torch.tensor([-3.0, 0.5]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1, "param_2": param_2},
+            {},
+            [{"params": [param_1, param_2]}],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=max_gradient,
+            clipping=GradientClipping.VALUE,
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([2.0, -4.0])
+        param_2.grad = torch.tensor([-3.0, 0.5])
+
+        mock_pg = MagicMock()
+        gradient_clipping_optimizer._sharded_params = {(mock_pg,): [param_1]}
+        gradient_clipping_optimizer._replicate_params = [param_2]
+
+        gradient_clipping_optimizer.step()
+
+        # sharded param grad clamped to [-1, 1]
+        torch.testing.assert_close(
+            param_1.grad, torch.tensor([1.0, -1.0]), rtol=0, atol=0
+        )
+        # replicate param grad clamped to [-1, 1]
+        torch.testing.assert_close(
+            param_2.grad, torch.tensor([-1.0, 0.5]), rtol=0, atol=0
+        )
+
+    def test_clip_gradients_value_with_none_and_empty_grads(self) -> None:
+        # Value clipping must skip params with None or empty gradients (across
+        # both replicate and sharded buckets) and still clip the rest.
+        param_clip = Variable(torch.tensor([2.0, -4.0]), requires_grad=True)
+        param_none = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+        param_empty = Variable(torch.tensor([]), requires_grad=True)
+        param_sharded = Variable(torch.tensor([5.0, -0.5]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {
+                "param_clip": param_clip,
+                "param_none": param_none,
+                "param_empty": param_empty,
+                "param_sharded": param_sharded,
+            },
+            {},
+            [
+                {
+                    "params": [
+                        param_clip,
+                        param_none,
+                        param_empty,
+                        param_sharded,
+                    ]
+                }
+            ],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.VALUE,
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_clip.grad = torch.tensor([2.0, -4.0])
+        param_none.grad = None
+        param_empty.grad = torch.tensor([])
+        param_sharded.grad = torch.tensor([5.0, -0.5])
+
+        mock_pg = MagicMock()
+        gradient_clipping_optimizer._replicate_params = [
+            param_clip,
+            param_none,
+            param_empty,
+        ]
+        gradient_clipping_optimizer._sharded_params = {(mock_pg,): [param_sharded]}
+
+        # Should not raise on None/empty grads.
+        gradient_clipping_optimizer.step()
+
+        torch.testing.assert_close(
+            param_clip.grad, torch.tensor([1.0, -1.0]), rtol=0, atol=0
+        )
+        self.assertIsNone(param_none.grad)
+        torch.testing.assert_close(param_empty.grad, torch.tensor([]), rtol=0, atol=0)
+        torch.testing.assert_close(
+            param_sharded.grad, torch.tensor([1.0, -0.5]), rtol=0, atol=0
+        )
+
     def test_last_total_grad_norm_none_before_step(self) -> None:
         param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
 


### PR DESCRIPTION
Summary:
**GradientClippingOptimizer previously raised NotImplementedError for GradientClipping.VALUE whenever any sharded parameter was present (global gradient clipping with param_to_pgs), so value clipping was unusable with FSDP/HSDP/n-D model parallelism.** This was an implementation gap, not a fundamental limitation: value clipping is elementwise, so each rank can clamp its local shard to [-max_gradient, max_gradient] independently and the result is identical to clipping the full unsharded gradient -- no collective is required, since max_gradient is a user-provided constant that is the same on every rank.

**This diff removes the guard and implements sharded value clipping.** The value branch now delegates to a new clip_grad_value_() method that collects gradients from both replicate and sharded params via _get_grads (which unwraps DTensors to their local tensors and filters out None/empty gradients) and clamps them in place with torch._foreach_clamp_min_/torch._foreach_clamp_max_. Replicate and sharded params share a single code path, mirroring how compute_total_grad_norm already handles the mix.

Note that enable_global_grad_clip / param_to_pgs only affect NORM clipping (whether the norm is aggregated across shard process groups via all-reduce); they are inert for VALUE clipping, which is elementwise. The class docstring is updated to say so.

**Scope / existing code paths: NORM and NONE clipping behavior is unchanged.** For FSDP, HSDP, and n-D model parallelism the production NORM gradient-clipping path (global norm via all-reduce across shard process groups, plus the no-sharded local fast path) is unchanged in behavior -- no edits to clip_grad_norm_, compute_total_grad_norm, _compute_total_norm, or _batch_cal_norm. The shared helper _get_grads now obtains a DTensor's local gradient via the public DTensor.to_local() under torch.no_grad() instead of the private ._local_tensor attribute; in the no-grad path to_local() returns the local tensor itself (identity, no autograd graph, no copy and no collective), so this is behavior-preserving for both the NORM and VALUE paths and is verified by the unchanged NORM unit tests still passing. The sharded-bucket VALUE path was hard-disabled (NotImplementedError) before, so enabling it is purely additive. The only previously-live VALUE path that moves is replicate-bucket value clipping (DDP, and FSDP/HSDP value clipping without global grad clip): it is refactored from torch.nn.utils.clip_grad_value_ to an equivalent _get_grads + torch._foreach_clamp_min_/max_ implementation (clip_grad_value_ is itself foreach clamp internally; the only deltas are filtering empty grads, which clamp as a no-op, and unwrapping DTensors), and the pre-existing DDP value unit tests, which assert exact expected outputs, still pass unchanged.

Differential Revision: D109758277


