### PR TITLE
SKUAware v1.5: cover Heuristical (OSS class + factory)

### DIFF
--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -40,6 +40,7 @@ class StorageReservationType(str, Enum):
     HEURISTIC = "heuristic"
     FIXED_PERCENTAGE = "fixed_percentage"
     FIXED_ABSOLUTE = "fixed_absolute"
+    SKU_AWARE = "sku_aware"
 
 
 def _get_module_size(module: nn.Module, multiplier: float) -> int:
@@ -264,6 +265,85 @@ class FixedAbsoluteStorageReservation(FixedPercentageStorageReservation):
         _reserve_storage_absolute(reserved_topology, self._hbm_reserved_bytes)
         self._last_reserved_topology = reserved_topology
         return reserved_topology
+
+
+class SKUAwareStorageReservation(StorageReservation):
+    """
+    Reserves a fixed absolute amount of HBM per device expressed in SKU-correct
+    terms: ``model_base_bytes`` (the hardware-independent footprint of the
+    non-sharded model, e.g. dense parameters, optimizer state, and DDP buffers)
+    plus ``runtime_overhead_bytes`` (the per-SKU runtime tax: driver/context,
+    NCCL buffers, and allocator fragmentation).
+
+    Unlike a percentage-of-HBM reservation, the reserved amount does not scale
+    with device capacity, so a model keeps the same reservation when it lands on
+    SKUs with different HBM caps. This avoids the cross-SKU mis-scaling that is a
+    dominant cause of planner OOM/failures under hardware fungibility.
+
+    Both inputs are hardware-aware values resolved by the caller (the OSS planner
+    cannot read the internal hardware registry); see the framework-side factory
+    that constructs this reservation from the resolved SKU.
+
+    Args:
+        model_base_bytes (int): hardware-independent non-sharded model footprint,
+            in bytes.
+        runtime_overhead_bytes (int): per-SKU runtime overhead, in bytes.
+    """
+
+    def __init__(self, model_base_bytes: int, runtime_overhead_bytes: int) -> None:
+        assert model_base_bytes >= 0
+        assert runtime_overhead_bytes >= 0
+        self._model_base_bytes: int = model_base_bytes
+        self._runtime_overhead_bytes: int = runtime_overhead_bytes
+        self._reserved_bytes: int = model_base_bytes + runtime_overhead_bytes
+        self._last_reserved_topology: Optional[Topology] = None
+
+    def reserve(
+        self,
+        topology: Topology,
+        batch_size: int,
+        module: nn.Module,
+        sharders: List[ModuleSharder[nn.Module]],
+        constraints: Optional[Dict[str, ParameterConstraints]] = None,
+    ) -> Topology:
+        reserved_topology = copy.deepcopy(topology)
+
+        # _reserve_storage_absolute floors at max(0, ...), which would silently
+        # hide a reservation that meets or exceeds available hbm. Guard explicitly
+        # (>=, since == leaves 0 hbm for sharded tables) so the over-reservation
+        # surfaces as an actionable error instead of a confusing downstream
+        # "could not place tables" failure.
+        available_hbm = reserved_topology.devices[0].storage.hbm
+        if self._reserved_bytes >= available_hbm:
+            reserved_gb = self._reserved_bytes / (1024**3)
+            model_base_gb = self._model_base_bytes / (1024**3)
+            overhead_gb = self._runtime_overhead_bytes / (1024**3)
+            insufficient_storage_solution = (
+                f"The SKU-aware storage reservation ({reserved_gb:.2f} GB per rank) "
+                "meets or exceeds the available hbm storage per rank "
+                f"({storage_repr_in_gb(topology.devices[0].storage)}), leaving no hbm "
+                "for sharded embedding tables, so it is not possible to find a valid "
+                "sharding plan. "
+                f"\n \n The reservation is model_base_bytes ({model_base_gb:.2f} GB) + "
+                f"runtime_overhead_bytes ({overhead_gb:.2f} GB). "
+                "\n \n Possible solutions:"
+                "\n  1) Reduce model_base_bytes (the non-sharded model footprint), "
+                "e.g. by supplying a more accurate measured estimate. "
+                "\n  2) Use hardware with a higher hbm cap. "
+            )
+            raise PlannerError(
+                error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
+                message=insufficient_storage_solution,
+            )
+
+        _reserve_storage_absolute(reserved_topology, self._reserved_bytes)
+        self._last_reserved_topology = reserved_topology
+        return reserved_topology
+
+    @property
+    def last_reserved_topology(self) -> Optional[Topology]:
+        "Returns a copy of the cached value of the most recent output from the reserve() method."
+        return copy.deepcopy(self._last_reserved_topology)
 
 
 class HeuristicalStorageReservation(StorageReservation):

