### PR TITLE
Fix _collective_tag_from being too expensive on wide RW-sharded models (#4418)

### DIFF
--- a/torchrec/distributed/_collective_tag.py
+++ b/torchrec/distributed/_collective_tag.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Deterministic tag for checking whether ranks agree on a collective.
+
+Callers pass identifying values (a label, feature keys, splits, etc.) and
+get back a 31-bit tag. All ranks that run the same collective with the
+same values compute the same tag. If two ranks compute different tags,
+they disagree on the collective they're trying to run.
+"""
+
+import hashlib
+from typing import List, Optional
+
+
+# Default per-part length limit for the hash. Each part contributes at most
+# this many bytes to the tag. Set high enough to cover realistic feature key
+# lists on wide models while keeping per-call cost bounded.
+_COLLECTIVE_TAG_MAX_BYTES: int = 32768
+
+
+def _append_bytes(buf: bytearray, p: object, remaining: int) -> int:
+    """Write p as bytes into buf. Stops after `remaining` bytes.
+
+    For a str or bytes, writes up to `remaining` bytes of it.
+    For a list or tuple, writes `L{count}\\x00` followed by each element
+    written the same way (recursively), with each element prefixed by
+    its own length so `["a,b"]` and `["a", "b"]` produce different bytes.
+    For anything else, converts to str and takes up to `remaining` bytes.
+
+    Returns the number of bytes written.
+    """
+    if remaining <= 0:
+        return 0
+    if isinstance(p, str):
+        # ASCII-only: code-point slicing may overshoot `remaining` on
+        # non-ASCII input. TorchRec feature keys are identifiers.
+        chunk = p[:remaining].encode()
+    elif isinstance(p, bytes):
+        chunk = p[:remaining]
+    elif isinstance(p, (list, tuple)):
+        header = f"L{len(p)}\x00".encode()[:remaining]
+        buf.extend(header)
+        written = len(header)
+        remaining -= written
+        for elem in p:
+            if remaining <= 0:
+                break
+            # Length-prefix each element to disambiguate boundaries
+            # within the per-part length limit. Past-limit elements
+            # may collide, e.g. at remaining=5 both "apple_pie" and
+            # "apple_bar" frame as "5\x00apple".
+            elem_buf = bytearray()
+            _append_bytes(elem_buf, elem, remaining)
+            frame = f"{len(elem_buf)}\x00".encode() + bytes(elem_buf)
+            chunk = frame[:remaining]
+            buf.extend(chunk)
+            written += len(chunk)
+            remaining -= len(chunk)
+        return written
+    else:
+        chunk = str(p).encode()[:remaining]
+    buf.extend(chunk)
+    return len(chunk)
+
+
+def _collective_tag_from(
+    *parts: object,
+    per_part_length_limits: Optional[List[Optional[int]]] = None,
+) -> int:
+    """Hash a list of parts into a single deterministic 31-bit tag.
+
+    Uses hashlib.blake2b, a C-implemented hash from the standard library.
+    The whole payload runs through a single native call instead of a
+    Python byte loop, so cost scales with C throughput not interpreter
+    overhead.
+
+    Each part contributes at most _COLLECTIVE_TAG_MAX_BYTES bytes to the
+    hash by default. Bytes past the limit are dropped and do not affect
+    the tag.
+
+    Pass per_part_length_limits (a list the same length as parts) with
+    None in a slot to hash that part in full instead of capping it. Use
+    this for values like splits, where any missed value would let a rank
+    disagreement go undetected.
+
+    The same parts always produce the same tag, on every rank. So if two
+    ranks compute this tag and get different values, we know they disagree
+    on something in the parts. Returns a non-negative value that fits in
+    signed int32.
+    """
+    if per_part_length_limits is None:
+        per_part_length_limits = [_COLLECTIVE_TAG_MAX_BYTES] * len(parts)
+    assert len(per_part_length_limits) == len(parts), (
+        f"per_part_length_limits length ({len(per_part_length_limits)}) "
+        f"must match parts length ({len(parts)})"
+    )
+    hasher = hashlib.blake2b(digest_size=4)
+    for i, (p, limit) in enumerate(zip(parts, per_part_length_limits)):
+        if i > 0:
+            hasher.update(b"\x00")
+        buf = bytearray()
+        # None means uncapped. Substitute a large limit so the whole
+        # part gets hashed. Any realistic part is well below this.
+        effective = limit if limit is not None else _UNCAPPED
+        _append_bytes(buf, p, effective)
+        hasher.update(bytes(buf))
+    # Mask to signed int32 so the tag fits an int32 splits tensor.
+    return int.from_bytes(hasher.digest(), "big") & 0x7FFFFFFF
+
+
+# Substitute for "no length limit on this part." Large enough that any
+# realistic tag part fits, small enough to avoid huge slice allocations.
+# Any tag part bigger than this is likely a bug.
+_UNCAPPED: int = 1 << 30  # 1 GiB

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -16,6 +16,10 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.autograd.profiler import record_function
+from torchrec.distributed._collective_tag import (
+    _collective_tag_from,
+    _COLLECTIVE_TAG_MAX_BYTES,
+)
 from torchrec.distributed.collective_utils import validate_collectives_enabled
 from torchrec.distributed.comm_ops import (
     all_gather_base_pooled,
@@ -139,38 +143,6 @@ _DTYPE_MAX: Dict[torch.dtype, int] = {
 }
 
 _TORCHREC_OVERFLOW_DEBUG: bool = os.environ.get("TORCHREC_OVERFLOW_DEBUG", "0") == "1"
-
-
-def _collective_tag_from(*parts: object) -> int:
-    """Compute a deterministic collective tag from identifying parts.
-
-    Returns a non-negative value that fits in signed int32. Uses FNV-1a
-    (deterministic across processes, unlike hash()).
-
-    The current call sites use int64 splits tensors, so a wider hash is
-    available in principle. The int32 cap is intentional forward-compat:
-    it guarantees the tag fits in any reasonable signed-integer splits dtype
-    without wrapping negative. Mixing runs in full 32-bit FNV-1a state and is
-    narrowed to 31 bits only at return; ~2.1B buckets leaves collision risk
-    negligible for the small number of distinct collective sites in flight
-    per process group.
-    """
-    # NUL separator (not ",") so str() of parts that themselves contain commas
-    # cannot collide with a different parts arity. Collective identifier parts
-    # (Python identifiers, sharding plan ints, container reprs) never contain
-    # \x00, so this separator is unambiguous in practice.
-    #
-    # In-loop mask is 0xFFFFFFFF (full 32-bit FNV-1a state); narrowing to
-    # signed int32 happens once at return. Masking to 31 bits inside the loop
-    # would discard bit 31 every iteration and weaken the avalanche relative
-    # to the reference algorithm without any benefit.
-    h = 0x811C9DC5
-    for b in "\x00".join(str(p) for p in parts).encode():
-        h = ((h ^ b) * 0x01000193) & 0xFFFFFFFF
-    # Post-loop mask still handles the empty-parts case: the FNV-1a seed
-    # (0x811C9DC5) exceeds signed-int32 max, so without this mask an empty
-    # call would violate the int32-fit contract.
-    return h & 0x7FFFFFFF
 
 
 def _safe_tolist_2d(tensor: torch.Tensor) -> List[List[int]]:
@@ -971,17 +943,26 @@ class KJTAllToAllSplitsAwaitable(Awaitable[KJTAllToAllTensorsAwaitable]):
         collective_tag: Optional[int] = None
         tag_parts: Optional[Tuple[object, ...]] = None
         if validate_collectives_enabled():
-            # Identity components, all rank-invariant by contract:
-            # - input.keys(): pre-AllToAll feature list (NOT local `keys`,
-            #   which is the post-AllToAll subset and differs per rank).
-            # - tuple(self._splits): the sharding plan — feature-to-rank
-            #   assignment from the constructor, documented as "Same for
-            #   all ranks." Including this catches divergent sharding
-            #   plans that have the same key set; without it, a config
-            #   bug giving ranks different splits would compute the same
-            #   tag and silently corrupt the all2all.
-            tag_parts = ("KJTAllToAllSplits", input.keys(), tuple(self._splits))
-            collective_tag = _collective_tag_from(*tag_parts)
+            # Values that all ranks must agree on:
+            # - input.keys(): the feature list BEFORE the all-to-all (not
+            #   the local `keys` variable, which is the post-all-to-all
+            #   subset and differs per rank).
+            # - splits: the feature-to-rank assignment. Passed with
+            #   length_limit=None so every value is hashed and a wide
+            #   keys list can't truncate a rank disagreement in splits.
+            tag_parts = (
+                "KJTAllToAllSplits",
+                input.keys(),
+                tuple(self._splits),
+            )
+            collective_tag = _collective_tag_from(
+                *tag_parts,
+                per_part_length_limits=[
+                    _COLLECTIVE_TAG_MAX_BYTES,
+                    _COLLECTIVE_TAG_MAX_BYTES,
+                    None,
+                ],
+            )
         self._splits_awaitable = SplitsAllToAllAwaitable(
             input_tensors,
             self._pg,

--- a/torchrec/distributed/embedding_sharding.py
+++ b/torchrec/distributed/embedding_sharding.py
@@ -16,9 +16,12 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import distributed as dist, nn
+from torchrec.distributed._collective_tag import (
+    _collective_tag_from,
+    _COLLECTIVE_TAG_MAX_BYTES,
+)
 from torchrec.distributed.collective_utils import validate_collectives_enabled
 from torchrec.distributed.dist_data import (
-    _collective_tag_from,
     KJTAllToAllTensorsAwaitable,
     SplitsAllToAllAwaitable,
 )
@@ -958,36 +961,45 @@ class FusedKJTListSplitsAwaitable(Awaitable[List[KJTListAwaitable]]):
         collective_tag: Optional[int] = None
         tag_parts: Optional[Tuple[object, ...]] = None
         if validate_collectives_enabled():
-            # Per-request rank-invariant identity, mirroring the tightening
-            # applied to KJTAllToAllSplitsAwaitable. A structural-only tag
-            # (e.g., len(splits_tensors) + self._lengths) collapses on real
-            # models: any two EBCs with identical KJT shape and sharding
-            # type produce the same `_lengths` vector, so a code-path
-            # divergence that fuses different module sets across ranks
-            # would compute the same tag and silently corrupt the all2all.
+            # Walk the fused list. For each real splits request, add
+            # its marker + splits + count + keys as parts. For each
+            # placeholder, add just its marker. Splits get length_limit=None
+            # so their full value is hashed and can't be truncated by a
+            # wide keys list. The "has_splits"/"no_splits" marker lets
+            # ranks detect when two ranks disagree on which slot is which.
             #
-            # Use aw._input.keys() (PRE-AllToAll keys, rank-invariant) —
-            # NOT aw.keys, which is the post-AllToAll local subset. Use
-            # tuple(aw.splits) for the per-request sharding plan
-            # (rank-invariant by KJTAllToAll's documented contract).
-            # Position-preserving: a None placeholder for non-meta
-            # awaitables keeps reordering detectable.
-            tag_parts = (
-                "FusedKJTListSplits",
-                tuple(
-                    (
+            # NOTE: parts_list and budgets_list must stay the same length.
+            # If you change what a request contributes, update both.
+            parts_list: List[object] = ["FusedKJTListSplits", len(self._awaitables)]
+            budgets_list: List[Optional[int]] = [
+                _COLLECTIVE_TAG_MAX_BYTES,  # "FusedKJTListSplits"
+                _COLLECTIVE_TAG_MAX_BYTES,  # len(self._awaitables)
+            ]
+            for aw in self._awaitables:
+                if isinstance(aw, KJTSplitsAllToAllMeta):
+                    parts_list.extend(
                         (
-                            tuple(aw._input.keys()),
+                            "has_splits",
                             tuple(aw.splits),
                             len(aw.splits_tensors),
+                            tuple(aw._input.keys()),
                         )
-                        if isinstance(aw, KJTSplitsAllToAllMeta)
-                        else None
                     )
-                    for aw in self._awaitables
-                ),
+                    budgets_list.extend(
+                        [
+                            _COLLECTIVE_TAG_MAX_BYTES,  # "has_splits"
+                            None,  # splits: uncapped
+                            _COLLECTIVE_TAG_MAX_BYTES,  # tensor count
+                            _COLLECTIVE_TAG_MAX_BYTES,  # keys
+                        ]
+                    )
+                else:
+                    parts_list.append("no_splits")
+                    budgets_list.append(_COLLECTIVE_TAG_MAX_BYTES)
+            tag_parts = tuple(parts_list)
+            collective_tag = _collective_tag_from(
+                *tag_parts, per_part_length_limits=budgets_list
             )
-            collective_tag = _collective_tag_from(*tag_parts)
         self._splits_awaitable: Optional[SplitsAllToAllAwaitable] = (
             SplitsAllToAllAwaitable(
                 input_tensors=splits_tensors,

--- a/torchrec/distributed/tests/test__collective_tag.py
+++ b/torchrec/distributed/tests/test__collective_tag.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List, Optional, Tuple
+
+from torchrec.distributed._collective_tag import (
+    _collective_tag_from,
+    _COLLECTIVE_TAG_MAX_BYTES,
+)
+
+
+class CollectiveTagFromTest(unittest.TestCase):
+    # Single-process unit tests for the _collective_tag_from helper.
+    _INT32_MAX = 0x7FFFFFFF
+
+    def test_empty_parts_fits_signed_int32(self) -> None:
+        # Empty parts must still produce a value that fits signed int32.
+        # blake2b returns a 4-byte digest; we mask to int31.
+        tag = _collective_tag_from()
+        self.assertGreaterEqual(tag, 0)
+        self.assertLessEqual(tag, self._INT32_MAX)
+
+    def test_various_parts_all_fit_signed_int32(self) -> None:
+        # Sanity check: the tag shapes both production call sites use
+        # produce non-negative int32 values. Splits are passed raw with
+        # length_limit=None so their full value is hashed.
+        _CAP = _COLLECTIVE_TAG_MAX_BYTES
+        # (parts, per_part_length_limits)
+        cases: List[Tuple[Tuple[object, ...], Optional[List[Optional[int]]]]] = [
+            # KJTAllToAllSplits: (name, keys, splits) with splits uncapped
+            (
+                ("KJTAllToAllSplits", ["f0", "f1"], (1, 1)),
+                [_CAP, _CAP, None],
+            ),
+            # FusedKJTListSplits flat shape: (name, count, "has_splits",
+            # splits, tensor count, keys, ..., "no_splits", ...).
+            (
+                (
+                    "FusedKJTListSplits",
+                    3,
+                    "has_splits",
+                    (1, 1),
+                    2,
+                    ("f0", "f1"),
+                    "no_splits",
+                    "has_splits",
+                    (1,),
+                    1,
+                    ("f2",),
+                ),
+                [_CAP, _CAP, _CAP, None, _CAP, _CAP, _CAP, _CAP, None, _CAP, _CAP],
+            ),
+            # Boundary: empty keys, empty splits
+            (("KJTAllToAllSplits", [], ()), [_CAP, _CAP, None]),
+            # Boundary: fused with zero requests
+            (("FusedKJTListSplits", 0), None),
+            # Long single string, guards against a length-related bug in the hash
+            (("x" * 1024,), None),
+        ]
+        for parts, budgets in cases:
+            with self.subTest(parts=parts):
+                tag = _collective_tag_from(*parts, per_part_length_limits=budgets)
+                self.assertGreaterEqual(tag, 0)
+                self.assertLessEqual(tag, self._INT32_MAX)
+
+    def test_intra_list_element_boundary_is_unambiguous(self) -> None:
+        # List elements are length-prefixed, so ["a,b", "c"] and
+        # ["a", "b,c"] must produce different tags.
+        self.assertNotEqual(
+            _collective_tag_from("X", ["a,b", "c"]),
+            _collective_tag_from("X", ["a", "b,c"]),
+        )
+
+    def test_doubly_nested_list_framing_disambiguates(self) -> None:
+        # Length-prefixing works through nested containers, so
+        # [[a, b], [c]] and [[a], [b, c]] must produce different tags.
+        self.assertNotEqual(
+            _collective_tag_from("X", [["a", "b"], ["c"]]),
+            _collective_tag_from("X", [["a"], ["b", "c"]]),
+        )
+
+    def test_separator_is_unambiguous(self) -> None:
+        # Parts are joined by NUL, which is safe because tag parts never
+        # contain \x00. Regression guard: if we ever used a printable
+        # separator, ("a", "b") and ("a,b") would produce the same bytes
+        # and hash to the same tag.
+        self.assertNotEqual(
+            _collective_tag_from("a", "b"),
+            _collective_tag_from("a,b"),
+        )
+
+    def test_length_divergence_detected(self) -> None:
+        # Lists of different lengths must produce different tags.
+        self.assertNotEqual(
+            _collective_tag_from("X", ["a"] * 10),
+            _collective_tag_from("X", ["a"] * 11),
+        )
+
+    def test_small_list_element_change_detected_via_iteration(self) -> None:
+        # When the list is small enough to fit in the length limit,
+        # any element change produces a different tag.
+        self.assertNotEqual(
+            _collective_tag_from("X", ["a"] * 10 + ["b"]),
+            _collective_tag_from("X", ["a"] * 10 + ["c"]),
+        )
+
+    def test_large_input_stays_in_int32_and_stays_deterministic(self) -> None:
+        # Even with a huge input, the tag stays in int32 range and
+        # is stable across repeated calls.
+        big = ["k"] * 100_000
+        tag_1 = _collective_tag_from("X", big)
+        tag_2 = _collective_tag_from("X", big)
+        self.assertEqual(tag_1, tag_2)
+        self.assertGreaterEqual(tag_1, 0)
+        self.assertLessEqual(tag_1, self._INT32_MAX)
+
+    def test_length_still_distinguished_beyond_cap(self) -> None:
+        # Two lists of different lengths must produce different tags
+        # even when both are past the length limit.
+        self.assertNotEqual(
+            _collective_tag_from("X", ["k"] * 100_000),
+            _collective_tag_from("X", ["k"] * 200_000),
+        )
+
+    def test_past_cap_middle_divergence_documented_collision(self) -> None:
+        # Documented blind spot: two lists that match up to the length
+        # limit produce the same tag, even if they differ past it.
+        a = ["padding"] * 10_000 + ["same_middle"] + ["padding"] * 9999 + ["tail"]
+        b = ["padding"] * 10_000 + ["diff_middle"] + ["padding"] * 9999 + ["tail"]
+        self.assertEqual(
+            _collective_tag_from("X", a),
+            _collective_tag_from("X", b),
+        )
+
+    def test_huge_scalar_string_and_bytes_bounded_allocation(self) -> None:
+        # A huge str or bytes gets truncated to the length limit, so it
+        # hashes to the same tag as its shorter prefix.
+        huge_str = "x" * 1_000_000
+        huge_bytes = b"x" * 1_000_000
+        prefix_str = "x" * _COLLECTIVE_TAG_MAX_BYTES
+        prefix_bytes = b"x" * _COLLECTIVE_TAG_MAX_BYTES
+        self.assertEqual(
+            _collective_tag_from("X", huge_str),
+            _collective_tag_from("X", prefix_str),
+        )
+        self.assertEqual(
+            _collective_tag_from("X", huge_bytes),
+            _collective_tag_from("X", prefix_bytes),
+        )
+
+    def test_fused_flat_shape_high_n_middle_splits_divergence(self) -> None:
+        # Each request's splits are passed with length_limit=None, so a
+        # change in one request's splits values is caught even when the
+        # surrounding keys are very wide.
+        _CAP = _COLLECTIVE_TAG_MAX_BYTES
+        huge_keys = tuple(f"feat_{i}" for i in range(5000))
+        splits_a = (2,) * 64 + (1,) * 63 + (2,)
+        splits_b = (2,) * 64 + (3,) * 63 + (2,)
+
+        def _flat(
+            divergent_at_7: Tuple[int, ...],
+        ) -> Tuple[Tuple[object, ...], List[Optional[int]]]:
+            parts: List[object] = ["FusedKJTListSplits", 15]
+            budgets: List[Optional[int]] = [_CAP, _CAP]
+            for j in range(15):
+                splits = divergent_at_7 if j == 7 else splits_a
+                parts.extend(("has_splits", splits, 1, huge_keys))
+                budgets.extend([_CAP, None, _CAP, _CAP])
+            return tuple(parts), budgets
+
+        parts_a, budgets_a = _flat(splits_a)
+        parts_b, budgets_b = _flat(splits_b)
+        self.assertNotEqual(
+            _collective_tag_from(*parts_a, per_part_length_limits=budgets_a),
+            _collective_tag_from(*parts_b, per_part_length_limits=budgets_b),
+        )
+
+    def test_fused_flat_shape_reordered_same_type_requests(self) -> None:
+        # Two requests with the same splits but different keys must
+        # produce different tags depending on their order.
+        _CAP = _COLLECTIVE_TAG_MAX_BYTES
+        splits = (2, 2, 2, 2)
+        req_a = ("has_splits", splits, 1, tuple(f"a{i}" for i in range(256)))
+        req_b = ("has_splits", splits, 1, tuple(f"b{i}" for i in range(256)))
+        budgets = [_CAP, _CAP] + [_CAP, None, _CAP, _CAP] * 2
+        self.assertNotEqual(
+            _collective_tag_from(
+                "FusedKJTListSplits",
+                2,
+                *req_a,
+                *req_b,
+                per_part_length_limits=budgets,
+            ),
+            _collective_tag_from(
+                "FusedKJTListSplits",
+                2,
+                *req_b,
+                *req_a,
+                per_part_length_limits=budgets,
+            ),
+        )
+
+    def test_rw_bucketized_keys_do_not_hide_splits(self) -> None:
+        # Realistic RW-bucketized shape: 78 features × 256 world_size
+        # replicas. Because splits are passed with length_limit=None,
+        # a change in a single split value is caught even with a very
+        # wide keys list.
+        _CAP = _COLLECTIVE_TAG_MAX_BYTES
+        bucketized_keys = [f"feat_{i}" for i in range(78)] * 256
+        splits_a = (78,) * 256
+        splits_b = (78,) * 128 + (77,) + (78,) * 127
+        self.assertNotEqual(
+            _collective_tag_from(
+                "KJTAllToAllSplits",
+                bucketized_keys,
+                splits_a,
+                per_part_length_limits=[_CAP, _CAP, None],
+            ),
+            _collective_tag_from(
+                "KJTAllToAllSplits",
+                bucketized_keys,
+                splits_b,
+                per_part_length_limits=[_CAP, _CAP, None],
+            ),
+        )
+
+    def test_tower_zero_heavy_split_destination_divergence(self) -> None:
+        # Cross-PG routing shape: mostly-zero splits with a nonzero
+        # entry that moves position. Different positions must produce
+        # different tags.
+        _CAP = _COLLECTIVE_TAG_MAX_BYTES
+        keys = [f"k{i}" for i in range(256)]
+        splits_a = (0, 0, 32, 0, 0, 0, 0, 0)
+        splits_b = (0, 0, 0, 32, 0, 0, 0, 0)
+        self.assertNotEqual(
+            _collective_tag_from(
+                "KJTAllToAllSplits",
+                keys,
+                splits_a,
+                per_part_length_limits=[_CAP, _CAP, None],
+            ),
+            _collective_tag_from(
+                "KJTAllToAllSplits",
+                keys,
+                splits_b,
+                per_part_length_limits=[_CAP, _CAP, None],
+            ),
+        )
+
+    def test_per_part_length_limits_none_slot_fully_hashes(self) -> None:
+        # A slot with limit=None hashes the entire part. This is what
+        # protects splits from truncation. Put the divergent value near
+        # the end of a long tuple so the default 32K-byte cap can't
+        # reach it: at 3 bytes/element under length-prefix framing, the
+        # cap covers ~10,900 elements.
+        n = 50000
+        splits_a = (2,) * (n - 1) + (1,)
+        splits_b = (2,) * (n - 1) + (3,)
+        # With uncapped slot: caught.
+        self.assertNotEqual(
+            _collective_tag_from("X", splits_a, per_part_length_limits=[None, None]),
+            _collective_tag_from("X", splits_b, per_part_length_limits=[None, None]),
+        )
+        # Without uncapped slot: NOT caught (default cap truncates
+        # before reaching the divergent value at the end).
+        self.assertEqual(
+            _collective_tag_from("X", splits_a),
+            _collective_tag_from("X", splits_b),
+        )
+
+    def test_per_part_length_limits_length_must_match_parts(self) -> None:
+        # Passing a budgets list of the wrong length is a programming
+        # error and should fail loudly.
+        with self.assertRaises(AssertionError):
+            _collective_tag_from(
+                "X",
+                "Y",
+                per_part_length_limits=[_COLLECTIVE_TAG_MAX_BYTES],
+            )

--- a/torchrec/distributed/tests/test_dist_data.py
+++ b/torchrec/distributed/tests/test_dist_data.py
@@ -30,9 +30,9 @@ import torch.distributed as dist
 import torchrec.distributed.collective_utils as cu
 from hypothesis import given, settings
 from pyre_extensions import none_throws
+from torchrec.distributed._collective_tag import _collective_tag_from
 from torchrec.distributed.dist_data import (
     _check_pg_for_nccl_error,
-    _collective_tag_from,
     _get_recat,
     JaggedTensorAllToAll,
     KJTAllToAll,
@@ -1574,75 +1574,6 @@ class GetRecatOverflowTest(unittest.TestCase):
         )
         self.assertIsNotNone(result)
         self.assertEqual(result.dtype, torch.int32)
-
-
-class CollectiveTagFromTest(unittest.TestCase):
-    # Single-process unit tests for the _collective_tag_from helper.
-    _INT32_MAX = 0x7FFFFFFF
-
-    def test_empty_parts_fits_signed_int32(self) -> None:
-        # Regression: the FNV-1a seed (0x811C9DC5) exceeds signed-int32 max,
-        # so a previous implementation that only masked inside the loop body
-        # returned the raw seed when parts was empty, violating the docstring's
-        # int32-fit contract and risking overflow in callers that assign the
-        # tag to an int32 splits tensor.
-        tag = _collective_tag_from()
-        self.assertGreaterEqual(tag, 0)
-        self.assertLessEqual(tag, self._INT32_MAX)
-
-    def test_various_parts_all_fit_signed_int32(self) -> None:
-        # Sanity: a range of realistic call shapes all stay within int32.
-        # Mirrors the actual tag shapes used by the two production call sites
-        # (KJTAllToAllSplitsAwaitable, FusedKJTListSplitsAwaitable). If FNV-1a's
-        # mixing changes or one of the call sites grows a new identity field,
-        # this catches a regression across both.
-        cases = [
-            # KJTAllToAllSplits production shape: (name, keys, tuple(splits))
-            ("KJTAllToAllSplits", ["f0", "f1"], (1, 1)),
-            # FusedKJTListSplits production shape: (name, tuple of per-request
-            # entries — meta entries are (keys, splits, count); non-meta is None).
-            (
-                "FusedKJTListSplits",
-                (
-                    (("f0", "f1"), (1, 1), 2),
-                    None,
-                    (("f2",), (1,), 1),
-                ),
-            ),
-            # Boundary: empty keys / empty splits
-            ("KJTAllToAllSplits", [], ()),
-            # Boundary: empty fused awaitables list
-            ("FusedKJTListSplits", ()),
-            # Long single string — guards against FNV-1a length-related issues
-            ("x" * 1024,),
-        ]
-        for parts in cases:
-            with self.subTest(parts=parts):
-                tag = _collective_tag_from(*parts)
-                self.assertGreaterEqual(tag, 0)
-                self.assertLessEqual(tag, self._INT32_MAX)
-
-    def test_deterministic(self) -> None:
-        # Determinism is the main reason this exists instead of hash().
-        # If the implementation accidentally introduces nondeterminism
-        # (e.g., switching to hash() under PYTHONHASHSEED randomization),
-        # different ranks would compute different tags and the validation
-        # would false-positive.
-        self.assertEqual(
-            _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3),
-            _collective_tag_from("KJTAllToAllSplits", ["f0", "f1"], 3),
-        )
-
-    def test_separator_is_unambiguous(self) -> None:
-        # Regression: with a "," separator, _collective_tag_from("a", "b") and
-        # _collective_tag_from("a,b") both serialize to the bytes b"a,b" and
-        # collide, silently disabling validation for any future call site that
-        # passes raw strings containing commas. The NUL separator avoids the
-        # collision because collective identifier parts cannot contain \x00.
-        self.assertNotEqual(
-            _collective_tag_from("a", "b"),
-            _collective_tag_from("a,b"),
-        )
 
 
 class SplitsAllToAllCollectiveTagTest(MultiProcessTestBase):


### PR DESCRIPTION
Summary:

Fix `_collective_tag_from` being too expensive on wide RW-sharded models.

The function hashes its inputs one byte at a time in Python. Row-wise sharding replicates the KJT keys list `num_features × world_size` times. On a wide model at 256 ranks the call could take up to ~100ms on the input-dist hot path.

This diff switches to `hashlib.blake2b(digest_size=4)` so the whole payload runs through a single native call. It also bumps the per-part length limit from 4K to 32K bytes for wider feature coverage. Splits still bypass the cap so any split-value disagreement is always caught.

Reviewed By: kausv

Differential Revision: D111329913


