### PR TITLE
Perf Testing: DLRM + torch.compile (#4398)

### DIFF
--- a/torchrec/models/cuda_graph_benchmark.py
+++ b/torchrec/models/cuda_graph_benchmark.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Benchmark for CUDA Graphs on a single-GPU, unsharded ``DLRM`` / ``DLRM_DCN``.
+
+It builds an eager model, measures ms/step, enables CUDA Graphs on the
+dense compute path via ``DLRM.compile_dense_path()`` (Step 5), re-measures, and
+reports the speedup, the max abs output diff (numerical parity), and the GPU
+memory delta. With ``--trace-dir`` it also exports before/after Kineto traces so
+you can confirm ``cudaGraphLaunch`` replaced long ``cudaLaunchKernel`` runs.
+
+CUDA Graphs only engage on a CUDA device; on CPU the script still runs (compile
+falls back to no graph capture) so it can be smoke-tested without a GPU.
+
+Example::
+
+    buck2 run @fbcode//mode/opt fbcode//torchrec/models:cuda_graph_benchmark -- \\
+        --model dlrm --batch-size 1024 --num-sparse-features 26 \\
+        --embedding-dim 64 --dense-in-features 13 --trace-dir /tmp/dlrm_cudagraph
+"""
+
+import argparse
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator, List, Tuple
+
+import torch
+from torchrec.models.cuda_graph_utils import (
+    build_dlrm,
+    build_ebc,
+    collect_outputs,
+    generate_batch,
+)
+from torchrec.models.dlrm import DLRM, DLRM_DCN
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _build_model(args: argparse.Namespace, device: torch.device) -> DLRM:
+    """Build an unsharded DLRM / DLRM_DCN on ``device`` from the parsed args."""
+    if args.model != "dlrm_dcn":
+        return build_dlrm(
+            device,
+            embedding_dim=args.embedding_dim,
+            num_sparse_features=args.num_sparse_features,
+            num_embeddings=args.num_embeddings,
+            dense_in_features=args.dense_in_features,
+        )
+    ebc = build_ebc(
+        device,
+        embedding_dim=args.embedding_dim,
+        num_sparse_features=args.num_sparse_features,
+        num_embeddings=args.num_embeddings,
+    )
+    model = DLRM_DCN(
+        embedding_bag_collection=ebc,
+        dense_in_features=args.dense_in_features,
+        # Final dense_arch layer size must equal embedding_dim (DLRM constraint).
+        dense_arch_layer_sizes=[args.embedding_dim * 2, args.embedding_dim],
+        over_arch_layer_sizes=[512, 256, 1],
+        dcn_num_layers=args.dcn_num_layers,
+        dcn_low_rank_dim=args.dcn_low_rank_dim,
+        dense_device=device,
+    )
+    return model.to(device).eval()
+
+
+def _generate_inputs(
+    args: argparse.Namespace, device: torch.device
+) -> Tuple[torch.Tensor, KeyedJaggedTensor]:
+    """Generate one synthetic (dense, sparse-KJT) batch directly on ``device``."""
+    return generate_batch(
+        device,
+        batch_size=args.batch_size,
+        num_sparse_features=args.num_sparse_features,
+        num_embeddings=args.num_embeddings,
+        dense_in_features=args.dense_in_features,
+        pooling_factor=args.pooling_factor,
+    )
+
+
+@contextmanager
+def _maybe_autocast(enabled: bool, device: torch.device) -> Iterator[None]:
+    """fp16 autocast on CUDA. Applied identically to warmup and measured loops so
+    the CUDA graph is captured and replayed under the same context (see the
+    runbook "Hang on first replay" failure mode)."""
+    if enabled and device.type == "cuda":
+        with torch.autocast(device_type="cuda", dtype=torch.float16):
+            yield
+    else:
+        yield
+
+
+@torch.inference_mode()
+def _measure_ms_per_step(
+    model: DLRM,
+    dense: torch.Tensor,
+    kjt: KeyedJaggedTensor,
+    args: argparse.Namespace,
+    device: torch.device,
+) -> float:
+    """Warmup then time ``warmup_iters`` + ``bench_iters`` forward passes."""
+    with _maybe_autocast(args.amp, device):
+        for _ in range(args.warmup_iters):
+            torch.compiler.cudagraph_mark_step_begin()
+            model(dense_features=dense, sparse_features=kjt)
+
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        with _maybe_autocast(args.amp, device):
+            for _ in range(args.bench_iters):
+                torch.compiler.cudagraph_mark_step_begin()
+                model(dense_features=dense, sparse_features=kjt)
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / args.bench_iters
+
+    # CPU fallback (no CUDA graph capture; timing is wall-clock only).
+    import time
+
+    t0 = time.perf_counter()
+    with _maybe_autocast(args.amp, device):
+        for _ in range(args.bench_iters):
+            torch.compiler.cudagraph_mark_step_begin()
+            model(dense_features=dense, sparse_features=kjt)
+    return (time.perf_counter() - t0) * 1000.0 / args.bench_iters
+
+
+@torch.inference_mode()
+def _collect_outputs(
+    model: DLRM,
+    batches: List[Tuple[torch.Tensor, KeyedJaggedTensor]],
+    args: argparse.Namespace,
+    device: torch.device,
+) -> List[torch.Tensor]:
+    """Collect one output per batch under the requested precision."""
+    with _maybe_autocast(args.amp, device):
+        return collect_outputs(model, batches)
+
+
+def _export_trace(
+    model: DLRM,
+    dense: torch.Tensor,
+    kjt: KeyedJaggedTensor,
+    path: str,
+    args: argparse.Namespace,
+    device: torch.device,
+) -> None:
+    """Export a Kineto/Chrome trace of a few forward passes to ``path``."""
+    from torch.profiler import profile, ProfilerActivity
+
+    activities = [ProfilerActivity.CPU]
+    if device.type == "cuda":
+        activities.append(ProfilerActivity.CUDA)
+    with torch.inference_mode(), _maybe_autocast(args.amp, device):
+        with profile(activities=activities) as prof:
+            for _ in range(10):
+                torch.compiler.cudagraph_mark_step_begin()
+                model(dense_features=dense, sparse_features=kjt)
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+    prof.export_chrome_trace(path)
+    logger.info("wrote trace: %s", path)
+
+
+def _run(args: argparse.Namespace) -> None:
+    device = torch.device(args.device)
+    if device.type != "cuda":
+        logger.warning(
+            "device=%s is not CUDA: 'reduce-overhead' will NOT capture a CUDA "
+            "graph, so this measures torch.compile overhead only.",
+            device,
+        )
+
+    if args.trace_dir:
+        os.makedirs(args.trace_dir, exist_ok=True)
+
+    model = _build_model(args, device)
+    timing_input = _generate_inputs(args, device)
+    parity_batches = [
+        _generate_inputs(args, device) for _ in range(args.parity_batches)
+    ]
+
+    # --- Step 4: baseline (eager) ---
+    baseline_ms = _measure_ms_per_step(model, *timing_input, args, device)
+    eager_outputs = _collect_outputs(model, parity_batches, args, device)
+    if args.trace_dir:
+        _export_trace(
+            model, *timing_input, f"{args.trace_dir}/before.json", args, device
+        )
+
+    # --- Step 5: enable Path A (CUDA Graphs via torch.compile) ---
+    mem_before = torch.cuda.max_memory_allocated(device) if device.type == "cuda" else 0
+    model.compile_dense_path()
+    compiled_ms = _measure_ms_per_step(model, *timing_input, args, device)
+    compiled_outputs = _collect_outputs(model, parity_batches, args, device)
+    mem_after = torch.cuda.max_memory_allocated(device) if device.type == "cuda" else 0
+    if args.trace_dir:
+        _export_trace(
+            model, *timing_input, f"{args.trace_dir}/after.json", args, device
+        )
+
+    # --- Step 7: validate ---
+    max_abs_diff = max(
+        (e - c).abs().max().item() for e, c in zip(eager_outputs, compiled_outputs)
+    )
+    tol = 1e-3 if args.amp else 1e-5
+    speedup_pct = (baseline_ms - compiled_ms) / baseline_ms * 100.0
+
+    print("=" * 60)
+    print(f"model:            {args.model}")
+    print(f"batch_size:       {args.batch_size}")
+    print(f"num_sparse_feats: {args.num_sparse_features}")
+    print(f"amp (fp16):       {args.amp}")
+    print("-" * 60)
+    print(f"baseline (eager): {baseline_ms:.4f} ms/step")
+    print(f"cudagraph (A):    {compiled_ms:.4f} ms/step")
+    print(f"speedup:          {speedup_pct:+.1f}%  (>=10% is the target)")
+    print(f"max abs diff:     {max_abs_diff:.2e}  (tol {tol:.0e})")
+    print(f"parity:           {'PASS' if max_abs_diff < tol else 'FAIL'}")
+    if device.type == "cuda":
+        print(f"max mem delta:    {(mem_after - mem_before) / 1e6:.1f} MB")
+    print("=" * 60)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", choices=["dlrm", "dlrm_dcn"], default="dlrm")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--batch-size", type=int, default=1024)
+    parser.add_argument("--dense-in-features", type=int, default=13)
+    parser.add_argument("--num-sparse-features", type=int, default=26)
+    parser.add_argument("--embedding-dim", type=int, default=64)
+    parser.add_argument("--num-embeddings", type=int, default=100_000)
+    parser.add_argument("--pooling-factor", type=int, default=20)
+    parser.add_argument("--warmup-iters", type=int, default=100)
+    parser.add_argument("--bench-iters", type=int, default=500)
+    parser.add_argument("--parity-batches", type=int, default=100)
+    parser.add_argument("--dcn-num-layers", type=int, default=2)
+    parser.add_argument("--dcn-low-rank-dim", type=int, default=8)
+    parser.add_argument(
+        "--amp", action="store_true", help="run forward under fp16 autocast"
+    )
+    parser.add_argument(
+        "--trace-dir",
+        type=str,
+        default=None,
+        help="if set, export before.json / after.json Kineto traces here",
+    )
+    return parser
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    _run(_build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/torchrec/models/cuda_graph_utils.py
+++ b/torchrec/models/cuda_graph_utils.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Shared helpers for the CUDA Graphs dense-path work on ``DLRM``: building a small
+unsharded model, generating synthetic ``(dense, KJT)`` batches directly on the
+target device, and collecting outputs across batches under the CUDA-graph replay
+protocol.
+"""
+
+from typing import List, Tuple
+
+import torch
+from torchrec.models.dlrm import DLRM
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+def build_ebc(
+    device: torch.device,
+    *,
+    embedding_dim: int,
+    num_sparse_features: int,
+    num_embeddings: int,
+) -> EmbeddingBagCollection:
+    """Build an ``EmbeddingBagCollection`` of ``num_sparse_features`` equal-dim tables."""
+    tables = [
+        EmbeddingBagConfig(
+            name=f"t{i}",
+            embedding_dim=embedding_dim,
+            num_embeddings=num_embeddings,
+            feature_names=[f"f{i}"],
+        )
+        for i in range(num_sparse_features)
+    ]
+    return EmbeddingBagCollection(tables=tables, device=device)
+
+
+def build_dlrm(
+    device: torch.device,
+    *,
+    embedding_dim: int,
+    num_sparse_features: int,
+    num_embeddings: int,
+    dense_in_features: int,
+    over_arch_layer_sizes: Tuple[int, ...] = (512, 256, 1),
+) -> DLRM:
+    """Build an unsharded base ``DLRM`` on ``device``, in eval mode."""
+    ebc = build_ebc(
+        device,
+        embedding_dim=embedding_dim,
+        num_sparse_features=num_sparse_features,
+        num_embeddings=num_embeddings,
+    )
+    model = DLRM(
+        embedding_bag_collection=ebc,
+        dense_in_features=dense_in_features,
+        # Final dense_arch layer must equal embedding_dim (DLRM constraint).
+        dense_arch_layer_sizes=[embedding_dim * 2, embedding_dim],
+        over_arch_layer_sizes=list(over_arch_layer_sizes),
+        dense_device=device,
+    )
+    return model.to(device).eval()
+
+
+def generate_batch(
+    device: torch.device,
+    *,
+    batch_size: int,
+    num_sparse_features: int,
+    num_embeddings: int,
+    dense_in_features: int,
+    pooling_factor: int,
+) -> Tuple[torch.Tensor, KeyedJaggedTensor]:
+    """Generate one synthetic ``(dense, sparse-KJT)`` batch directly on ``device``."""
+    b, f, length = batch_size, num_sparse_features, pooling_factor
+    # Citrine C3: create tensors directly on device, never CPU-then-.to(device).
+    dense = torch.rand(b, dense_in_features, device=device)
+    lengths = torch.full((f * b,), length, dtype=torch.long, device=device)
+    values = torch.randint(
+        0, num_embeddings, (f * b * length,), dtype=torch.long, device=device
+    )
+    kjt = KeyedJaggedTensor(
+        keys=[f"f{i}" for i in range(f)], values=values, lengths=lengths
+    )
+    return dense, kjt
+
+
+def collect_outputs(
+    model: DLRM,
+    batches: List[Tuple[torch.Tensor, KeyedJaggedTensor]],
+) -> List[torch.Tensor]:
+    """Run ``model`` over ``batches``, returning one cloned output per batch.
+
+    ``reduce-overhead`` replays a CUDA graph into static buffers, so mark the step
+    boundary before each call and clone each output — otherwise a later replay can
+    overwrite a result we still hold. For mixed precision, wrap the call in an
+    autocast context; the forwards run inside that dynamic scope.
+    """
+    outputs: List[torch.Tensor] = []
+    for dense, kjt in batches:
+        torch.compiler.cudagraph_mark_step_begin()
+        outputs.append(
+            model(dense_features=dense, sparse_features=kjt).detach().clone()
+        )
+    return outputs

--- a/torchrec/models/dlrm.py
+++ b/torchrec/models/dlrm.py
@@ -468,6 +468,13 @@ class DLRM(nn.Module):
             specified here.
         dense_device (Optional[torch.device]): default compute device.
 
+    To reduce per-step CPU kernel-launch overhead, call `compile_dense_path()`
+    after construction to enable CUDA Graphs on the dense compute path
+    (`dense_arch`, `inter_arch`, `over_arch`) via
+    `torch.compile(mode="reduce-overhead")`. Gate that call behind your own
+    `enable_cuda_graph` feature flag so it can be toggled / rolled back without
+    a model change. `sparse_arch` is intentionally left eager.
+
     Example::
 
         B = 2
@@ -519,6 +526,9 @@ class DLRM(nn.Module):
         dense_device: Optional[torch.device] = None,
     ) -> None:
         super().__init__()
