### PR TITLE
Enable embedding memory stashing for VLE modules (#4422)

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -1692,7 +1692,9 @@ class ShardedEmbeddingCollection(
             ):
                 embs = lookup(features)
                 if MemoryStashingManager.is_enabled():
-                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    stash_result = MemoryStashingManager.stash_embedding_weights(
+                        lookup, caller=self.__class__.__name__
+                    )
                     if stash_result is not None:
                         await_restore, *_ = stash_result
                         embs.register_hook(await_restore)

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -1977,7 +1977,9 @@ class ShardedEmbeddingBagCollection(
                     # pyrefly: ignore[not-callable]: `wait_for_forward` is dynamically checked
                     lookup.wait_for_forward()
                 if MemoryStashingManager.is_enabled():
-                    stash_result = MemoryStashingManager.stash_embedding_weights(lookup)
+                    stash_result = MemoryStashingManager.stash_embedding_weights(
+                        lookup, caller=self.__class__.__name__
+                    )
                     if stash_result is not None:
                         await_restore, _, _execute_stash = stash_result
                         embs.register_hook(await_restore)

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -31,12 +31,21 @@ _STASH_CHUNK_SIZE_BYTES: int = 32 * 1024**2
 
 
 def _tensor_size_text(tensor: Union[List[torch.Tensor], torch.Tensor]) -> str:
-    """Return a human-readable size string (MB or GB) for a tensor."""
+    """Return a human-readable size string (KB / MB / GB) for a tensor.
+
+    Uses a KB→MB→GB ladder so small stashed groups (e.g. VLE tables under a
+    shrunk ``max_ind_range``) are still legible in the ``record_function``
+    trace labels for size validation.
+    """
     if isinstance(tensor, list):
-        size_mb = sum(t.numel() * t.element_size() for t in tensor) / (1024**2)
+        size_bytes = sum(t.numel() * t.element_size() for t in tensor)
     else:
-        size_mb = tensor.numel() * tensor.element_size() / (1024**2)
-    if size_mb < 200:
+        size_bytes = tensor.numel() * tensor.element_size()
+    size_kb = size_bytes / 1024
+    if size_kb < 1024:
+        return f"{size_kb:.2f} KB"
+    size_mb = size_kb / 1024
+    if size_mb < 1024:
         return f"{size_mb:.2f} MB"
     return f"{size_mb / 1024:.2f} GB"
 
@@ -615,6 +624,7 @@ class MemoryStashingManager:
     def stash_embedding_weights(
         cls,
         lookup: nn.Module,
+        caller: str = "",
     ) -> Optional[
         Tuple[
             Callable[[Optional[torch.Tensor]], None],
@@ -692,12 +702,15 @@ class MemoryStashingManager:
                 continue
             tensors.append(weights_dev)
 
+        tensor_size = _tensor_size_text(tensors) if tensors else "0.00 Bytes"
         cls._log_ems_once(
             "ems_stash_embedding_weights_collected",
             {
+                "caller": caller,
                 "lookup": type(lookup).__name__,
                 "module": type(module).__name__,
                 "num_tensors": str(len(tensors)),
+                "tensor_size": tensor_size,
             },
         )
 


### PR DESCRIPTION
Summary:

The APS factory only sets `stash_weights=True` on `EmbeddingBagCollection` modules, completely missing `VariableLengthEmbeddingArch` (VLE) modules used for event-based features in omniFM and other UHM models. This causes VLE embedding weights to remain in HBM during dense forward/backward while EBC weights are stashed to CPU, creating severe GPU memory imbalance across ranks (observed 0.4% to 82.8% HBM utilization in test run `aps-V5_0427tk_128gpu_mega_ems-3bc8fb453f`).

Changes:
1. `ads_rec_train_factory.py`: Add `VariableLengthEmbeddingArch` to the factory loop that sets `stash_weights=True` on embedding configs before sharding. VLE tables now get marked for stashing alongside EBC tables.
2. `variable_length_embedding_arch.py`: Add `MemoryStashingManager.stash_embedding_weights()` call to the basic `compute()` method in `ShardedVariableLengthEmbeddingArch`. The fused `compute_and_output_dist()` path (used by pipelined training) already had this call; the basic path was missing it.

Note: The DCP checkpoint crash (`RuntimeError: Trying to resize storage that is not resizable`) is being addressed separately in D105632395.

Reviewed By: TroyGarden

Differential Revision: D105979017