--- a/torchrec/distributed/planner/storage_reservations.py
+++ b/torchrec/distributed/planner/storage_reservations.py
@@ -269,33 +269,64 @@ class FixedAbsoluteStorageReservation(FixedPercentageStorageReservation):
 
 class SKUAwareStorageReservation(StorageReservation):
     """
-    Reserves a fixed absolute amount of HBM per device expressed in SKU-correct
-    terms: ``model_base_bytes`` (the hardware-independent footprint of the
-    non-sharded model, e.g. dense parameters, optimizer state, and DDP buffers)
-    plus ``runtime_overhead_bytes`` (the per-SKU runtime tax: driver/context,
-    NCCL buffers, and allocator fragmentation).
+    SKU-correct replacement for HeuristicalStorageReservation. Reserves, per rank:
 
-    Unlike a percentage-of-HBM reservation, the reserved amount does not scale
-    with device capacity, so a model keeps the same reservation when it lands on
-    SKUs with different HBM caps. This avoids the cross-SKU mis-scaling that is a
-    dominant cause of planner OOM/failures under hardware fungibility.
+        reserved = model_base_bytes (STATIC: dense + margin)
+                 + kjt              (DYNAMIC, recomputed live from the local batch)
+                 + runtime_overhead_bytes
 
-    Both inputs are hardware-aware values resolved by the caller (the OSS planner
-    cannot read the internal hardware registry); see the framework-side factory
-    that constructs this reservation from the resolved SKU.
+    The STATIC base has two forms:
+      - computed (default): ``margin_bytes`` (``percentage * HBM[home]``, anchored to a FIXED
+        home SKU so it does not scale with the landing SKU) + ``dense`` (``params * multiplier``,
+        computed from the module, optionally overridden by ``dense_tensor_estimate``);
+      - provided: an explicit ``model_base_bytes`` (a user value, or a KR 2.9 measured static
+        base) that REPLACES the computed margin + dense.
+
+    The DYNAMIC term (``kjt`` today; a measured activation term later) is ALWAYS recomputed live
+    from the current local batch, so the reservation stays correct as the batch / world_size
+    changes (variable trainers, checkpoint-eval).
+
+    HeuristicalStorageReservation reserves ``dense + kjt + percentage * HBM[current]``; the last
+    term is the only one that scales with the device the job lands on, a dominant cause of
+    cross-SKU planner OOM/mis-scaling under hardware fungibility. With the computed static base
+    and ``runtime_overhead_bytes == 0``, this class is byte-identical to Heuristical on the home
+    SKU (an exact no-op) while being SKU-invariant. ``margin_bytes`` and ``runtime_overhead_bytes``
+    are resolved by the framework-side factory (the OSS planner cannot read the internal hardware
+    registry).
 
     Args:
-        model_base_bytes (int): hardware-independent non-sharded model footprint,
-            in bytes.
-        runtime_overhead_bytes (int): per-SKU runtime overhead, in bytes.
+        margin_bytes (int): home-anchored percentage margin (``percentage * HBM[home]``); used
+            only when ``model_base_bytes`` is not provided.
+        runtime_overhead_bytes (int): per-SKU runtime tax (driver/context, NCCL buffers,
+            allocator fragmentation); the slot for exact measured overhead (KR 2.9). Defaults
+            to 0 (exact Heuristical parity).
+        parameter_multiplier (float): dense-footprint multiplier for the computed dense
+            (parameter + optimizer + DDP); used only when ``model_base_bytes`` is not provided.
+        model_base_bytes (Optional[int]): explicit STATIC base (dense + margin) that replaces the
+            computed margin + dense when set (user-provided or a KR 2.9 measured static base).
+        dense_tensor_estimate (Optional[int]): explicit DENSE-only override for the computed path
+            (keeps the margin); used only when ``model_base_bytes`` is None - e.g. for FSDP /
+            dry-run, or a measured-dense value that should still get the margin on top.
     """
 
-    def __init__(self, model_base_bytes: int, runtime_overhead_bytes: int) -> None:
-        assert model_base_bytes >= 0
+    def __init__(
+        self,
+        margin_bytes: int,
+        runtime_overhead_bytes: int = 0,
+        parameter_multiplier: float = 6.0,
+        model_base_bytes: Optional[int] = None,
+        dense_tensor_estimate: Optional[int] = None,
+    ) -> None:
+        assert margin_bytes >= 0
         assert runtime_overhead_bytes >= 0
-        self._model_base_bytes: int = model_base_bytes
+        assert model_base_bytes is None or model_base_bytes >= 0
+        self._margin_bytes: int = margin_bytes
         self._runtime_overhead_bytes: int = runtime_overhead_bytes
