### PR TITLE
Restore stashed tensors before 2D-sync allreduce (#4430)

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -1473,6 +1473,73 @@ class DMPCollection(DistributedModelParallel):
                 indices_slots=reserved_indices,
             )
 
+    def _restore_stashed_sync_tensors(
+        self,
+        ctx: DMPCollectionContext,
+        include_optimizer_state: bool = True,
+    ) -> None:
+        """Restore memory-stashed sync tensors to HBM before the 2D allreduce.
+
+        Memory stashing (e.g. EMS) frees a tensor's HBM via
+        ``storage.resize_(0)`` to reduce peak memory. If ``sync()`` runs while a
+        tensor it is about to allreduce is still stashed, the collective reads
+        freed memory and fails with ``cudaErrorIllegalAddress``. Restore any
+        stashed sync tensors first.
+
+        Gated so it costs nothing on the hot path: a no-op when memory stashing
+        is disabled and when the sync tensors are already resident (the
+        steady-state case, where the pipeline restores them during backward
+        before this post-backward sync). It restores only in the window that
+        would otherwise crash and does NOT re-stash -- the next forward
+        re-stashes as usual, so peak memory is unchanged and no extra D2H is
+        added.
+        """
+        # Local import to avoid any import cycle at module import time.
+        from torchrec.distributed.memory_stashing import MemoryStashingManager
+
+        if not MemoryStashingManager.is_enabled():
+            return
+
+        def _count_stashed(
+            tensors_by_dtype: Dict[torch.dtype, List[torch.Tensor]],
+        ) -> int:
+            return sum(
+                1
+                for tensors in tensors_by_dtype.values()
+                for t in tensors
+                if t.is_cuda and t.untyped_storage().size() == 0
+            )
+
+        num_weights_stashed = _count_stashed(ctx.weights_by_dtype)
+        num_optimizer_stashed = (
+            _count_stashed(ctx.optimizer_tensors_by_dtype)
+            if include_optimizer_state and ctx.optimizer_tensors_by_dtype
+            else 0
+        )
+
+        if num_weights_stashed == 0 and num_optimizer_stashed == 0:
+            # Steady state: tensors already resident -> nothing to do, no extra IO.
+            return
+
+        logger.warning(
+            "[DMP 2D-sync] memory-stashed tensors detected at sync "
+            "(stashed weights=%d, optimizer=%d); restoring to HBM before "
+            "allreduce to avoid an illegal memory access. If this fires every "
+            "step, the stash/restore ordering for these tensors needs review.",
+            num_weights_stashed,
+            num_optimizer_stashed,
+        )
+
+        if num_weights_stashed > 0:
+            MemoryStashingManager.restore_embedding_weights()
+        if num_optimizer_stashed > 0:
+            MemoryStashingManager.restore_optimizer_state()
+
+        # The restore H2D copies run on the stashing H2D stream; make the
+        # current (collective) stream wait for them before the allreduce reads
+        # the tensors.
+        torch.cuda.current_stream().wait_stream(MemoryStashingManager.h2d_stream())
+
     def _sync(
         self,
         ctx: DMPCollectionContext,
@@ -1487,6 +1554,12 @@ class DMPCollection(DistributedModelParallel):
               (if include_optimizer_state is True)
         """
         assert ctx.replica_pg is not None, "replica_pg is not initialized!"
+
+        # Memory stashing (e.g. EMS) may have freed the HBM of the TBE weight /
+        # fused-optimizer tensors this sync allreduces. Restore any that are
+        # currently stashed before the collective to avoid cudaErrorIllegalAddress.
+        # No-op when stashing is off or the tensors are already resident.
+        self._restore_stashed_sync_tensors(ctx, include_optimizer_state)
 
         opts = None
         if self._custom_all_reduce is None:

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -11,6 +11,7 @@ import math
 import os
 import unittest
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock, patch
 
@@ -31,6 +32,7 @@ from torchrec.distributed.memory_stashing import (
     chunked_copy_,
     MemoryStashingManager,
 )
+from torchrec.distributed.model_parallel import DMPCollection
 from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig, PoolingType
 from torchrec.modules.embedding_modules import EmbeddingBagCollection
 
@@ -1359,6 +1361,126 @@ class TestStashOptimizerStateSliced(unittest.TestCase):
             torch.allclose(model.weight, weights_before),
             "Weights should change after optimizer step",
         )
+
+
+class TestRestoreStashedSyncTensors(unittest.TestCase):
+    """Tests for DMPCollection._restore_stashed_sync_tensors (the 2D-sync IMA fix).
+
+    The helper restores any memory-stashed TBE weight / optimizer tensors back
+    to HBM before DMPCollection.sync()'s allreduce, so the collective never
+    reads freed memory (cudaErrorIllegalAddress). It is gated to be a no-op when
+    stashing is disabled or the tensors are already resident.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        self.device = torch.device("cuda:0")
+        MemoryStashingManager.set_streams(torch.cuda.Stream(device=self.device))
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+
+    def _call_helper(
+        self,
+        ctx: object,
+        include_optimizer_state: bool = True,
+    ) -> None:
+        # The method does not use `self`, so None is fine for this unit test.
+        # pyre-ignore[6]: None self (unused) + SimpleNamespace ctx are test stubs.
+        DMPCollection._restore_stashed_sync_tensors(None, ctx, include_optimizer_state)
+
+    def _stash(self, tensor: torch.Tensor) -> None:
+        """Stash a tensor via the embedding path (registers global restore)."""
+        inner = Mock()
+        inner.weights_dev = tensor
+        emb = Mock()
+        emb._emb_module = inner
+        lookup = Mock(spec=["_emb_modules"])
+        lookup._emb_modules = [emb]
+        self.assertIsNotNone(MemoryStashingManager.stash_embedding_weights(lookup))
+
+    def test_restores_stashed_weight_before_sync(self) -> None:
+        """A stashed sync weight view is restored bit-exact before the allreduce."""
+        # ``weights_dev`` is the TBE weight slab that EMS stashes; ``sync_view``
+        # mirrors the separate per-table tensor DMPCollection caches from
+        # ``split_embedding_weights()`` -- a view sharing weights_dev's storage.
+        weights_dev = torch.randn(256, 128, device=self.device)
+        original = weights_dev.clone()
+        sync_view = weights_dev.detach().view(-1)
+
+        self._stash(weights_dev)
+        # EMS re-points weights_dev to CPU, but the sync view keeps the original
+        # (now freed) CUDA storage -- exactly the signal the helper detects.
+        self.assertTrue(sync_view.is_cuda)
+        self.assertEqual(sync_view.untyped_storage().size(), 0)
+
+        ctx = SimpleNamespace(
+            weights_by_dtype={sync_view.dtype: [sync_view]},
+            optimizer_tensors_by_dtype={},
+        )
+        self._call_helper(ctx)
+        torch.cuda.synchronize()
+
+        # Restored to HBM and bit-exact, so a subsequent allreduce is safe.
+        self.assertGreater(sync_view.untyped_storage().size(), 0)
+        torch.testing.assert_close(
+            sync_view.view(256, 128), original, rtol=1e-05, atol=1e-08
+        )
+
+    def test_restores_stashed_optimizer_tensor(self) -> None:
+        """A stashed optimizer sync tensor view is also restored."""
+        # ``momentum_dev`` is the fused-optimizer slab that EMS stashes;
+        # ``sync_view`` mirrors the per-table tensor DMPCollection caches from
+        # ``get_optimizer_state()["sum"]`` -- a view sharing momentum_dev's
+        # storage. Stash through _stash_tensors and register on the optimizer
+        # callback stack directly to mirror optimizer stashing.
+        momentum_dev = torch.randn(512, 512, device=self.device)
+        original = momentum_dev.clone()
+        sync_view = momentum_dev.detach().view(-1)
+
+        _await, restore, _exec = MemoryStashingManager._stash_tensors([momentum_dev])
+        MemoryStashingManager._optimizer_state_restore_callbacks.append(restore)
+        # The sync view keeps the original (now freed) CUDA storage.
+        self.assertTrue(sync_view.is_cuda)
+        self.assertEqual(sync_view.untyped_storage().size(), 0)
+
+        ctx = SimpleNamespace(
+            weights_by_dtype={},
+            optimizer_tensors_by_dtype={sync_view.dtype: [sync_view]},
+        )
+        self._call_helper(ctx)
+        torch.cuda.synchronize()
+
+        self.assertGreater(sync_view.untyped_storage().size(), 0)
+        torch.testing.assert_close(
+            sync_view.view(512, 512), original, rtol=1e-05, atol=1e-08
+        )
+
+    def test_noop_when_tensors_resident(self) -> None:
+        """Steady state (tensors resident): no-op, data untouched, no extra IO."""
+        weight = torch.randn(64, 64, device=self.device)
+        original = weight.clone()
+        ctx = SimpleNamespace(
+            weights_by_dtype={weight.dtype: [weight]},
+            optimizer_tensors_by_dtype={},
+        )
+        self._call_helper(ctx)
+        torch.cuda.synchronize()
+        self.assertGreater(weight.untyped_storage().size(), 0)
+        torch.testing.assert_close(weight, original, rtol=1e-05, atol=1e-08)
+
+    def test_noop_when_stashing_disabled(self) -> None:
+        """When stashing is disabled the helper returns before touching streams."""
+        MemoryStashingManager.reset()
+        self.assertFalse(MemoryStashingManager.is_enabled())
+        weight = torch.randn(32, 32, device=self.device)
+        ctx = SimpleNamespace(
+            weights_by_dtype={weight.dtype: [weight]},
+            optimizer_tensors_by_dtype={},
+        )
+        # Must not raise (e.g. from h2d_stream() asserting an unset stream).
+        self._call_helper(ctx)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

Embedding Memory Stashing (EMS) frees TBE weight / optimizer-state HBM via
`storage.resize_(0)` to reduce peak memory. In 2D sparse-parallel training,
`DMPCollection.sync()` runs a cross-replica allreduce over those weight and
optimizer tensors. If the sync fires while a tensor it is about to allreduce is
still stashed (HBM freed), the collective reads freed device memory and crashes
with `cudaErrorIllegalAddress`.

Add `DMPCollection._restore_stashed_sync_tensors`, invoked from `_sync()` right
before the allreduce. It detects any memory-stashed sync tensors
(`is_cuda and untyped_storage().size() == 0`) and restores them to HBM first,
then makes the collective stream wait on the H2D restore stream so the allreduce
reads valid data. Gated to a no-op when memory stashing is disabled or the
tensors are already resident (the steady-state case where the pipeline restores
them during backward), so it costs nothing on the hot path and adds no extra D2H.

The checkpoint-staging variant of this same freed-HBM race (DCP stager) is
handled separately by D106558104.

Reviewed By: Fiery, TroyGarden

Differential Revision: D112018213


