### PR TITLE
short-circuit invalid bucket sharding spec (#4402)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -118,7 +118,7 @@ class RunOptions(BenchFuncConfig):
     """
 
     world_size: int = 2
-    batch_size: int = 1024 * 32
+    batch_size: int = 1024 * 16
     num_batches: int = 10
     num_benchmarks: int = 5
     num_profiles: int = 2

--- a/torchrec/distributed/sharding_plan.py
+++ b/torchrec/distributed/sharding_plan.py
@@ -122,6 +122,12 @@ def calculate_shard_sizes_and_offsets(
     elif sharding_type == ShardingType.TABLE_WISE.value:
         return [[rows, columns]], [[0, 0]]
     elif sharding_type == ShardingType.ROW_WISE.value:
+        if num_buckets and num_buckets < world_size:
+            raise ValueError(
+                f"Number of buckets ({num_buckets}) must be >= the number of "
+                f"ranks ({world_size}): a bucket cannot be split across ranks. "
+                "Increase total_num_buckets or reduce world_size."
+            )
         return (
             _calculate_rw_shard_sizes_and_offsets(
                 rows, world_size, columns, num_buckets

--- a/torchrec/distributed/tests/test_sharding_plan.py
+++ b/torchrec/distributed/tests/test_sharding_plan.py
@@ -21,6 +21,7 @@ from torchrec.distributed.quant_embedding import (
 from torchrec.distributed.sharding_plan import (
     _calculate_rw_shard_sizes_and_offsets,
     _calculate_uneven_rw_shard_sizes_and_offsets,
+    calculate_shard_sizes_and_offsets,
     column_wise,
     construct_module_sharding_plan,
     data_parallel,
@@ -1357,6 +1358,18 @@ class RowWiseShardingTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             _calculate_rw_shard_sizes_and_offsets(
                 hash_size=100, num_devices=4, columns=16, num_buckets=7
+            )
+
+    def test_rw_sharding_num_buckets_less_than_world_size(self) -> None:
+        """Test that calculate_shard_sizes_and_offsets raises ValueError for row-wise sharding when num_buckets < world_size (a bucket cannot be split across ranks)"""
+        # num_buckets (3) < world_size (4); a bucket cannot be split across ranks
+        with self.assertRaises(ValueError):
+            calculate_shard_sizes_and_offsets(
+                tensor=torch.empty(12, 8),
+                world_size=4,
+                local_world_size=4,
+                sharding_type=ShardingType.ROW_WISE.value,
+                num_buckets=3,
             )
 
     def test_uneven_rw_sharding_hash_size_not_divisible_by_num_buckets(self) -> None:


### PR DESCRIPTION
Summary:

1. Early fail on sharding planner for invalid num_buckets spec
2. Reduce default batch size on benchmarker

Reviewed By: kausv

Differential Revision: D110366214