-        self._reserved_bytes: int = model_base_bytes + runtime_overhead_bytes
+        self._parameter_multiplier: float = parameter_multiplier
+        self._model_base_bytes: Optional[int] = model_base_bytes
+        self._dense_tensor_estimate: Optional[int] = dense_tensor_estimate
+        self._dense_storage: Optional[Storage] = None
+        self._kjt_storage: Optional[Storage] = None
         self._last_reserved_topology: Optional[Topology] = None
 
     def reserve(
@@ -308,36 +339,91 @@ class SKUAwareStorageReservation(StorageReservation):
     ) -> Topology:
         reserved_topology = copy.deepcopy(topology)
 
-        # _reserve_storage_absolute floors at max(0, ...), which would silently
-        # hide a reservation that meets or exceeds available hbm. Guard explicitly
-        # (>=, since == leaves 0 hbm for sharded tables) so the over-reservation
-        # surfaces as an actionable error instead of a confusing downstream
-        # "could not place tables" failure.
-        available_hbm = reserved_topology.devices[0].storage.hbm
-        if self._reserved_bytes >= available_hbm:
-            reserved_gb = self._reserved_bytes / (1024**3)
-            model_base_gb = self._model_base_bytes / (1024**3)
+        batch_inputs, shardable_modules = _get_batch_inputs_and_shardable_parameters(
+            module, sharders, batch_size, constraints
+        )
+
+        # Static base as a flooring absolute, applied BEFORE the (non-flooring)
+        # module-derived terms so an over-reservation stays visible to the <= 0 guard
+        # (_reserve_storage_absolute floors at max(0, ...)). The static base is either
+        # an explicit model_base_bytes (dense + margin, provided/measured) or the
+        # home-anchored margin (with dense computed below). Overhead is also a flooring
+        # absolute, applied here for the same ordering reason.
+        _reserve_storage_absolute(
+            reserved_topology,
+            (
+                self._model_base_bytes
+                if self._model_base_bytes is not None
+                else self._margin_bytes
+            ),
+        )
+        _reserve_storage_absolute(reserved_topology, self._runtime_overhead_bytes)
+
+        # Computed dense (only when the static base is not explicitly provided) plus the
+        # live dynamic (kjt) term, recomputed from the current local batch every plan so
+        # the reservation stays correct across batch / world_size changes (VT, eval).
+        if self._model_base_bytes is None:
+            self._dense_storage = _reserve_dense_storage(
+                topology=reserved_topology,
+                module=module,
+                shardable_modules=shardable_modules,
+                multiplier=self._parameter_multiplier,
+                dense_tensor_estimate=self._dense_tensor_estimate,
+            )
+        self._kjt_storage = _reserve_kjt_storage(
+            topology=reserved_topology,
+            batch_size=batch_size,
+            batch_inputs=batch_inputs,
+            input_data_type_size=BIGINT_DTYPE,
+            # 2 pipelined batches each with 10 internal copies
+            multiplier=20,
+        )
+
+        # <= 0 (not < 0): the static base + overhead are flooring absolutes, so at the
+        # exact-capacity boundary (they consume all hbm and the module terms add 0) the
+        # remaining hbm lands at exactly 0, which leaves no room for sharded tables and
+        # is still infeasible. Catching it here surfaces an actionable reservation error
+        # instead of a confusing downstream "could not place tables" failure.
+        if reserved_topology.devices[0].storage.hbm <= 0:
+            if self._model_base_bytes is not None:
+                static_desc = (
+                    f"model_base_bytes {self._model_base_bytes / (1024**3):.2f} GB"
+                )
+                # An explicit static base was supplied, so there is no analytic dense to
+                # replace; the fix is to lower the provided value or the overhead.
+                reduce_static_solution = (
+                    "\n  1) Reduce model_base_bytes (the provided static base) or "
+                    "runtime_overhead_bytes. "
+                )
+            else:
+                static_desc = (
+                    f"home-anchored margin {self._margin_bytes / (1024**3):.2f} GB + "
+                    f"dense {storage_repr_in_gb(self._dense_storage)}"
+                )
+                reduce_static_solution = (
+                    "\n  1) Supply a measured model_base_bytes / dense_tensor_estimate "
+                    "(the analytic dense estimate over-counts under FSDP/dry-run). "
+                )
             overhead_gb = self._runtime_overhead_bytes / (1024**3)
             insufficient_storage_solution = (
-                f"The SKU-aware storage reservation ({reserved_gb:.2f} GB per rank) "
-                "meets or exceeds the available hbm storage per rank "
+                f"The SKU-aware storage reservation ({static_desc} + kjt "
+                f"{storage_repr_in_gb(self._kjt_storage)} + overhead {overhead_gb:.2f} GB) "
+                f"meets or exceeds the available hbm storage per rank "
                 f"({storage_repr_in_gb(topology.devices[0].storage)}), leaving no hbm "
                 "for sharded embedding tables, so it is not possible to find a valid "
                 "sharding plan. "
-                f"\n \n The reservation is model_base_bytes ({model_base_gb:.2f} GB) + "
-                f"runtime_overhead_bytes ({overhead_gb:.2f} GB). "
                 "\n \n Possible solutions:"
-                "\n  1) Reduce model_base_bytes (the non-sharded model footprint), "
-                "e.g. by supplying a more accurate measured estimate. "
-                "\n  2) Use hardware with a higher hbm cap. "
+                + reduce_static_solution
+                + f"\n  2) Reduce the local batch size ({batch_size}) to lower the kjt "
+                "storage. "
+                "\n  3) Use hardware with a higher hbm cap. "
             )
             raise PlannerError(
                 error_type=PlannerErrorType.INSUFFICIENT_STORAGE,
                 message=insufficient_storage_solution,
             )
 
