### PR TITLE
Fix InMemoryBinaryCriteoIterDataPipe construction when hashes is None

### DIFF
--- a/torchrec/datasets/criteo.py
+++ b/torchrec/datasets/criteo.py
@@ -779,7 +779,11 @@ class InMemoryBinaryCriteoIterDataPipe(IterableDataset):
         # pyrefly: ignore [bad-argument-type, implicit-import]
         np.random.seed(shuffle_training_set_random_seed)
         self.mmap_mode = mmap_mode
-        self.hashes: np.ndarray = np.array(hashes).reshape((1, CAT_FEATURE_COUNT))
+        self.hashes: Optional[np.ndarray] = (
+            np.array(hashes).reshape((1, CAT_FEATURE_COUNT))
+            if hashes is not None
+            else None
+        )
         self.path_manager_key = path_manager_key
         self.path_manager: "PathManager" = _get_path_manager(path_manager_key)
 

--- a/torchrec/datasets/tests/test_criteo.py
+++ b/torchrec/datasets/tests/test_criteo.py
@@ -540,3 +540,31 @@ class TestInMemoryBinaryCriteoIterDataPipe(CriteoTest):
         self._test_in_memory_training_set_shuffle([100] * 10, 32, 4, random_seed=100)
         self._test_in_memory_training_set_shuffle([10000], 128, 8, random_seed=0)
         self._test_in_memory_training_set_shuffle([10000], 128, 8, random_seed=100)
+
+    def test_dataset_default_hashes_none(self) -> None:
+        num_rows = 20
+        batch_size = 4
+        sparse = np.mgrid[0:num_rows, 0:CAT_FEATURE_COUNT][0].astype(np.int32)
+        with self._create_dataset_npys(num_rows=num_rows, sparse=sparse) as (
+            dense_path,
+            sparse_path,
+            labels_path,
+        ):
+            datapipe = InMemoryBinaryCriteoIterDataPipe(
+                stage="train",
+                dense_paths=[dense_path],
+                sparse_paths=[sparse_path],
+                labels_paths=[labels_path],
+                batch_size=batch_size,
+                rank=0,
+                world_size=1,
+            )
+            self.assertIsNone(datapipe.hashes)
+            row = 0
+            for batch in datapipe:
+                self._validate_batch(batch, batch_size=batch_size)
+                expected = sparse[row : row + batch_size, :].T.reshape(-1)
+                np.testing.assert_array_equal(
+                    batch.sparse_features.values().numpy(), expected
+                )
+                row += batch_size


### PR DESCRIPTION
Summary:
`InMemoryBinaryCriteoIterDataPipe` documents `hashes` as optional with a default of `None`, but the constructor unconditionally runs `np.array(hashes).reshape((1, CAT_FEATURE_COUNT))`. With the default, `np.array(None).reshape((1, 26))` raises, so the datapipe cannot actually be constructed without explicitly passing `hashes`, contradicting the docstring.

Fix: only build the reshaped array when `hashes is not None`; otherwise keep `self.hashes = None`. The attribute type becomes `Optional[np.ndarray]`. The downstream modulo path already applies hashing only when `self.hashes` is set, so leaving it `None` cleanly skips hashing and yields the raw category values.

Test Plan:
Added `test_dataset_default_hashes_none`, which constructs the datapipe without passing `hashes`, asserts `datapipe.hashes is None`, iterates the full dataset, and checks that each batch's sparse feature values match the raw, un-hashed input.

The new test fails on `main` (construction raises with `TypeError` from `np.array(None).reshape`) and passes with this change. Existing `test_criteo` cases continue to pass.

Fixes #2308
