### PR TITLE
Add SKUAwareStorageReservation policy (#4397)

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -40,6 +40,7 @@ class StorageReservationType(str, Enum):
     HEURISTIC = "heuristic"
     FIXED_PERCENTAGE = "fixed_percentage"
     FIXED_ABSOLUTE = "fixed_absolute"
+    SKU_AWARE = "sku_aware"
 
 
 def _get_module_size(module: nn.Module, multiplier: float) -> int:
@@ -264,6 +265,85 @@ class FixedAbsoluteStorageReservation(FixedPercentageStorageReservation):
         _reserve_storage_absolute(reserved_topology, self._hbm_reserved_bytes)
         self._last_reserved_topology = reserved_topology
         return reserved_topology
+
+
+class SKUAwareStorageReservation(StorageReservation):
+    """
+    Reserves a fixed absolute amount of HBM per device expressed in SKU-correct
+    terms: ``model_base_bytes`` (the hardware-independent footprint of the
+    non-sharded model, e.g. dense parameters, optimizer state, and DDP buffers)
+    plus ``runtime_overhead_bytes`` (the per-SKU runtime tax: driver/context,
+    NCCL buffers, and allocator fragmentation).
+
+    Unlike a percentage-of-HBM reservation, the reserved amount does not scale
+    with device capacity, so a model keeps the same reservation when it lands on
+    SKUs with different HBM caps. This avoids the cross-SKU mis-scaling that is a
+    dominant cause of planner OOM/failures under hardware fungibility.
+
+    Both inputs are hardware-aware values resolved by the caller (the OSS planner
+    cannot read the internal hardware registry); see the framework-side factory
+    that constructs this reservation from the resolved SKU.
+
+    Args:
+        model_base_bytes (int): hardware-independent non-sharded model footprint,
+            in bytes.
+        runtime_overhead_bytes (int): per-SKU runtime overhead, in bytes.
+    """
+
+    def __init__(self, model_base_bytes: int, runtime_overhead_bytes: int) -> None:
+        assert model_base_bytes >= 0
+        assert runtime_overhead_bytes >= 0
+        self._model_base_bytes: int = model_base_bytes
+        self._runtime_overhead_bytes: int = runtime_overhead_bytes
+        self._reserved_bytes: int = model_base_bytes + runtime_overhead_bytes
+        self._last_reserved_topology: Optional[Topology] = None
+
+    def reserve(
+        self,
+        topology: Topology,
+        batch_size: int,
+        module: nn.Module,
+        sharders: List[ModuleSharder[nn.Module]],
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    ) -> Topology:
+        reserved_topology = copy.deepcopy(topology)
+
+        # _reserve_storage_absolute floors at max(0, ...), which would silently
+        # hide a reservation that meets or exceeds available hbm. Guard explicitly
+        # (>=, since == leaves 0 hbm for sharded tables) so the over-reservation
+        # surfaces as an actionable error instead of a confusing downstream
+        # "could not place tables" failure.
+        available_hbm = reserved_topology.devices[0].storage.hbm
+        if self._reserved_bytes >= available_hbm:
+            reserved_gb = self._reserved_bytes / (1024**3)
+            model_base_gb = self._model_base_bytes / (1024**3)
+            overhead_gb = self._runtime_overhead_bytes / (1024**3)
+            insufficient_storage_solution = (
+                f"The SKU-aware storage reservation ({reserved_gb:.2f} GB per rank) "
+                "meets or exceeds the available hbm storage per rank "
+                f"({storage_repr_in_gb(topology.devices[0].storage)}), leaving no hbm "
+                "for sharded embedding tables, so it is not possible to find a valid "
+                "sharding plan. "
+                f"\n \n The reservation is model_base_bytes ({model_base_gb:.2f} GB) + "
+                f"runtime_overhead_bytes ({overhead_gb:.2f} GB). "
+                "\n \n Possible solutions:"
+                "\n  1) Reduce model_base_bytes (the non-sharded model footprint), "
+                "e.g. by supplying a more accurate measured estimate. "
+                "\n  2) Use hardware with a higher hbm cap. "
+            )
+            raise PlannerError(
+                error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
+                message=insufficient_storage_solution,
+            )
+
+        _reserve_storage_absolute(reserved_topology, self._reserved_bytes)
+        self._last_reserved_topology = reserved_topology
+        return reserved_topology
+
+    @property
+    def last_reserved_topology(self) -> Optional[Topology]:
+        "Returns a copy of the cached value of the most recent output from the reserve() method."
+        return copy.deepcopy(self._last_reserved_topology)
 
 
 class HeuristicalStorageReservation(StorageReservation):

--- a/torchrec/distributed/planner/tests/test_storage_reservations.py
+++ b/torchrec/distributed/planner/tests/test_storage_reservations.py
@@ -23,6 +23,7 @@ from torchrec.distributed.planner.storage_reservations import (
     FixedAbsoluteStorageReservation,
     FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
+    SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import PlannerError, PlannerErrorType, Topology
 from torchrec.distributed.planner.utils import gb_to_bytes
@@ -591,3 +592,183 @@ class TestFixedAbsoluteStorageReservation(unittest.TestCase):
     def test_negative_bytes_raises(self) -> None:
         with self.assertRaises(AssertionError):
             FixedAbsoluteStorageReservation(hbm_reserved_bytes=-1)
+
+
+class TestSKUAwareStorageReservation(unittest.TestCase):
+    def _create_model_and_sharders(
+        self,
+    ) -> tuple[TestModel, List[ModuleSharder[nn.Module]]]:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=10,
+                name="table_0",
+                feature_names=["feature_0"],
+            )
+        ]
+        ebc = EmbeddingBagCollection(tables)
+        model = TestModel(shardable_sparse=ebc)
+        sharders = cast(
+            List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()]
+        )
+        return model, sharders
+
+    def test_reserves_model_base_plus_overhead(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap)
+
+        model_base_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        )
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
+        self.assertEqual(reserved_topology.devices[1].storage.hbm, expected_hbm)
+
+    def test_reservation_is_invariant_across_hbm_caps(self) -> None:
+        # The defining SKU-aware property: the reserved amount is absolute and
+        # does not scale with device hbm, so a model reserves the same bytes
+        # regardless of the SKU it lands on (unlike percentage-of-hbm).
+        model, sharders = self._create_model_and_sharders()
+        model_base_bytes = gb_to_bytes(3.0)
+        runtime_overhead_bytes = gb_to_bytes(1.0)
+        expected_reserved = model_base_bytes + runtime_overhead_bytes
+
+        small_cap = 16 * 1024 * 1024 * 1024
+        large_cap = 80 * 1024 * 1024 * 1024
+
+        small_reserved = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        ).reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=small_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+        large_reserved = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        ).reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=large_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertEqual(
+            small_cap - small_reserved.devices[0].storage.hbm, expected_reserved
+        )
+        self.assertEqual(
+            large_cap - large_reserved.devices[0].storage.hbm, expected_reserved
+        )
+
+    def test_zero_reservation_matches_no_reservation(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=0, runtime_overhead_bytes=0
+        )
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, hbm_cap)
+
+    def test_insufficient_storage_raises(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        # Reserve more than the device can provide.
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=gb_to_bytes(9.0),
+            runtime_overhead_bytes=gb_to_bytes(2.0),
+        )
+
+        with self.assertRaises(PlannerError) as context:
+            reservation.reserve(
+                topology=topology,
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
+
+    def test_exact_capacity_raises(self) -> None:
+        # reserved == available leaves 0 hbm for sharded tables, which is still
+        # infeasible, so the boundary must raise (the >= guard).
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=gb_to_bytes(8.0),
+            runtime_overhead_bytes=gb_to_bytes(2.0),
+        )
+
+        with self.assertRaises(PlannerError) as context:
+            reservation.reserve(
+                topology=topology,
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
+
+    def test_last_reserved_topology_returns_copy(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        model_base_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        )
+
+        self.assertIsNone(reservation.last_reserved_topology)
+
+        reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        cached = reservation.last_reserved_topology
+        self.assertIsNotNone(cached)
+        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
+        self.assertEqual(cached.devices[0].storage.hbm, expected_hbm)
+
+    def test_negative_model_base_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            SKUAwareStorageReservation(model_base_bytes=-1, runtime_overhead_bytes=0)
+
+    def test_negative_runtime_overhead_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            SKUAwareStorageReservation(model_base_bytes=0, runtime_overhead_bytes=-1)


### PR DESCRIPTION
Summary:

**Design Doc:** https://docs.google.com/document/d/1L2c_L_gIAQXdJFsBX6-HqB5sZ0h-RkBf2Im3cjPLdhM/edit?tab=t.0#heading=h.dqzvsbkh1qwm

First building block of KR 1.2 (hardware resolution layer): a SKU-correct storage reservation policy that reserves an absolute amount of HBM per device, computed as `model_base_bytes` (the hardware-independent footprint of the non-sharded model: dense params, optimizer state, DDP buffers) plus `runtime_overhead_bytes` (the per-SKU runtime tax: driver/context, NCCL buffers, allocator fragmentation).

Unlike `FixedPercentageStorageReservation`, the reserved amount does not scale with device capacity, so a model keeps the same reservation when it lands on SKUs with different HBM caps. This removes the cross-SKU mis-scaling of percentage-of-HBM reservation, which is a dominant cause of planner OOM/failures under hardware fungibility (TC_ANY).

`SKUAwareStorageReservation` subclasses the `StorageReservation` ABC directly . `reserve()` adds an explicit `INSUFFICIENT_STORAGE` guard before reserving, because the shared `_reserve_storage_absolute` helper floors HBM at `max(0, ...)` and would otherwise silently hide an over-reservation. `SKU_AWARE` is added to `StorageReservationType`.

The class is OSS-clean (no `torchrec/fb` imports); both byte inputs are resolved and injected by the caller. A framework-side factory that sources `runtime_overhead_bytes` from the hardware registry and computes `model_base_bytes` follows in the next diff.

Also includes the `arc lint -a` autodeps fix on the `storage_reservations` target (`//caffe2:torch` -> `fbsource//third-party/pypi/torch:torch`).

Reviewed By: mserturk

Differential Revision: D109762141