-        _reserve_storage_absolute(reserved_topology, self._reserved_bytes)
-        self._last_reserved_topology = reserved_topology
+        self._last_reserved_topology = copy.deepcopy(reserved_topology)
         return reserved_topology
 
     @property

--- a/torchrec/distributed/planner/tests/test_storage_reservations.py
+++ b/torchrec/distributed/planner/tests/test_storage_reservations.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 import unittest
-from typing import cast, List
+from typing import cast, List, Optional
 
 from torch import nn
 from torchrec.distributed.embedding_tower_sharding import (
@@ -613,43 +613,84 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
         )
         return model, sharders
 
-    def test_reserves_model_base_plus_overhead(self) -> None:
+    def test_matches_heuristical_on_home_sku(self) -> None:
+        # No-regression: with overhead=0 and margin=percentage*hbm[home], on the
+        # home SKU SKUAware reserves exactly what HeuristicalStorageReservation
+        # does. Both compute dense + kjt from the same module via the same
+        # underlying primitives; the only difference is the margin (absolute) vs
+        # percentage term, which coincide when hbm[home] == the device hbm and
+        # percentage*hbm is integral.
         model, sharders = self._create_model_and_sharders()
-        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
-        topology = Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap)
+        hbm_cap = 8 * 1024 * 1024 * 1024  # 8 GB; 0.25 * cap is integral
+        percentage = 0.25
 