+        # Tracks whether the dense compute path has been wrapped for CUDA Graphs.
+        # Used to keep compile_dense_path() idempotent.
+        self._cuda_graph_enabled: bool = False
         assert (
             len(embedding_bag_collection.embedding_bag_configs()) > 0
         ), "At least one embedding bag is required"
@@ -559,6 +569,44 @@ class DLRM(nn.Module):
             layer_sizes=over_arch_layer_sizes,
             device=dense_device,
         )
+
+    def compile_dense_path(self, compile_mode: str = "reduce-overhead") -> None:
+        """
+        Enable CUDA Graphs on the dense compute path via `torch.compile`.
+
+        Wraps `dense_arch`, `inter_arch`, and `over_arch` with
+        `torch.compile(mode=compile_mode)`. With the default
+        ``"reduce-overhead"`` mode, Inductor captures a CUDA graph for each of
+        these blocks, replacing long runs of `cudaLaunchKernel` for small
+        kernels with a single `cudaGraphLaunch` and cutting per-step CPU
+        dispatch overhead.
+
+        `sparse_arch` is intentionally left eager: it runs
+        `EmbeddingBagCollection` lookups over a `KeyedJaggedTensor` whose shapes
+        vary batch-to-batch, which is incompatible with CUDA graph capture.
+
+        This method is additive and idempotent: the eager `forward` is unchanged
+        until it is called, and calling it more than once is a no-op. Call it
+        once, after construction, on a model that is already on a CUDA device;
+        gate the call behind an `enable_cuda_graph` feature flag at the call
+        site so it can be toggled / rolled back without a model change. It works
+        for `DLRM` and its subclasses (`DLRM_DCN`, `DLRM_Projection`) because by
+        the time it runs the subclass `inter_arch`/`over_arch` overrides are
+        already in place.
+
+        Args:
+            compile_mode (str): the `torch.compile` mode. Defaults to
+                ``"reduce-overhead"`` (the CUDA Graphs path).
+        """
+        if self._cuda_graph_enabled:
+            return
+        # pyrefly: ignore[bad-assignment]
+        self.dense_arch = torch.compile(self.dense_arch, mode=compile_mode)
+        # pyrefly: ignore[bad-assignment]
+        self.inter_arch = torch.compile(self.inter_arch, mode=compile_mode)
+        # pyrefly: ignore[bad-assignment]
+        self.over_arch = torch.compile(self.over_arch, mode=compile_mode)
+        self._cuda_graph_enabled = True
 
     def forward(
         self,

--- a/torchrec/models/tests/test_cuda_graph.py
+++ b/torchrec/models/tests/test_cuda_graph.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+GPU (RE) test for ``DLRM.compile_dense_path()`` — the CUDA Graphs dense-path
+optimization. Runs on a ``gpu-remote-execution`` worker via ``buck2 test`` so the
+``reduce-overhead`` path actually captures a CUDA graph (it is a no-op on CPU).
+
+Validates two things on a real GPU:
+  * numerical parity — the compiled dense path matches eager outputs, and
+  * the optimization is runnable end-to-end (idempotent enable, replay works).
+
+It deliberately does NOT hard-assert a speedup threshold: the win is real but
+HW- and queue-dependent, and a fixed bar would make the test flaky. The speedup
+is logged for the human reading the test output.
+"""
+
+import logging
+import time
+import unittest
+
+import torch
+from torchrec.models.cuda_graph_utils import build_dlrm, collect_outputs, generate_batch
+from torchrec.models.dlrm import DLRM
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Small, fast model/inputs — this is a correctness test, not a benchmark.
+_BATCH_SIZE = 256
+_NUM_SPARSE_FEATURES = 8
+_EMBEDDING_DIM = 32
+_NUM_EMBEDDINGS = 10_000
+_DENSE_IN_FEATURES = 13
+_POOLING_FACTOR = 20
+_PARITY_BATCHES = 8
+
+
+def _build_model(device: torch.device) -> DLRM:
+    return build_dlrm(
+        device,
+        embedding_dim=_EMBEDDING_DIM,
+        num_sparse_features=_NUM_SPARSE_FEATURES,
+        num_embeddings=_NUM_EMBEDDINGS,
+        dense_in_features=_DENSE_IN_FEATURES,
+    )
+
+
+def _gen_batch(device: torch.device) -> tuple[torch.Tensor, KeyedJaggedTensor]:
+    return generate_batch(
+        device,
+        batch_size=_BATCH_SIZE,
+        num_sparse_features=_NUM_SPARSE_FEATURES,
+        num_embeddings=_NUM_EMBEDDINGS,
+        dense_in_features=_DENSE_IN_FEATURES,
+        pooling_factor=_POOLING_FACTOR,
+    )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA Graphs require a GPU")
+class DLRMCudaGraphTest(unittest.TestCase):
+    @torch.inference_mode()
+    def test_dense_path_parity(self) -> None:
+        """Compiled dense path must match eager outputs within fusion tolerance."""
+        device = torch.device("cuda")
+        model = _build_model(device)
+        batches = [_gen_batch(device) for _ in range(_PARITY_BATCHES)]
+
+        eager = collect_outputs(model, batches)
+
+        model.compile_dense_path()
+        # Idempotent: a second call must be a no-op.
+        model.compile_dense_path()
+
+        compiled = collect_outputs(model, batches)
+
+        max_abs_diff = max((e - c).abs().max().item() for e, c in zip(eager, compiled))
+        logger.info("max abs diff (eager vs cudagraph): %.3e", max_abs_diff)
+        # fp32 path; tolerance accounts for Inductor fusion/reduction reordering.
+        self.assertLess(max_abs_diff, 1e-3)
+
+    @torch.inference_mode()
+    def test_dense_path_runs_and_reports_speedup(self) -> None:
+        """End-to-end smoke + informational speedup (no hard threshold)."""
+        device = torch.device("cuda")
+        model = _build_model(device)
+        dense, kjt = _gen_batch(device)
+
+        def _time_ms(iters: int) -> float:
+            # Simple CPU wall-clock timing (runbook Step 4: Capture a Baseline).
+            # cudagraph_mark_step_begin() is required on the compiled replay path
+            # (the runbook's Step 4 snippet omits it because it times eager).
+            for _ in range(10):  # warmup
+                torch.compiler.cudagraph_mark_step_begin()
+                model(dense_features=dense, sparse_features=kjt)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(iters):
+                torch.compiler.cudagraph_mark_step_begin()
+                model(dense_features=dense, sparse_features=kjt)
+            torch.cuda.synchronize()
+            return (time.perf_counter() - t0) * 1000.0 / iters
+
+        baseline_ms = _time_ms(50)
+        model.compile_dense_path()
+        compiled_ms = _time_ms(50)
+
+        speedup_pct = (baseline_ms - compiled_ms) / baseline_ms * 100.0
+        logger.info(
+            "baseline=%.4f ms/step  cudagraph=%.4f ms/step  speedup=%+.1f%%",
+            baseline_ms,
+            compiled_ms,
+            speedup_pct,
+        )
+        self.assertGreater(baseline_ms, 0.0)
+        self.assertGreater(compiled_ms, 0.0)

--- a/torchrec/models/tests/test_dlrm.py
+++ b/torchrec/models/tests/test_dlrm.py
@@ -415,6 +415,35 @@ class DLRMTest(unittest.TestCase):
             )
         )
 
+    def test_compile_dense_path(self) -> None:
+        # compile_dense_path() wraps the dense compute path (dense_arch,
+        # inter_arch, over_arch) with torch.compile. Wrapping is lazy -- no graph
+        # is captured until a forward -- so this exercises the method on CPU
+        # without a GPU or an Inductor compile. It must also be idempotent.
+        D = 8
+        eb_config = EmbeddingBagConfig(
+            name="t1", embedding_dim=D, num_embeddings=100, feature_names=["f1"]
+        )
+        ebc = EmbeddingBagCollection(tables=[eb_config])
+        sparse_nn = DLRM(
+            embedding_bag_collection=ebc,
+            dense_in_features=100,
+            dense_arch_layer_sizes=[20, D],
+            over_arch_layer_sizes=[5, 1],
+        )
+
+        self.assertFalse(sparse_nn._cuda_graph_enabled)
+        sparse_nn.compile_dense_path()
+        self.assertTrue(sparse_nn._cuda_graph_enabled)
+        # The dense-path submodules are now torch.compile wrappers, not originals.
+        self.assertNotIsInstance(sparse_nn.dense_arch, DenseArch)
+        self.assertNotIsInstance(sparse_nn.inter_arch, InteractionArch)
+
+        # Idempotent: a second call returns early and leaves the wrappers intact.
+        compiled_dense_arch = sparse_nn.dense_arch
+        sparse_nn.compile_dense_path()
+        self.assertIs(sparse_nn.dense_arch, compiled_dense_arch)
+
     def test_one_sparse(self) -> None:
         B = 2
         D = 8


### PR DESCRIPTION
Summary:

Test potential speedup in DLRM model using `torch.compile()` (eg. [option A in this document](https://docs.google.com/document/d/1ImsxZ1TGEMT-wgJ1BpJtn7GXnaj1TlqeSpN0rqImuow/edit?tab=t.0)).

Testing indicates that there is no speedup.

Reviewed By: zhaozhul

Differential Revision: D110137165


