### PR TITLE
Reland D110435026 with non-DI int4 (quint4x2) merge-sample lowering fix

### DIFF
--- a/torchrec/quant/embedding_modules.py
+++ b/torchrec/quant/embedding_modules.py
@@ -914,6 +914,12 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
             self.tbes: torch.nn.ModuleList = torch.nn.ModuleList(self._emb_modules)
         setattr(self, MODULE_ATTR_CACHE_FEATURES_ORDER, cache_features_order)
 
+    def _apply_maybe_quint4x2_to_int8(self, embedding: torch.Tensor) -> torch.Tensor:
+        # Overridable seam for the quint4x2 -> uint8 reinterpret. The base uses
+        # the portable int_repr()-based op; subclasses may swap in a zero-copy
+        # variant. Both keep the fx op name that downstream graph passes detect.
+        return _maybe_quint4x2_to_int8(embedding)
+
     def forward(
         self,
         features: KeyedJaggedTensor,
@@ -965,7 +971,7 @@ class EmbeddingCollection(EmbeddingCollectionInterface, ModuleNoCopyMixin):
                 if self.register_tbes
                 else emb_module.forward(indices=indices, offsets=offsets)
             )
-            lookup = _maybe_quint4x2_to_int8(lookup)
+            lookup = self._apply_maybe_quint4x2_to_int8(lookup)
             if getattr(self, MODULE_ATTR_USE_UNFLATTENED_LENGTHS_FOR_BATCHING, False):
                 lengths = _get_unflattened_lengths(lengths, len(embedding_names))
                 lookup = _get_batching_hinted_output(lengths=lengths, output=lookup)


### PR DESCRIPTION
Summary:
Relands D110435026 ([4/N] int4 (quint4x2) sparse output sample request correction), which was backed out by D111006252 after causing S683543 and S683708: a deterministic AOTINDUCTOR merge-net lowering crash `mat1 and mat2 shapes cannot be multiplied (512x2176 and 1088x512)` (2176 = 2x1088) on non-DI int4 models (`cfr_main_feed_mtml_roo_hstu`, preset `cfr_cint`, MI300X/GFX942).

Root cause (fixed here): for a non-DI model using on-device int4 (quint4x2) dequant, dense quantization builds the merge net at the halved boundary width (`in_features=1088`) and `generate_submod_inputs_for_packing` captures the matching halved merge sample into `submod_to_inputs`. But `simple_tgif_ien_executor` only forwarded `submod_to_inputs` to lowering when `distributed_inference_config` was set. Non-DI fell back to the full `model_inputs`, so `workspace_preparation.prepare_sample_input` regenerated the merge sample under a flag-less `SplitDispatchMode()` at the un-halved width (2176), mismatching the 1088 merge Linear and crashing AOTINDUCTOR. This is entirely in the trunk publish pipeline; the pinned `ien.lower` RE package only lowers the already-prepared graph and sample, so no `ien.lower` re-cut is required.

The executor now forwards the precomputed `submod_to_inputs` whenever the merge boundary is not the naive full-model shape: DI / universal sharding OR non-DI on-device int4. The on-device int4 decision is centralized into a single shared predicate `quint4x2_dequant_on_device_enabled` (`tgif/lib/utils`) used by all three deciding sites -- module shape-prop, submodule sample capture, and the lowering handoff -- so the sample width can no longer drift from the module width (the underlying defect).

Differential Revision: D111193072