-        model_base_bytes = gb_to_bytes(2.0)
-        runtime_overhead_bytes = gb_to_bytes(0.5)
-        reservation = SKUAwareStorageReservation(
-            model_base_bytes=model_base_bytes,
-            runtime_overhead_bytes=runtime_overhead_bytes,
+        heuristical = HeuristicalStorageReservation(
+            percentage=percentage, parameter_multiplier=6.0
+        )
+        sku_aware = SKUAwareStorageReservation(
+            margin_bytes=int(percentage * hbm_cap),
+            runtime_overhead_bytes=0,
+            parameter_multiplier=6.0,
         )
 
-        reserved_topology = reservation.reserve(
-            topology=topology,
+        heuristical_topology = heuristical.reserve(
+            topology=Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+        sku_aware_topology = sku_aware.reserve(
+            topology=Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap),
             batch_size=10,
             module=model,
             sharders=sharders,
         )
 
-        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
-        self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
-        self.assertEqual(reserved_topology.devices[1].storage.hbm, expected_hbm)
+        self.assertEqual(
+            sku_aware_topology.devices[0].storage.hbm,
+            heuristical_topology.devices[0].storage.hbm,
+        )
+
+    def test_reserves_margin_and_overhead_on_top_of_dense_kjt(self) -> None:
+        # margin + overhead are reserved in addition to the computed dense + kjt,
+        # so a reservation with margin M and overhead O reserves exactly M + O
+        # more than one with zero margin/overhead on the same model.
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 20 * 1024 * 1024 * 1024
+        margin_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
+
+        def _reserve(margin: int, overhead: int) -> int:
+            reserved = SKUAwareStorageReservation(
+                margin_bytes=margin,
+                runtime_overhead_bytes=overhead,
+            ).reserve(
+                topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+            return reserved.devices[0].storage.hbm
+
+        with_flat = _reserve(margin_bytes, runtime_overhead_bytes)
+        without_flat = _reserve(0, 0)
+        self.assertEqual(
+            without_flat - with_flat, margin_bytes + runtime_overhead_bytes
+        )
 
     def test_reservation_is_invariant_across_hbm_caps(self) -> None:
-        # The defining SKU-aware property: the reserved amount is absolute and
-        # does not scale with device hbm, so a model reserves the same bytes
-        # regardless of the SKU it lands on (unlike percentage-of-hbm).
+        # The defining SKU-aware property: with a fixed home-anchored margin the
+        # reserved amount does not scale with device hbm, so a model reserves the
+        # same bytes regardless of the SKU it lands on (unlike percentage-of-hbm).
         model, sharders = self._create_model_and_sharders()
-        model_base_bytes = gb_to_bytes(3.0)
-        runtime_overhead_bytes = gb_to_bytes(1.0)
-        expected_reserved = model_base_bytes + runtime_overhead_bytes
+        margin_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
 
         small_cap = 16 * 1024 * 1024 * 1024
         large_cap = 80 * 1024 * 1024 * 1024
 
         small_reserved = SKUAwareStorageReservation(
-            model_base_bytes=model_base_bytes,
+            margin_bytes=margin_bytes,
             runtime_overhead_bytes=runtime_overhead_bytes,
         ).reserve(
             topology=Topology(world_size=1, compute_device="cuda", hbm_cap=small_cap),
@@ -658,7 +699,7 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
             sharders=sharders,
         )
         large_reserved = SKUAwareStorageReservation(
-            model_base_bytes=model_base_bytes,
+            margin_bytes=margin_bytes,
             runtime_overhead_bytes=runtime_overhead_bytes,
         ).reserve(
             topology=Topology(world_size=1, compute_device="cuda", hbm_cap=large_cap),
@@ -668,39 +709,112 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
         )
 
         self.assertEqual(
-            small_cap - small_reserved.devices[0].storage.hbm, expected_reserved
-        )
-        self.assertEqual(
-            large_cap - large_reserved.devices[0].storage.hbm, expected_reserved
+            small_cap - small_reserved.devices[0].storage.hbm,
+            large_cap - large_reserved.devices[0].storage.hbm,
         )
 
-    def test_zero_reservation_matches_no_reservation(self) -> None:
+    def test_dense_tensor_estimate_overrides_computed(self) -> None:
+        # An explicit dense estimate overrides the computed dense footprint, so a
+        # larger estimate reserves proportionally more.
         model, sharders = self._create_model_and_sharders()
-        hbm_cap = 10 * 1024 * 1024 * 1024
-        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+        hbm_cap = 20 * 1024 * 1024 * 1024
+        margin_bytes = gb_to_bytes(1.0)
+
+        def _reserve_with_dense(dense_gb: float) -> int:
+            reserved = SKUAwareStorageReservation(
+                margin_bytes=margin_bytes,
+                dense_tensor_estimate=gb_to_bytes(dense_gb),
+            ).reserve(
+                topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+            return reserved.devices[0].storage.hbm
+
+        small_dense_hbm = _reserve_with_dense(1.0)
+        large_dense_hbm = _reserve_with_dense(3.0)
+        self.assertEqual(small_dense_hbm - large_dense_hbm, gb_to_bytes(2.0))
+
+    def test_model_base_bytes_replaces_static_base(self) -> None:
+        # An explicit model_base_bytes REPLACES the whole static base: the
+        # reservation becomes model_base_bytes + kjt + overhead, with neither the
+        # home-anchored margin nor the computed dense added on top. Reserving
+        # against a kjt-only baseline (static base == 0) must give back exactly
+        # model_base_bytes - proving dense is not double-counted.
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 20 * 1024 * 1024 * 1024
+        model_base_bytes = gb_to_bytes(3.0)
+
+        def _reserve(margin: int, model_base: Optional[int]) -> int:
+            reserved = SKUAwareStorageReservation(
+                margin_bytes=margin,
+                model_base_bytes=model_base,
+            ).reserve(
+                topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+            return reserved.devices[0].storage.hbm
+
+        # Static base == 0 reserves only kjt; the baseline for the delta below.
+        kjt_only = _reserve(margin=0, model_base=0)
+        # A deliberately large margin that MUST be ignored when model_base is set.
+        with_model_base = _reserve(margin=gb_to_bytes(5.0), model_base=model_base_bytes)
+        self.assertEqual(kjt_only - with_model_base, model_base_bytes)
+
+    def test_model_base_bytes_ignores_margin(self) -> None:
+        # When model_base_bytes is set, margin_bytes has no effect (the static
+        # base is fully replaced), so two different margins reserve identically.
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 20 * 1024 * 1024 * 1024
+        model_base_bytes = gb_to_bytes(3.0)
+
+        def _reserve(margin: int) -> int:
+            reserved = SKUAwareStorageReservation(
+                margin_bytes=margin,
+                model_base_bytes=model_base_bytes,
+            ).reserve(
+                topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+            return reserved.devices[0].storage.hbm
+
+        self.assertEqual(_reserve(gb_to_bytes(1.0)), _reserve(gb_to_bytes(4.0)))
+
+    def test_model_base_bytes_skips_dense_computation(self) -> None:
+        # With an explicit static base the computed-dense branch is skipped, so
+        # _dense_storage stays None while _kjt_storage (the live term) is set.
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 20 * 1024 * 1024 * 1024
 
         reservation = SKUAwareStorageReservation(
-            model_base_bytes=0, runtime_overhead_bytes=0
+            margin_bytes=0,
+            model_base_bytes=gb_to_bytes(3.0),
         )
-
-        reserved_topology = reservation.reserve(
-            topology=topology,
+        reservation.reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
             batch_size=10,
             module=model,
             sharders=sharders,
         )
 
-        self.assertEqual(reserved_topology.devices[0].storage.hbm, hbm_cap)
+        self.assertIsNone(reservation._dense_storage)
+        self.assertIsNotNone(reservation._kjt_storage)
 
-    def test_insufficient_storage_raises(self) -> None:
+    def test_over_capacity_raises(self) -> None:
         model, sharders = self._create_model_and_sharders()
         hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
         topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
 
-        # Reserve more than the device can provide.
+        # Dense estimate alone exceeds what is left after the margin, driving the
+        # available hbm negative (the <= 0 guard must fire).
         reservation = SKUAwareStorageReservation(
-            model_base_bytes=gb_to_bytes(9.0),
-            runtime_overhead_bytes=gb_to_bytes(2.0),
+            margin_bytes=gb_to_bytes(2.0),
+            dense_tensor_estimate=gb_to_bytes(9.0),
         )
 
         with self.assertRaises(PlannerError) as context:
@@ -716,20 +830,32 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
         )
 
     def test_exact_capacity_raises(self) -> None:
-        # reserved == available leaves 0 hbm for sharded tables, which is still
-        # infeasible, so the boundary must raise (the >= guard).
+        # Boundary: when the full reservation (static base + overhead + kjt) exactly
+        # equals available hbm, 0 hbm is left for sharded tables -- still infeasible,
+        # so the <= 0 guard must fire (not only the strictly-negative case). Size the
+        # static base against the live kjt so the reservation lands exactly at capacity.
         model, sharders = self._create_model_and_sharders()
-        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
-        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+        hbm_cap = 20 * 1024 * 1024 * 1024
 
-        reservation = SKUAwareStorageReservation(
-            model_base_bytes=gb_to_bytes(8.0),
-            runtime_overhead_bytes=gb_to_bytes(2.0),
+        # Measure the live kjt term on a roomy cap (static base 0 -> no raise).
+        probe = SKUAwareStorageReservation(margin_bytes=0, model_base_bytes=0)
+        probe.reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
         )
+        kjt_storage = probe._kjt_storage
+        assert kjt_storage is not None
 
+        # model_base_bytes == cap - kjt, overhead 0 -> reserved == cap -> hbm == 0.
+        reservation = SKUAwareStorageReservation(
+            margin_bytes=0,
+            model_base_bytes=hbm_cap - kjt_storage.hbm,
+        )
         with self.assertRaises(PlannerError) as context:
             reservation.reserve(
-                topology=topology,
+                topology=Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap),
                 batch_size=10,
                 module=model,
                 sharders=sharders,
@@ -744,16 +870,14 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
         hbm_cap = 10 * 1024 * 1024 * 1024
         topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
 
-        model_base_bytes = gb_to_bytes(2.0)
-        runtime_overhead_bytes = gb_to_bytes(0.5)
         reservation = SKUAwareStorageReservation(
-            model_base_bytes=model_base_bytes,
-            runtime_overhead_bytes=runtime_overhead_bytes,
+            margin_bytes=gb_to_bytes(2.0),
+            runtime_overhead_bytes=gb_to_bytes(0.5),
         )
 
         self.assertIsNone(reservation.last_reserved_topology)
 
-        reservation.reserve(
+        reserved = reservation.reserve(
             topology=topology,
             batch_size=10,
             module=model,
@@ -762,13 +886,16 @@ class TestSKUAwareStorageReservation(unittest.TestCase):
 
         cached = reservation.last_reserved_topology
         self.assertIsNotNone(cached)
-        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
-        self.assertEqual(cached.devices[0].storage.hbm, expected_hbm)
+        self.assertEqual(cached.devices[0].storage.hbm, reserved.devices[0].storage.hbm)
 
-    def test_negative_model_base_bytes_raises(self) -> None:
+    def test_negative_margin_bytes_raises(self) -> None:
         with self.assertRaises(AssertionError):
-            SKUAwareStorageReservation(model_base_bytes=-1, runtime_overhead_bytes=0)
+            SKUAwareStorageReservation(margin_bytes=-1)
 
     def test_negative_runtime_overhead_bytes_raises(self) -> None:
         with self.assertRaises(AssertionError):
-            SKUAwareStorageReservation(model_base_bytes=0, runtime_overhead_bytes=-1)
+            SKUAwareStorageReservation(margin_bytes=0, runtime_overhead_bytes=-1)
+
+    def test_negative_model_base_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            SKUAwareStorageReservation(margin_bytes=0, model_base_bytes=-1)

--- a/torchrec/distributed/planner/tests/test_storage_reservations.py
+++ b/torchrec/distributed/planner/tests/test_storage_reservations.py
@@ -23,6 +23,7 @@ from torchrec.distributed.planner.storage_reservations import (
     FixedAbsoluteStorageReservation,
     FixedPercentageStorageReservation,
     HeuristicalStorageReservation,
+    SKUAwareStorageReservation,
 )
 from torchrec.distributed.planner.types import PlannerError, PlannerErrorType, Topology
 from torchrec.distributed.planner.utils import gb_to_bytes
@@ -591,3 +592,183 @@ class TestFixedAbsoluteStorageReservation(unittest.TestCase):
     def test_negative_bytes_raises(self) -> None:
         with self.assertRaises(AssertionError):
             FixedAbsoluteStorageReservation(hbm_reserved_bytes=-1)
+
+
+class TestSKUAwareStorageReservation(unittest.TestCase):
+    def _create_model_and_sharders(
+        self,
+    ) -> tuple[TestModel, List[ModuleSharder[nn.Module]]]:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=10,
+                name="table_0",
+                feature_names=["feature_0"],
+            )
+        ]
+        ebc = EmbeddingBagCollection(tables)
+        model = TestModel(shardable_sparse=ebc)
+        sharders = cast(
+            List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()]
+        )
+        return model, sharders
+
+    def test_reserves_model_base_plus_overhead(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=2, compute_device="cuda", hbm_cap=hbm_cap)
+
+        model_base_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        )
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, expected_hbm)
+        self.assertEqual(reserved_topology.devices[1].storage.hbm, expected_hbm)
+
+    def test_reservation_is_invariant_across_hbm_caps(self) -> None:
+        # The defining SKU-aware property: the reserved amount is absolute and
+        # does not scale with device hbm, so a model reserves the same bytes
+        # regardless of the SKU it lands on (unlike percentage-of-hbm).
+        model, sharders = self._create_model_and_sharders()
+        model_base_bytes = gb_to_bytes(3.0)
+        runtime_overhead_bytes = gb_to_bytes(1.0)
+        expected_reserved = model_base_bytes + runtime_overhead_bytes
+
+        small_cap = 16 * 1024 * 1024 * 1024
+        large_cap = 80 * 1024 * 1024 * 1024
+
+        small_reserved = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        ).reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=small_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+        large_reserved = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        ).reserve(
+            topology=Topology(world_size=1, compute_device="cuda", hbm_cap=large_cap),
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertEqual(
+            small_cap - small_reserved.devices[0].storage.hbm, expected_reserved
+        )
+        self.assertEqual(
+            large_cap - large_reserved.devices[0].storage.hbm, expected_reserved
+        )
+
+    def test_zero_reservation_matches_no_reservation(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=0, runtime_overhead_bytes=0
+        )
+
+        reserved_topology = reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        self.assertEqual(reserved_topology.devices[0].storage.hbm, hbm_cap)
+
+    def test_insufficient_storage_raises(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        # Reserve more than the device can provide.
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=gb_to_bytes(9.0),
+            runtime_overhead_bytes=gb_to_bytes(2.0),
+        )
+
+        with self.assertRaises(PlannerError) as context:
+            reservation.reserve(
+                topology=topology,
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
+
+    def test_exact_capacity_raises(self) -> None:
+        # reserved == available leaves 0 hbm for sharded tables, which is still
+        # infeasible, so the boundary must raise (the >= guard).
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024  # 10 GB
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=gb_to_bytes(8.0),
+            runtime_overhead_bytes=gb_to_bytes(2.0),
+        )
+
+        with self.assertRaises(PlannerError) as context:
+            reservation.reserve(
+                topology=topology,
+                batch_size=10,
+                module=model,
+                sharders=sharders,
+            )
+
+        self.assertEqual(
+            context.exception.error_type, PlannerErrorType.INSUFFICIENT_STORAGE
+        )
+
+    def test_last_reserved_topology_returns_copy(self) -> None:
+        model, sharders = self._create_model_and_sharders()
+        hbm_cap = 10 * 1024 * 1024 * 1024
+        topology = Topology(world_size=1, compute_device="cuda", hbm_cap=hbm_cap)
+
+        model_base_bytes = gb_to_bytes(2.0)
+        runtime_overhead_bytes = gb_to_bytes(0.5)
+        reservation = SKUAwareStorageReservation(
+            model_base_bytes=model_base_bytes,
+            runtime_overhead_bytes=runtime_overhead_bytes,
+        )
+
+        self.assertIsNone(reservation.last_reserved_topology)
+
+        reservation.reserve(
+            topology=topology,
+            batch_size=10,
+            module=model,
+            sharders=sharders,
+        )
+
+        cached = reservation.last_reserved_topology
+        self.assertIsNotNone(cached)
+        expected_hbm = hbm_cap - (model_base_bytes + runtime_overhead_bytes)
+        self.assertEqual(cached.devices[0].storage.hbm, expected_hbm)
+
+    def test_negative_model_base_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            SKUAwareStorageReservation(model_base_bytes=-1, runtime_overhead_bytes=0)
+
+    def test_negative_runtime_overhead_bytes_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            SKUAwareStorageReservation(model_base_bytes=0, runtime_overhead_bytes=-1)


### PR DESCRIPTION
Summary:
Extends `SKUAwareStorageReservation` (the OSS torchrec class) and its HUM factory `build_sku_aware_reservation` into a no-regression, SKU-correct replacement for `HeuristicalStorageReservation` - the default storage-reservation policy for ~78% of training jobs and ~76% of distinct models (ai_training_sharding_stats, 30d). This diff is the shared, framework-agnostic base; the APF and MVAI dispatch wiring are separate stacked diffs (one per trainer).

Structure: the per-rank reservation is a STATIC base plus a LIVE dynamic term plus overhead:

    reserved_per_rank = model_base_bytes (STATIC: dense + margin) + kjt (DYNAMIC, recomputed live) + runtime_overhead_bytes

The STATIC `model_base_bytes` is the memory resident for the whole run (dense params + optimizer + DDP) plus a percentage margin anchored to a FIXED home SKU (`margin = percentage * HBM[home]`). It has two forms: computed (default) = `margin + dense` derived from the module exactly like Heuristical; or provided = an explicit `model_base_bytes` (an owner-set value, or a [KR 2.9 measured static base](https://docs.google.com/spreadsheets/d/1WfHTkHudAWDTFiCJUA7g8DZpbyahBfvqdP3NuwvzWNk/edit?gid=284330042#gid=284330042)) that REPLACES the computed margin + dense. The DYNAMIC term (`kjt` today; a measured activation term later) is ALWAYS recomputed from the current local batch every plan, so the reservation stays correct as the batch / world_size changes (Variable Trainers, checkpoint-eval).

Why this shape: `HeuristicalStorageReservation` reserves `percentage * HBM[current] + dense + kjt`; the `percentage * HBM[current]` term is the only one that scales with the SKU a job lands on - a dominant cause of cross-SKU planner OOM/mis-scaling under hardware fungibility. Anchoring the margin to a fixed home SKU makes the whole static base SKU-invariant. On the home SKU, with the computed base and `runtime_overhead_bytes == 0`, the reservation is byte-identical to Heuristical (exact no-op). This is a SKU-correctness change, not an accuracy change: it reproduces Heuristical's reserve exactly - including Heuristical's known activation under-reservation (Heuristical does not model fwd/bwd activations; they fall on the percentage margin), which is closed later by sizing the DYNAMIC term from measured activations (KR 2.9), not by this diff.

Two distinct overrides (routed separately, NOT conflated): `model_base_bytes` REPLACES the whole static base (dense + margin) - the slot for an owner-set value or a KR 2.9 measured static base; `dense_tensor_estimate` (a framework estimate, e.g. APF's `get_dense_tensor_estimate`) overrides ONLY the computed dense, with the home margin still added on top, and is used only when `model_base_bytes` is None. When neither is set, the static base is computed as `margin + dense` from the module. `runtime_overhead_bytes` defaults to 0 (exact Heuristical parity) and is the slot for measured per-SKU overhead (KR 2.9); the HUM factory's fallback `DEFAULT_RUNTIME_OVERHEAD_BYTES` (`detection.py`) is likewise set to 0 by this diff (previously a 4 GiB placeholder that no SKU overrode), so an unmeasured SKU - currently every SKU - adds no runtime tax and a factory-built reservation is a true no-op, not just the class default.

Implementation: `SKUAwareStorageReservation` applies the static base (explicit `model_base_bytes` if set, else the home-anchored `margin_bytes`) and `runtime_overhead_bytes` as flooring absolutes FIRST, then computes dense (only when no explicit static base is given) and kjt (always) via the existing `_reserve_dense_storage` / `_reserve_kjt_storage` primitives - the same primitives `HeuristicalStorageReservation` uses, so their model-footprint accounting cannot drift. The flooring-absolutes-first ordering is load-bearing: `_reserve_storage_absolute` floors at `max(0, ...)`, so applying it after a dense/kjt over-reservation would mask the negative from the `< 0` INSUFFICIENT_STORAGE guard. This diff does NOT modify `HeuristicalStorageReservation` - it is byte-identical to trunk (an earlier draft factored a shared `_reserve_dense_and_kjt` helper and routed Heuristical through it; that was reverted so the ~78% majority policy is left completely untouched).

Reviewed By: mserturk

Differential Revision: D112232212


