### PR TITLE
memory_stashing: sliced (gradual) stash/restore API

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.autograd.profiler import record_function
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._tensor import DTensor
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -1065,6 +1067,8 @@ def _collect_cuda_tensors_from_value(
 
     Handles nested structures like:
     - Direct tensors
+    - Sharded optimizer state (ShardedTensor / DTensor), unwrapped to their
+      local shard tensor(s)
     - Tuples/lists of tensors (e.g., Shampoo's factor_matrices)
     - Objects with tensor attributes (e.g., ShampooKroneckerFactors)
     - Nested dicts
@@ -1080,7 +1084,16 @@ def _collect_cuda_tensors_from_value(
     """
     tensors: List[torch.Tensor] = []
 
-    if isinstance(value, torch.Tensor):
+    if isinstance(value, ShardedTensor):
+        for shard in value.local_shards():
+            tensors.extend(
+                _collect_cuda_tensors_from_value(shard.tensor, min_size_bytes)
+            )
+    elif isinstance(value, DTensor):
+        tensors.extend(
+            _collect_cuda_tensors_from_value(value.to_local(), min_size_bytes)
+        )
+    elif isinstance(value, torch.Tensor):
         if value.is_cuda and value.numel() > 0:
             tensor_size_bytes = value.numel() * value.element_size()
             if tensor_size_bytes >= min_size_bytes:

--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -363,6 +363,28 @@ class MemoryStashingManager:
             cls._optimizer_state_restore_callbacks.pop()(None, sync_event)
 
     @classmethod
+    def restore_optimizer_state_next(
+        cls,
+        _grad: Optional[torch.Tensor] = None,
+        sync_event: Optional[torch.cuda.Event] = None,
+    ) -> None:
+        """Pop and run exactly ONE optimizer-state restore callback (FIFO).
+
+        Used by the gradual (sliced) restore path: each PARAM_GRAD backward hook
+        restores the next slice. Slice 0 -- registered first, i.e. the
+        output-side / earliest-firing backward hook -- is restored first. No-op
+        when the callback stack is empty (e.g. all slices already restored by the
+        ``_step_optimizer`` pop-all guard, or hooks fired more times than there
+        are slices).
+        """
+        if cls._optimizer_state_restore_callbacks:
+            logger.info(
+                "restore_optimizer_state_next: restoring one slice "
+                f"({len(cls._optimizer_state_restore_callbacks)} remaining)"
+            )
+            cls._optimizer_state_restore_callbacks.pop(0)(None, sync_event)
+
+    @classmethod
     def _stash_tensors(
         cls,
         tensors: List[torch.Tensor],
@@ -913,6 +935,7 @@ class MemoryStashingManager:
         cls,
         optimizer: torch.optim.Optimizer,
         sync_event: Optional[torch.cuda.Event] = None,
+        num_slices: int = 1,
     ) -> Tuple[
         Callable[[Optional[torch.Tensor]], None],
         Callable[[Optional[torch.Tensor]], None],
@@ -932,11 +955,23 @@ class MemoryStashingManager:
 
         Args:
             optimizer: A PyTorch optimizer containing state tensors to stash.
+            sync_event: Optional CUDA event recorded on the caller's stream that
+                the D2H/H2D streams wait on (required when run on a background
+                thread). Forwarded to every slice's stash.
+            num_slices: Number of byte-balanced slices to partition the collected
+                state into for gradual restore. ``1`` (default) preserves the
+                single-shot behavior. When ``> 1`` each slice is stashed
+                independently and its restore is registered as a separate
+                callback (slice 0 first), to be driven per-hook via
+                ``restore_optimizer_state_next``; the returned ``await_restore``
+                then gates on ALL slices' restore completion.
 
         Returns:
             A tuple of two callback functions:
             - await_restore: Pauses current stream awaiting restore completion
+              (of all slices when ``num_slices > 1``)
             - restore: Retrieves stashed data from CPU back to HBM asynchronously
+              (all slices when ``num_slices > 1``)
 
         Usage:
             >>> await_restore, restore = MemoryStashingManager.stash_optimizer_state(optimizer)
@@ -971,16 +1006,58 @@ class MemoryStashingManager:
             },
         )
 
-        await_restore, restore, _execute_stash = cls._stash_tensors(
-            tensors, label="optimizer state", sync_event=sync_event
+        if num_slices <= 1:
+            await_restore, restore, _execute_stash = cls._stash_tensors(
+                tensors, label="optimizer state", sync_event=sync_event
+            )
+            cls._optimizer_state_restore_callbacks.append(restore)
+            return await_restore, restore
+
+        # Gradual (throttled) restore: partition the dense optimizer state into
+        # byte-balanced slices and stash each independently. Each slice's restore
+        # (resize_ + H2D) is registered as its own callback so it can be driven
+        # one-at-a-time by per-hook ``restore_optimizer_state_next`` calls placed
+        # at progressively deeper backward FQNs -- spreading the H2D bandwidth and
+        # deferring each slice's HBM allocation to a later point in backward.
+        slices = _partition_tensors_into_slices(tensors, num_slices)
+        logger.info(
+            f"stash_optimizer_state: partitioned {len(tensors)} tensors into "
+            f"{len(slices)} slices (requested {num_slices})"
         )
-        cls._optimizer_state_restore_callbacks.append(restore)
-        return await_restore, restore
+        slice_awaits: List[Callable[[Optional[torch.Tensor]], None]] = []
+        slice_restores: List[Callable[..., None]] = []
+        for k, slice_tensors in enumerate(slices):
+            await_restore_k, restore_k, _execute_stash_k = cls._stash_tensors(
+                slice_tensors,
+                label=f"optimizer state slice {k + 1}/{len(slices)}",
+                sync_event=sync_event,
+            )
+            slice_awaits.append(await_restore_k)
+            slice_restores.append(restore_k)
+            # Append in slice order so ``restore_optimizer_state_next`` (FIFO)
+            # maps slice k to the k-th hook to fire.
+            cls._optimizer_state_restore_callbacks.append(restore_k)
+
+        def aggregate_await(_grad: Optional[torch.Tensor] = None) -> None:
+            """Gate the current stream on EVERY slice's restore completion."""
+            for slice_await in slice_awaits:
+                slice_await(None)
+
+        def restore_all(
+            _grad: Optional[torch.Tensor] = None,
+            sync_event: Optional[torch.cuda.Event] = None,
+        ) -> None:
+            """Restore all slices (used when no per-hook driver is present)."""
+            for slice_restore in slice_restores:
+                slice_restore(None, sync_event)
+
+        return aggregate_await, restore_all
 
     @classmethod
     def stash_optimizer_state_threaded(
         cls,
         optimizer: torch.optim.Optimizer,
+        num_slices: int = 1,
     ) -> "Future[Tuple[Callable[[Optional[torch.Tensor]], None], Callable[[Optional[torch.Tensor]], None]]]":
         """
         Submit ``stash_optimizer_state`` to a background thread.
@@ -1003,7 +1080,9 @@ class MemoryStashingManager:
             Callable[[Optional[torch.Tensor]], None],
         ]:
             torch.cuda.set_device(device)
-            return cls.stash_optimizer_state(optimizer, sync_event=sync_event)
+            return cls.stash_optimizer_state(
+                optimizer, sync_event=sync_event, num_slices=num_slices
+            )
 
         return cls.thread_submit(_work)
 
@@ -1056,6 +1135,53 @@ class MemoryStashingManager:
             cls.restore_embedding_weights(sync_event=sync_event)
 
         return cls.thread_submit(_work)
+
+
+def _partition_tensors_into_slices(
+    tensors: List[torch.Tensor],
+    num_slices: int,
+) -> List[List[torch.Tensor]]:
+    """Partition ``tensors`` into at most ``num_slices`` byte-balanced sublists.
+
+    Tensors that share the same underlying storage (same
+    ``untyped_storage().data_ptr()``) are kept together in the same slice so a
+    ``resize_(0)`` / ``resize_(orig_size)`` pair is never split across slices
+    (splitting shared storage would free/realloc bytes another slice still
+    references, corrupting the buffer).
+
+    Uses a greedy longest-processing-time (LPT) assignment: storage groups are
+    sorted by descending byte size and each is placed into the currently
+    smallest slice. This is deterministic (stable sort + first-min tie-break),
+    keeping the slice schedule reproducible across ranks and in tests.
+
+    Returns the non-empty slices in order (slice 0 first). When there are fewer
+    storage groups than ``num_slices`` the result has fewer than ``num_slices``
+    slices.
+    """
+    if num_slices <= 1 or len(tensors) <= 1:
+        return [tensors] if tensors else []
+
+    # Group tensors by shared storage, preserving first-seen order.
+    groups: Dict[int, List[torch.Tensor]] = {}
+    for tensor in tensors:
+        storage_ptr = tensor.untyped_storage().data_ptr()
+        groups.setdefault(storage_ptr, []).append(tensor)
+
+    def group_bytes(group: List[torch.Tensor]) -> int:
+        # Count each distinct storage once; tensors in a group share storage.
+        return group[0].untyped_storage().nbytes()
+
+    n = min(num_slices, len(groups))
+    bins: List[List[torch.Tensor]] = [[] for _ in range(n)]
+    bin_bytes: List[int] = [0] * n
+
+    # Largest groups first; assign each to the currently smallest bin.
+    for group in sorted(groups.values(), key=group_bytes, reverse=True):
+        idx = min(range(n), key=lambda i: bin_bytes[i])
+        bins[idx].extend(group)
+        bin_bytes[idx] += group_bytes(group)
+
+    return [b for b in bins if b]
 
 
 def _collect_cuda_tensors_from_value(

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import math
+import os
 import unittest
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
@@ -16,14 +17,21 @@ from unittest.mock import Mock, patch
 import hypothesis.strategies as st
 import torch
 from hypothesis import given, settings
-from torch import nn
+from torch import distributed as dist, nn
+from torch.distributed._shard.sharded_tensor import init_from_local_shards, Shard
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, Replicate
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
     ShardedEmbeddingTable,
 )
-from torchrec.distributed.memory_stashing import chunked_copy_, MemoryStashingManager
-from torchrec.modules.embedding_configs import DataType, PoolingType
+from torchrec.distributed.memory_stashing import (
+    _collect_cuda_tensors_from_value,
+    chunked_copy_,
+    MemoryStashingManager,
+)
+from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig, PoolingType
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
 
 
 class TestStashTensors(unittest.TestCase):
@@ -85,7 +93,9 @@ class TestStashTensors(unittest.TestCase):
         await_restore, restore, _execute_stash = MemoryStashingManager._stash_tensors(
             []
         )
-        # Should not raise
+        # No-op callbacks must be callable and must not raise.
+        self.assertTrue(callable(restore))
+        self.assertTrue(callable(await_restore))
         restore(None)
         await_restore(None)
 
@@ -856,9 +866,6 @@ class TestEmsConfigWiring(unittest.TestCase):
 
     def test_ebc_model_stash_weights_mutation(self) -> None:
         """Simulates the factory bridge: setting stash_weights=True on EBC configs in a model."""
-        from torchrec.modules.embedding_configs import EmbeddingBagConfig
-        from torchrec.modules.embedding_modules import EmbeddingBagCollection
-
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=100,
@@ -892,9 +899,6 @@ class TestEmsConfigWiring(unittest.TestCase):
 
     def test_ebc_model_stash_weights_not_set_when_disabled(self) -> None:
         """When EMS is disabled, stash_weights remains False on all EBC configs."""
-        from torchrec.modules.embedding_configs import EmbeddingBagConfig
-        from torchrec.modules.embedding_modules import EmbeddingBagCollection
-
         tables = [
             EmbeddingBagConfig(
                 num_embeddings=100,
@@ -1091,5 +1095,65 @@ class ChunkedCopyTest(unittest.TestCase):
         self.assertTrue(torch.equal(dst.cpu(), src.cpu()))
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestCollectCudaTensorsSharded(unittest.TestCase):
+    """``_collect_cuda_tensors_from_value`` must unwrap ShardedTensor / DTensor
+    optimizer state into their local CUDA shard tensors instead of crashing on
+    ``.is_cuda`` (which routes through their ``__torch_function__`` and raises).
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if not dist.is_available():
+            self.skipTest("torch.distributed not available")
+        self.device = torch.device("cuda:0")
+        self._created_pg = False
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="cpu:gloo,cuda:nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file:///tmp/trec_memstash_pg_{os.getpid()}",
+            )
+            self._created_pg = True
+
+    def tearDown(self) -> None:
+        if self._created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_collect_unwraps_sharded_tensor(self) -> None:
+        # 1024 * 512 * 4 bytes = 2MB, above the 1MB stash threshold.
+        local = torch.randn(1024, 512, device=self.device)
+        shard = Shard.from_tensor_and_offsets(local, shard_offsets=[0, 0], rank=0)
+        st = init_from_local_shards([shard], 1024, 512)
+
+        collected = _collect_cuda_tensors_from_value(st)
+
+        self.assertEqual(len(collected), 1)
+        self.assertTrue(collected[0].is_cuda)
+        self.assertEqual(collected[0].data_ptr(), local.data_ptr())
+
+    def test_collect_sharded_tensor_in_optimizer_state_dict(self) -> None:
+        # Mirrors the real failure: a sharded optimizer-state tensor nested in
+        # the per-param state dict, as iterated by ``stash_optimizer_state``.
+        local = torch.randn(1024, 512, device=self.device)
+        shard = Shard.from_tensor_and_offsets(local, shard_offsets=[0, 0], rank=0)
+        st = init_from_local_shards([shard], 1024, 512)
+        state_value = {"exp_avg": st, "step": torch.tensor(1)}
+
+        collected = _collect_cuda_tensors_from_value(state_value)
+
+        # exp_avg (sharded, 2MB) is collected; step (tiny CPU scalar) is skipped.
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0].data_ptr(), local.data_ptr())
+
+    def test_collect_unwraps_dtensor(self) -> None:
+        mesh = DeviceMesh("cuda", [0])
+        # 2MB, above the 1MB stash threshold.
+        local = torch.randn(1024, 512, device=self.device)
+        dt = distribute_tensor(local, mesh, [Replicate()])
+
+        collected = _collect_cuda_tensors_from_value(dt)
+
+        self.assertEqual(len(collected), 1)
+        self.assertTrue(collected[0].is_cuda)

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -27,6 +27,7 @@ from torchrec.distributed.embedding_types import (
 )
 from torchrec.distributed.memory_stashing import (
     _collect_cuda_tensors_from_value,
+    _partition_tensors_into_slices,
     chunked_copy_,
     MemoryStashingManager,
 )
