### PR TITLE
Fix racy grad-norm reporting under VALUE/NONE clipping (#4421)

### DIFF
--- a/torchrec/optim/clipping.py
+++ b/torchrec/optim/clipping.py
@@ -152,14 +152,14 @@ class GradientClippingOptimizer(OptimizerWrapper):
 
         elif self._clipping == GradientClipping.VALUE:
             if self._track_grad_norm:
-                self._last_total_grad_norm, _ = self.compute_total_grad_norm()
+                self._last_total_grad_norm = self._compute_grad_norm_for_logging()
             torch.nn.utils.clip_grad_value_(
                 parameters=self._replicate_params, clip_value=self._max_gradient
             )
 
         elif self._clipping == GradientClipping.NONE:
             if self._track_grad_norm:
-                self._last_total_grad_norm, _ = self.compute_total_grad_norm()
+                self._last_total_grad_norm = self._compute_grad_norm_for_logging()
 
         super().step(closure)
         self._step_num += 1
@@ -169,6 +169,35 @@ class GradientClippingOptimizer(OptimizerWrapper):
         """Returns the total gradient norm from the most recent step, or None
         if no step has run yet."""
         return self._last_total_grad_norm
+
+    def _compute_grad_norm_for_logging(self) -> Optional[torch.Tensor]:
+        """Compute the total gradient norm for monitoring only (no clipping).
+
+        Uses torch's ``get_total_norm`` - the same on-device primitive the
+        non-sharded NORM clip path uses - instead of ``compute_total_grad_norm``.
+        The latter routes through ``_compute_total_norm``, which does a
+        ``non_blocking=True`` GPU->CPU copy of the norm and then reads it
+        immediately; that race intermittently yields a stale/near-zero value in
+        the logged metric. Keeping the reduction on-device avoids it.
+
+        Falls back to ``compute_total_grad_norm`` when sharded params require a
+        cross-rank reduction (VALUE clipping already forbids sharded params).
+        """
+        if len(self._sharded_params) != 0:
+            total_norm, _ = self.compute_total_grad_norm()
+            return total_norm
+        replicate_params = [
+            p._local_tensor if isinstance(p, DTensor) else p
+            for p in self._replicate_params
+        ]
+        grads = [
+            p.grad
+            for p in replicate_params
+            if p.grad is not None and p.grad.numel() > 0
+        ]
+        if not grads:
+            return None
+        return torch.nn.utils.get_total_norm(grads, norm_type=self._norm_type)
 
     def compute_total_grad_norm(
         self,

--- a/torchrec/optim/tests/test_clipping.py
+++ b/torchrec/optim/tests/test_clipping.py
@@ -347,6 +347,40 @@ class TestGradientClippingOptimizer(unittest.TestCase):
             atol=1e-08,
         )
 
+    def test_last_total_grad_norm_value_clipping_multi_params(self) -> None:
+        # VALUE + track_grad_norm aggregates the pre-clip norm across params via
+        # the on-device get_total_norm path (not the racy _compute_total_norm).
+        param_1 = Variable(torch.tensor([1.0, 2.0]), requires_grad=True)
+        param_2 = Variable(torch.tensor([3.0, 4.0]), requires_grad=True)
+
+        keyed_optimizer = DummyKeyedOptimizer(
+            {"param_1": param_1, "param_2": param_2},
+            {},
+            [{"params": [param_1]}, {"params": [param_2]}],
+        )
+
+        gradient_clipping_optimizer = GradientClippingOptimizer(
+            optimizer=keyed_optimizer,
+            max_gradient=1.0,
+            clipping=GradientClipping.VALUE,
+            track_grad_norm=True,
+        )
+
+        gradient_clipping_optimizer.zero_grad()
+        param_1.grad = torch.tensor([3.0, 4.0])
+        param_2.grad = torch.tensor([0.0, 12.0])
+        gradient_clipping_optimizer.step()
+
+        # norm is computed pre-clip over both params: sqrt(3^2+4^2+12^2) = 13
+        expected_norm = (3.0**2 + 4.0**2 + 12.0**2) ** 0.5
+        self.assertIsNotNone(gradient_clipping_optimizer.last_total_grad_norm)
+        torch.testing.assert_close(
+            gradient_clipping_optimizer.last_total_grad_norm,
+            torch.tensor(expected_norm),
+            rtol=1e-05,
+            atol=1e-08,
+        )
+
     def test_last_total_grad_norm_multi_params(self) -> None:
         param_1 = Variable(torch.tensor([3.0, 4.0]), requires_grad=True)
         param_2 = Variable(torch.tensor([6.0, 8.0]), requires_grad=True)


### PR DESCRIPTION
Summary:

`GradientClippingOptimizer.last_total_grad_norm` (consumed by the MVAI ranking pipeline and logged as `grad_norm/optimizer_*`) was intermittently reported as ~0 (e.g. `1e-22` / `5e-21`) for the dense Muon optimizer under `GradientClipping.VALUE` + `track_grad_norm=True`, even though the actual gradients were healthy and training was fine.

Root cause: the VALUE/NONE `track_grad_norm` path computes the norm via `compute_total_grad_norm()` -> `_compute_total_norm()`, which reduces the replicate-param norm on GPU and then does a `non_blocking=True` GPU->CPU copy (`.to(sharded_grad_norm.device, non_blocking=True)`, where `sharded_grad_norm` is a CPU `torch.tensor(0.0)`) and reads it immediately. The async copy into pageable host memory races with the read, so the stored norm intermittently reflects stale/near-zero host memory. This explains why the reported value oscillated between the true norm and `~1e-22`, why reading the same tensor compute-side vs reader-side gave different values, and why it was independent of the Muon CUDA graph. The NORM clip path was unaffected because `torch.nn.utils.clip_grad_norm_` / `get_total_norm` keep the reduction fully on-device.

Fix: for the VALUE/NONE `track_grad_norm` path, compute the monitoring norm with `torch.nn.utils.get_total_norm` (the same on-device primitive `clip_grad_norm_` uses), via a new `_compute_grad_norm_for_logging()` helper. It falls back to `compute_total_grad_norm()` when sharded params require a cross-rank reduction (VALUE clipping already forbids sharded params). `compute_total_grad_norm()` and the sharded / global-grad-clip path are unchanged.

Note (follow-up, out of scope): the same `non_blocking` GPU->CPU copy in `_compute_total_norm` still affects the sharded NORM global-grad-clip path, where a stale norm corrupts the actual clip coefficient (not just monitoring). That deserves its own diff.

Differential Revision: D111520970


