### PR TITLE
Bound the compute-thread join at CPUOffloaded metric teardown (#4392)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -11,6 +11,7 @@ import concurrent
 import contextlib
 import logging
 import queue
+import sys
 import threading
 import time
 import traceback
@@ -84,6 +85,21 @@ metric_update_thread_name: str = "metric_update"
 metric_compute_thread_name: str = "metric_compute"
 
 _DRAIN_WAIT_WARN_INTERVAL_SEC: float = 60.0
+
+# Bound the compute-thread join at teardown. If the compute thread is wedged in
+# an orphaned GLOO all_gather (a peer rank skipped the collective), an unbounded
+# join hangs the post_train_teardown lease and the whole job is StuckJob-killed.
+_COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC: float = 300.0
+
+
+def _format_thread_stack(thread: threading.Thread) -> str:
+    ident = thread.ident
+    if ident is None:
+        return "<no frame; thread not started>"
+    frame = sys._current_frames().get(ident)
+    if frame is None:
+        return "<no frame; thread not found or already exited>"
+    return "".join(traceback.format_stack(frame))
 
 
 def _safe_merge_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -461,7 +477,17 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
         self._compute_shutdown_event.set()
         if self.compute_thread.is_alive():
-            self.compute_thread.join()
+            self.compute_thread.join(timeout=_COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC)
+            if self.compute_thread.is_alive():
+                logger.error(
+                    "compute_thread did not exit within "
+                    f"{_COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC}s at shutdown; abandoning "
+                    "the join to avoid a teardown deadlock "
+                    f"(compute_queue={self.compute_queue.qsize()}, "
+                    f"captured_exception={self._captured_exception_event.is_set()}, "
+                    f"compute_errors={self._compute_errors}). compute_thread stack:\n"
+                    f"{_format_thread_stack(self.compute_thread)}"
+                )
         logger.info(
             f"Compute thread: alive={self.compute_thread.is_alive()}, "
             f"compute_queue_remaining={self.compute_queue.qsize()}"

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -22,8 +22,10 @@ import torch.distributed as dist
 from torchrec.distributed.logging_utils import EventType
 from torchrec.distributed.test_utils.multi_process import MultiProcessTestBase
 from torchrec.metrics.cpu_offloaded_metric_module import (
+    _COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC,
     _foreach_clone_dict,
     _foreach_clone_kwargs,
+    _format_thread_stack,
     _merge_update_jobs,
     CPUOffloadedRecMetricModule,
     MetricUpdateJob,
@@ -340,6 +342,53 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         with patch.object(self.cpu_module, "_log_event") as mock_log_event:
             self.cpu_module.shutdown()
             mock_log_event.assert_not_called()
+
+    def test_shutdown_logs_stack_when_compute_thread_will_not_exit(self) -> None:
+        """A compute thread still alive past the bounded join must not hang
+        teardown: shutdown() abandons the join, logs an error with the thread
+        stack, then raises so the job fails loudly."""
+        with patch.object(
+            self.cpu_module.compute_thread, "join", return_value=None
+        ), patch.object(
+            self.cpu_module.compute_thread, "is_alive", return_value=True
+        ), patch.object(
+            self.cpu_module, "_log_event"
+        ), patch(
+            "torchrec.metrics.cpu_offloaded_metric_module.logger"
+        ) as mock_logger:
+            with self.assertRaises(RecMetricException):
+                self.cpu_module.shutdown()
+
+        mock_logger.error.assert_called_once()
+        (msg,) = mock_logger.error.call_args[0]
+        self.assertIn(f"did not exit within {_COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC}", msg)
+        self.assertIn("compute_thread stack", msg)
+
+    def test_format_thread_stack(self) -> None:
+        # Not-started thread: ident is None.
+        self.assertIn(
+            "not started", _format_thread_stack(threading.Thread(target=lambda: None))
+        )
+
+        # Live thread: a real formatted stack.
+        started = threading.Event()
+        release = threading.Event()
+
+        def _run() -> None:
+            started.set()
+            release.wait(timeout=5.0)
+
+        live = threading.Thread(target=_run)
+        live.start()
+        try:
+            self.assertTrue(started.wait(timeout=5.0))
+            self.assertIn("File", _format_thread_stack(live))
+        finally:
+            release.set()
+            live.join(timeout=5.0)
+
+        # Exited thread: ident is set but has no current frame.
+        self.assertIn("already exited", _format_thread_stack(live))
 
     def test_shutdown_reraises_captured_exception(self) -> None:
         """If a worker thread crashed before shutdown(), shutdown() must


### PR DESCRIPTION
Summary:

`CPUOffloadedRecMetricModule` joined its background compute thread unboundedly at shutdown. If that thread is blocked in a cross-rank collective whose peers have already exited, the join never returns, so teardown hangs until the job is force-killed. Bound the join with a timeout; on timeout, log the compute-thread stack plus queue/exception state and proceed (the compute thread is a daemon and exits with the process). Happy-path behavior is unchanged — a healthy compute thread joins well within the bound.

Reviewed By: derekwan1

Differential Revision: D109742400


