### PR TITLE
Migrate contained C10_LIKELY/C10_UNLIKELY to [[likely]]/[[unlikely]] (pytorch/torchrec) (#4425)

### DIFF
--- a/contrib/dynamic_embedding/src/tde/details/cacheline_id_transformer_impl.h
+++ b/contrib/dynamic_embedding/src/tde/details/cacheline_id_transformer_impl.h
@@ -93,7 +93,7 @@ inline bool CachelineIDTransformer<
     if (cache_id < 0) {
       if (empty_slot >= 0) {
         // The transformer is full.
-        if (C10_UNLIKELY(bitmap_.Full())) {
+        if (bitmap_.Full()) [[unlikely]] {
           return false;
         }
         auto& cache_value = group_begin[empty_slot];

--- a/contrib/dynamic_embedding/src/tde/details/mixed_lfu_lru_strategy.cpp
+++ b/contrib/dynamic_embedding/src/tde/details/mixed_lfu_lru_strategy.cpp
@@ -17,7 +17,7 @@ MixedLFULRUStrategy::lxu_record_t MixedLFULRUStrategy::Update(
   Record r{};
   r.time_ = time_->load();
 
-  if (C10_UNLIKELY(!val.has_value())) {
+  if (!val.has_value()) [[unlikely]] {
     r.freq_power_ = min_lfu_power_;
   } else {
     auto freq_power = reinterpret_cast<Record*>(&val.value())->freq_power_;

--- a/contrib/dynamic_embedding/src/tde/details/naive_id_transformer_impl.h
+++ b/contrib/dynamic_embedding/src/tde/details/naive_id_transformer_impl.h
@@ -25,7 +25,7 @@ inline int64_t Bitmap<T>::NextFreeBit() {
     offset++;
   }
   value = values_[offset];
-  if (C10_LIKELY(value)) {
+  if (value) [[likely]] {
     next_free_bit_ = offset * num_bits_per_value + Ctz(value);
   } else {
     next_free_bit_ = num_total_bits_;
@@ -71,7 +71,7 @@ inline bool NaiveIDTransformer<LXURecord, T>::Transform(
           update(iter->second.lxu_record_, global_id, cache_id);
     } else {
       // The transformer is full.
-      if (C10_UNLIKELY(bitmap_.Full())) {
+      if (bitmap_.Full()) [[unlikely]] {
         return false;
       }
       auto stored_cache_id = bitmap_.NextFreeBit();

--- a/contrib/dynamic_embedding/src/tde/details/random_bits_generator.cpp
+++ b/contrib/dynamic_embedding/src/tde/details/random_bits_generator.cpp
@@ -5,10 +5,10 @@
 namespace tde::details {
 
 bool BitScanner::IsNextNBitsAllZero(uint16_t& n_bits) {
-  if (C10_UNLIKELY((n_bits == 0))) {
+  if ((n_bits == 0)) [[unlikely]] {
     return true;
   }
-  if (C10_UNLIKELY(array_idx_ == size_)) {
+  if (array_idx_ == size_) [[unlikely]] {
     return true;
   }
 
@@ -80,7 +80,7 @@ bool RandomBitsGenerator::IsNextNBitsAllZero(uint16_t n_bits) {
     return false;
   }
 
-  if (C10_UNLIKELY(n_bits != 0)) {
+  if (n_bits != 0) [[unlikely]] {
     return IsNextNBitsAllZero(n_bits);
   } else {
     return true;

--- a/torchrec/csrc/dynamic_embedding/details/bitmap_impl.h
+++ b/torchrec/csrc/dynamic_embedding/details/bitmap_impl.h
@@ -32,7 +32,7 @@ inline int64_t Bitmap<T>::next_free_bit() {
     offset++;
   }
   value = values_[offset];
-  if (C10_LIKELY(value)) {
+  if (value) [[likely]] {
     next_free_bit_ = offset * num_bits_per_value + ctz(value);
   } else {
     next_free_bit_ = num_total_bits_;


### PR DESCRIPTION
Summary:

Migrates fully-contained uses of the `C10_LIKELY`/`C10_UNLIKELY` macros -- where the macro is the entire controlling condition of an `if`/`else if`/`while`/`for` -- to the standard C++20 `[[likely]]`/`[[unlikely]]` branch-prediction attributes, e.g. `if (C10_LIKELY(x))` becomes `if (x) [[likely]]`.

This diff is one of several split out from D111576576 by GitHub project, and contains only the changes under `fbcode/torchrec/`. Conditions where the macro is only one clause of a compound condition (`if (a && C10_LIKELY(b))`), `return C10_LIKELY(x);` forms, macro definitions, and `generated` files are deliberately left untouched.

The migration was performed by the `c10_likely_to_attr` codemod, landed as a companion diff.

This diff was authored with the assistance of an AI coding agent.

Differential Revision: D111945044