@@ -1157,3 +1158,205 @@ class TestCollectCudaTensorsSharded(unittest.TestCase):
 
         self.assertEqual(len(collected), 1)
         self.assertTrue(collected[0].is_cuda)
+
+
+class TestPartitionTensorsIntoSlices(unittest.TestCase):
+    """Tests for the byte-balanced slice partitioning helper (CUDA-free)."""
+
+    def test_single_slice_returns_all_tensors(self) -> None:
+        tensors = [torch.empty(100), torch.empty(200)]
+        slices = _partition_tensors_into_slices(tensors, num_slices=1)
+        self.assertEqual(len(slices), 1)
+        # num_slices <= 1 returns the original list unmodified.
+        self.assertIs(slices[0], tensors)
+
+    def test_nonpositive_slices_returns_all_tensors(self) -> None:
+        tensors = [torch.empty(100)]
+        slices = _partition_tensors_into_slices(tensors, num_slices=0)
+        self.assertEqual(len(slices), 1)
+        self.assertIs(slices[0], tensors)
+
+    def test_empty_tensor_list_returns_empty(self) -> None:
+        self.assertEqual(_partition_tensors_into_slices([], num_slices=4), [])
+
+    def test_partition_covers_every_tensor_exactly_once(self) -> None:
+        sizes = [100, 200, 300, 400, 500, 600, 700, 800]
+        tensors = [torch.empty(s, dtype=torch.float32) for s in sizes]
+        slices = _partition_tensors_into_slices(tensors, num_slices=4)
+        self.assertEqual(len(slices), 4)
+        flat = [t for one_slice in slices for t in one_slice]
+        self.assertCountEqual(
+            [t.data_ptr() for t in flat],
+            [t.data_ptr() for t in tensors],
+        )
+
+    def test_partition_is_byte_balanced(self) -> None:
+        sizes = [100, 200, 300, 400, 500, 600, 700, 800]
+        tensors = [torch.empty(s, dtype=torch.float32) for s in sizes]
+        slices = _partition_tensors_into_slices(tensors, num_slices=4)
+        bin_bytes = [
+            sum(t.numel() * t.element_size() for t in one_slice) for one_slice in slices
+        ]
+        # Greedy LPT keeps bins within a tensor's worth of each other.
+        self.assertLessEqual(max(bin_bytes) - min(bin_bytes), 800 * 4)
+
+    def test_shared_storage_tensors_stay_in_same_slice(self) -> None:
+        # Two views of one storage must never be split across slices (a
+        # resize_(0)/resize_(size) pair would otherwise corrupt the buffer).
+        base = torch.empty(1000, dtype=torch.float32)
+        view_a = base[:500]
+        view_b = base[500:]
+        other = torch.empty(4000, dtype=torch.float32)
+        tensors = [view_a, other, view_b]
+        slices = _partition_tensors_into_slices(tensors, num_slices=2)
+        slice_of_a = next(
+            i for i, s in enumerate(slices) if any(t is view_a for t in s)
+        )
+        slice_of_b = next(
+            i for i, s in enumerate(slices) if any(t is view_b for t in s)
+        )
+        self.assertEqual(slice_of_a, slice_of_b)
+
+    def test_fewer_groups_than_requested_slices(self) -> None:
+        tensors = [torch.empty(100), torch.empty(200)]
+        slices = _partition_tensors_into_slices(tensors, num_slices=5)
+        # Bounded by the number of distinct storage groups.
+        self.assertEqual(len(slices), 2)
+
+
+class TestStashOptimizerStateSliced(unittest.TestCase):
+    """Tests for gradual (sliced) optimizer-state stash/restore."""
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        self.device = torch.device("cuda:0")
+        MemoryStashingManager.set_streams(torch.cuda.Stream(device=self.device))
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+
+    def _adam_with_state(self) -> torch.optim.Optimizer:
+        # nn.Linear(512, 512): weight is exactly 1MB so Adam keeps two large
+        # state tensors (exp_avg, exp_avg_sq) -> the state forms 2 slices.
+        model = nn.Linear(512, 512).to(self.device)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001, foreach=True)
+        x = torch.randn(32, 512, device=self.device)
+        model(x).sum().backward()
+        optimizer.step()
+        return optimizer
+
+    def _clone_state(
+        self, optimizer: torch.optim.Optimizer
+    ) -> Dict[Any, Dict[str, torch.Tensor]]:
+        original: Dict[Any, Dict[str, torch.Tensor]] = {}
+        for param, state in optimizer.state.items():
+            if isinstance(state, dict):
+                original[param] = {
+                    k: v.clone()
+                    for k, v in state.items()
+                    if isinstance(v, torch.Tensor)
+                }
+        return original
+
+    def _assert_restored(
+        self,
+        optimizer: torch.optim.Optimizer,
+        original: Dict[Any, Dict[str, torch.Tensor]],
+    ) -> None:
+        for param, state in optimizer.state.items():
+            if param in original and isinstance(state, dict):
+                for key, value in state.items():
+                    if key in original[param]:
+                        self.assertTrue(
+                            torch.allclose(value, original[param][key]),
+                            f"State {key} not restored correctly",
+                        )
+
+    def test_sliced_stash_registers_one_callback_per_slice(self) -> None:
+        optimizer = self._adam_with_state()
+        MemoryStashingManager.stash_optimizer_state(optimizer, num_slices=2)
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_state_restore_callbacks), 2
+        )
+
+    def test_restore_optimizer_state_next_pops_one_slice(self) -> None:
+        optimizer = self._adam_with_state()
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
+            optimizer, num_slices=2
+        )
+        callbacks = MemoryStashingManager._optimizer_state_restore_callbacks
+        self.assertEqual(len(callbacks), 2)
+        MemoryStashingManager.restore_optimizer_state_next()
+        self.assertEqual(len(callbacks), 1)
+        MemoryStashingManager.restore_optimizer_state_next()
+        self.assertEqual(len(callbacks), 0)
+        # Popping again with an empty stack is a safe no-op.
+        MemoryStashingManager.restore_optimizer_state_next()
+        self.assertEqual(len(callbacks), 0)
+        await_restore(None)
+
+    def test_pop_all_restores_remaining_slices(self) -> None:
+        optimizer = self._adam_with_state()
+        original = self._clone_state(optimizer)
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
+            optimizer, num_slices=2
+        )
+        # Drive one slice via the per-hook path, the rest via the pop-all guard.
+        MemoryStashingManager.restore_optimizer_state_next()
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_state_restore_callbacks), 1
+        )
+        MemoryStashingManager.restore_optimizer_state()
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_state_restore_callbacks), 0
+        )
+        await_restore(None)
+        torch.cuda.synchronize()
+        self._assert_restored(optimizer, original)
+
+    def test_sliced_round_trip_matches_original(self) -> None:
+        optimizer = self._adam_with_state()
+        original = self._clone_state(optimizer)
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
+            optimizer, num_slices=2
+        )
+        # All large state tensors should be freed after the sliced stash.
+        for _param, state in optimizer.state.items():
+            if isinstance(state, dict):
+                for value in state.values():
+                    if (
+                        isinstance(value, torch.Tensor)
+                        and value.is_cuda
+                        and value.numel() * value.element_size() >= 1024 * 1024
+                    ):
+                        self.assertEqual(value.untyped_storage().size(), 0)
+        MemoryStashingManager.restore_optimizer_state()
+        await_restore(None)
+        torch.cuda.synchronize()
+        self._assert_restored(optimizer, original)
+
+    def test_sliced_optimizer_step_works_after_restore(self) -> None:
+        model = nn.Linear(512, 512).to(self.device)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.001, foreach=True)
+        x = torch.randn(32, 512, device=self.device)
+        model(x).sum().backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        weights_before = model.weight.detach().clone()
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
+            optimizer, num_slices=2
+        )
+        MemoryStashingManager.restore_optimizer_state()
+        await_restore(None)
+        # Another training step after the sliced restore must update weights.
+        model(torch.randn(32, 512, device=self.device)).sum().backward()
+        optimizer.step()
+        self.assertFalse(
+            torch.allclose(model.weight, weights_before),
+            "Weights should change after optimizer step",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add a sliced stash/restore API so the APS pipeline can spread the optimizer-state
restore across backward (gradual restore):
- `_partition_tensors_into_slices`: byte-balanced LPT partition that keeps
  shared-storage tensors in the same slice.
- `stash_optimizer_state(num_slices=N)`: stashes each slice independently and
  registers its restore as a separate FIFO callback (slice 0 first);
  `stash_optimizer_state_threaded` forwards num_slices.
- `restore_optimizer_state_next`: pops and runs exactly one slice's restore
  (driven per PARAM_GRAD backward hook); the pop-all guard restores the rest.
Adds unit tests for the partitioner and the sliced stash/restore lifecycle.

Differential Revision: D109727601


