### PR TITLE
memory_stashing: unwrap ShardedTensor/DTensor in optimizer-state collection (#4411)

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._tensor import DTensor
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -1052,6 +1054,8 @@ def _collect_cuda_tensors_from_value(
 
     Handles nested structures like:
     - Direct tensors
+    - Sharded optimizer state (ShardedTensor / DTensor), unwrapped to their
+      local shard tensor(s)
     - Tuples/lists of tensors (e.g., Shampoo's factor_matrices)
     - Objects with tensor attributes (e.g., ShampooKroneckerFactors)
     - Nested dicts
@@ -1067,7 +1071,16 @@ def _collect_cuda_tensors_from_value(
     """
     tensors: List[torch.Tensor] = []
 
-    if isinstance(value, torch.Tensor):
+    if isinstance(value, ShardedTensor):
+        for shard in value.local_shards():
+            tensors.extend(
+                _collect_cuda_tensors_from_value(shard.tensor, min_size_bytes)
+            )
+    elif isinstance(value, DTensor):
+        tensors.extend(
+            _collect_cuda_tensors_from_value(value.to_local(), min_size_bytes)
+        )
+    elif isinstance(value, torch.Tensor):
         if value.is_cuda and value.numel() > 0:
             tensor_size_bytes = value.numel() * value.element_size()
             if tensor_size_bytes >= min_size_bytes:

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import math
+import os
 import unittest
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
@@ -16,14 +17,21 @@ from unittest.mock import Mock, patch
 import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings
-from torch import nn
+from torch import distributed as dist, nn
+from torch.distributed._shard.sharded_tensor import init_from_local_shards, Shard
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
-from torchrec.distributed.memory_stashing import chunked_copy_, MemoryStashingManager
-from torchrec.modules.embedding_configs import DataType, PoolingType
+from torchrec.distributed.memory_stashing import (
+    _collect_cuda_tensors_from_value,
+    chunked_copy_,
+    MemoryStashingManager,
+)
+from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig, PoolingType
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
 
 
 class TestStashTensors(unittest.TestCase):
@@ -85,7 +93,9 @@ class TestStashTensors(unittest.TestCase):
         await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
             []
         )
-        # Should not raise
+        # No-op callbacks must be callable and must not raise.
+        self.assertTrue(callable(restore))
+        self.assertTrue(callable(await_restore))
         restore(None)
         await_restore(None)
 
@@ -856,9 +866,6 @@ class TestEmsConfigWiring(unittest.TestCase):
 
     def test_ebc_model_stash_weights_mutation(self) -> None:
         """Simulates the factory bridge: setting stash_weights=True on EBC configs in a model."""
-        from torchrec.modules.embedding_configs import EmbeddingBagConfig
-        from torchrec.modules.embedding_modules import EmbeddingBagCollection
-
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=100,
@@ -892,9 +899,6 @@ class TestEmsConfigWiring(unittest.TestCase):
 
     def test_ebc_model_stash_weights_not_set_when_disabled(self) -> None:
         """When EMS is disabled, stash_weights remains False on all EBC configs."""
-        from torchrec.modules.embedding_configs import EmbeddingBagConfig
-        from torchrec.modules.embedding_modules import EmbeddingBagCollection
-
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=100,
@@ -1091,5 +1095,65 @@ class ChunkedCopyTest(unittest.TestCase):
         self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestCollectCudaTensorsSharded(unittest.TestCase):
+    """``_collect_cuda_tensors_from_value`` must unwrap ShardedTensor / DTensor
+    optimizer state into their local CUDA shard tensors instead of crashing on
+    ``.is_cuda`` (which routes through their ``__torch_function__`` and raises).
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if not dist.is_available():
+            self.skipTest("torch.distributed not available")
+        self.device = torch.device("cuda:0")
+        self._created_pg = False
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="cpu:gloo,cuda:nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file:///tmp/trec_memstash_pg_{os.getpid()}",
+            )
+            self._created_pg = True
+
+    def tearDown(self) -> None:
+        if self._created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_collect_unwraps_sharded_tensor(self) -> None:
+        # 1024 * 512 * 4 bytes = 2MB, above the 1MB stash threshold.
+        local = torch.randn(1024, 512, device=self.device)
+        shard = Shard.from_tensor_and_offsets(local, shard_offsets=[0, 0], rank=0)
+        st = init_from_local_shards([shard], 1024, 512)
+
+        collected = _collect_cuda_tensors_from_value(st)
+
+        self.assertEqual(len(collected), 1)
+        self.assertTrue(collected[0].is_cuda)
+        self.assertEqual(collected[0].data_ptr(), local.data_ptr())
+
+    def test_collect_sharded_tensor_in_optimizer_state_dict(self) -> None:
+        # Mirrors the real failure: a sharded optimizer-state tensor nested in
+        # the per-param state dict, as iterated by ``stash_optimizer_state``.
+        local = torch.randn(1024, 512, device=self.device)
+        shard = Shard.from_tensor_and_offsets(local, shard_offsets=[0, 0], rank=0)
+        st = init_from_local_shards([shard], 1024, 512)
+        state_value = {"exp_avg": st, "step": torch.tensor(1)}
+
+        collected = _collect_cuda_tensors_from_value(state_value)
+
+        # exp_avg (sharded, 2MB) is collected; step (tiny CPU scalar) is skipped.
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0].data_ptr(), local.data_ptr())
+
+    def test_collect_unwraps_dtensor(self) -> None:
+        mesh = DeviceMesh("cuda", [0])
+        # 2MB, above the 1MB stash threshold.
+        local = torch.randn(1024, 512, device=self.device)
+        dt = distribute_tensor(local, mesh, [Replicate()])
+
+        collected = _collect_cuda_tensors_from_value(dt)
+
+        self.assertEqual(len(collected), 1)
+        self.assertTrue(collected[0].is_cuda)


### PR DESCRIPTION
Summary:

`_collect_cuda_tensors_from_value` now unwraps ShardedTensor / DTensor to their
local shard tensor(s) before the plain-tensor checks. These types subclass
torch.Tensor but route attribute access (e.g. `.is_cuda`) through
`__torch_function__`, which raises for them -- so sharded dense optimizer state
(e.g. Adam moments stored as ShardedTensor in optimizer.state) was silently
skipped instead of stashed. Adds unit tests for ShardedTensor / DTensor
collection (incl. nested in the per-param optimizer state dict).

Fix for issue found while iterating on V3 upstream model

Reviewed By: TroyGarden

Differential Revision: D109618266


