### PR TITLE
ZORM: re-pin metric state to CPU on first update to cover restores that bypass load_state_dict (#4412)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -303,6 +303,9 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         self._update_errors: int = 0
         self._compute_errors: int = 0
 
+        # One-shot guard: re-pin metric state to CPU on the first update.
+        self._metric_state_repinned: bool = False
+
         self.update_thread.start()
         self.compute_thread.start()
 
@@ -428,6 +431,18 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
 
             if required_inputs:
                 metric_update_job.kwargs["required_inputs"] = required_inputs
+
+            # Cover restores that write state in place (bypassing load_state_dict)
+            # and leave it off-CPU: re-pin once before the first update.
+            if not self._metric_state_repinned:
+                moved = self._repin_metric_state_to_cpu()
+                self._metric_state_repinned = True
+                if moved:
+                    logger.warning(
+                        f"CPUOffloadedRecMetricModule: re-pinned {moved} metric state "
+                        "tensors to CPU on first update; a checkpoint restore deposited "
+                        "non-CPU state without firing the load_state_dict post-hook."
+                    )
 
             self.rec_metrics.update(
                 predictions=predictions,
@@ -981,23 +996,17 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
         """
         pass
 
-    @staticmethod
-    def _move_state_to_cpu_after_load(
-        module: torch.nn.Module, incompatible_keys: Any
-    ) -> None:
-        """`load_state_dict` post-hook: move any non-CPU metric state back to CPU.
+    def _repin_metric_state_to_cpu(self) -> int:
+        """Move any non-CPU metric state tensor back to CPU; return the count moved.
 
         torchmetrics `add_state` stores state via `setattr` (not `register_buffer`),
-        and `_load_from_state_dict` writes loaded tensors the same way — so checkpoint
-        restores can deposit cuda state on a CPU-only metric, crashing the next
-        `update()`. Walk `_reductions` on each `RecMetricComputation` and move via
-        getattr/setattr.
+        so a checkpoint restore can deposit accelerator state on a CPU-only metric.
+        Walk `_reductions` on each `RecMetricComputation` and re-pin via
+        getattr/setattr. No-op once everything is already on CPU.
         """
-        if not isinstance(module, CPUOffloadedRecMetricModule):
-            return
         moved = 0
         with torch.no_grad():
-            for metric in module.rec_metrics.rec_metrics:
+            for metric in self.rec_metrics.rec_metrics:
                 for comp in metric._metrics_computations:  # pyre-ignore[16]
                     for attr_name in comp._reductions:
                         state = getattr(comp, attr_name, None)
@@ -1020,6 +1029,20 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                             if list_moved:
                                 setattr(comp, attr_name, new_list)
                                 moved += 1
+        return moved
+
+    @staticmethod
+    def _move_state_to_cpu_after_load(
+        module: torch.nn.Module, incompatible_keys: Any
+    ) -> None:
+        """`load_state_dict` post-hook: re-pin metric state to CPU after a restore.
+
+        Only fires on the `load_state_dict` path; in-place restores are covered by
+        the one-shot guard in `_process_metric_update_job`.
+        """
+        if not isinstance(module, CPUOffloadedRecMetricModule):
+            return
+        moved = module._repin_metric_state_to_cpu()
         if moved:
             logger.info(
                 f"CPUOffloadedRecMetricModule: moved {moved} state tensors to CPU after load_state_dict"

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -14,7 +14,7 @@ import random
 import threading
 import time
 import unittest
-from typing import Callable, cast, Optional
+from typing import Any, Callable, cast, Optional
 from unittest.mock import patch
 
 import torch
@@ -1969,6 +1969,56 @@ class LoadStateDictDevicePinTest(unittest.TestCase):
         after = self._get_first_state(cpu_module)
         self.assertEqual(after.device.type, "cpu")
         torch.testing.assert_close(before, after)
+
+    def _deposit_cuda_state_out_of_band(
+        self, cpu_module: CPUOffloadedRecMetricModule
+    ) -> tuple[Any, str]:
+        """Write cuda state via setattr, bypassing load_state_dict."""
+        # pyrefly: ignore[bad-index]
+        first_comp = cpu_module.rec_metrics.rec_metrics[0]._metrics_computations[
+            0
+        ]  # pyre-ignore[16]
+        attr_name = next(iter(first_comp._reductions))  # pyre-ignore[16]
+        with torch.no_grad():
+            setattr(first_comp, attr_name, getattr(first_comp, attr_name).to("cuda"))
+        self.assertEqual(getattr(first_comp, attr_name).device.type, "cuda")
+        return first_comp, attr_name
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "needs GPU")
+    def test_out_of_band_cuda_state_mismatches_without_repin(self) -> None:
+        """Out-of-band cuda state device-mismatches on a CPU-side add."""
+        cpu_module = self._make_module()
+        first_comp, attr_name = self._deposit_cuda_state_out_of_band(cpu_module)
+        state = getattr(first_comp, attr_name)
+        with self.assertRaisesRegex(RuntimeError, "two devices|same device"):
+            state.add_(torch.zeros(state.shape, dtype=state.dtype))
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "needs GPU")
+    def test_repin_helper_recovers_out_of_band_cuda_state(self) -> None:
+        """The re-pin helper recovers cuda state the post-hook can't see."""
+        cpu_module = self._make_module()
+        first_comp, attr_name = self._deposit_cuda_state_out_of_band(cpu_module)
+        moved = cpu_module._repin_metric_state_to_cpu()
+        self.assertGreaterEqual(moved, 1)
+        self.assertEqual(getattr(first_comp, attr_name).device.type, "cpu")
+
+    @unittest.skipIf(torch.cuda.device_count() < 1, "needs GPU")
+    def test_first_update_repins_out_of_band_cuda_state(self) -> None:
+        """First update re-pins out-of-band cuda state to CPU."""
+        cpu_module = self._make_module()
+        first_comp, attr_name = self._deposit_cuda_state_out_of_band(cpu_module)
+        self.assertFalse(cpu_module._metric_state_repinned)
+
+        model_out = {
+            "task1-prediction": torch.tensor([0.5, 0.7]),
+            "task1-label": torch.tensor([0.0, 1.0]),
+            "task1-weight": torch.tensor([1.0, 1.0]),
+        }
+        cpu_module._process_metric_update_job(MetricUpdateJob(model_out, {}, 1))
+
+        self.assertTrue(cpu_module._metric_state_repinned)
+        self.assertEqual(getattr(first_comp, attr_name).device.type, "cpu")
+        self.assertTrue(self.mock_metric.update_called())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

CPUOffloadedRecMetricModule keeps metric state on CPU so metric update/compute run off the training critical path. A checkpoint restore that does not go through nn.Module.load_state_dict can leave metric state on the accelerator, so the first update() after resume fails with "Expected all tensors to be on the same device, but found at least two devices". The existing load_state_dict post-hook only re-pins state for restores that call load_state_dict, so out-of-band restores are not covered. This adds a one-shot guard on the first metric update that re-pins any non-CPU metric state before it is consumed, making the update path correct regardless of how the checkpoint was restored. The device-pin walk is factored into a shared helper reused by the post-hook.

Reviewed By: micrain

Differential Revision: D110780329


