### PR TITLE
Fix worker-side micro-batching shape mismatch for TensorWeightedAvg (#4432)

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -102,12 +102,33 @@ def _format_thread_stack(thread: threading.Thread) -> str:
     return "".join(traceback.format_stack(frame))
 
 
-def _safe_merge_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
-    """Concatenate tensors along the batch dim. Falls back to torch.stack
-    for 0-dim tensors since torch.cat cannot concatenate them."""
-    if tensors[0].dim() == 0:
-        return torch.stack(tensors, dim=0)
-    return torch.cat(tensors, dim=0)
+def _job_batch_size(model_out: Dict[str, torch.Tensor]) -> int:
+    sizes = [t.shape[0] for t in model_out.values() if t.dim() >= 1]
+    return max(sizes) if sizes else 1
+
+
+def _align_to_batch(t: torch.Tensor, batch_size: int) -> torch.Tensor:
+    # Expand per-batch broadcast values (scalar / single-element) to batch_size so
+    # cat(dim=0) stays row-aligned with per-example tensors, matching K=1 broadcast.
+    if t.dim() == 0:
+        return t.reshape(1).expand(batch_size)
+    if t.shape[0] == batch_size:
+        return t
+    if t.shape[0] == 1:
+        return t.expand(batch_size, *t.shape[1:])
+    raise RecMetricException(
+        f"worker-side micro-batching cannot align a tensor with leading dim "
+        f"{t.shape[0]} to batch size {batch_size}: expected a per-example "
+        f"(dim-0 == batch) or per-batch broadcast (scalar/single-element) tensor."
+    )
+
+
+def _merge_tensors_across_jobs(
+    tensors: list[torch.Tensor], batch_sizes: list[int]
+) -> torch.Tensor:
+    return torch.cat(
+        [_align_to_batch(t, b) for t, b in zip(tensors, batch_sizes)], dim=0
+    )
 
 
 def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
@@ -130,8 +151,9 @@ def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
         return jobs[0]
 
     first = jobs[0]
+    batch_sizes = [_job_batch_size(j.model_out) for j in jobs]
     merged_model_out: Dict[str, torch.Tensor] = {
-        key: _safe_merge_tensors([j.model_out[key] for j in jobs])
+        key: _merge_tensors_across_jobs([j.model_out[key] for j in jobs], batch_sizes)
         for key in first.model_out.keys()
     }
 
@@ -139,7 +161,9 @@ def _merge_update_jobs(jobs: list[MetricUpdateJob]) -> MetricUpdateJob:
     required_inputs_first = first.kwargs.get("required_inputs")
     if isinstance(required_inputs_first, dict) and required_inputs_first:
         merged_required: Dict[str, torch.Tensor] = {
-            key: _safe_merge_tensors([j.kwargs["required_inputs"][key] for j in jobs])
+            key: _merge_tensors_across_jobs(
+                [j.kwargs["required_inputs"][key] for j in jobs], batch_sizes
+            )
             for key in required_inputs_first.keys()
         }
         merged_kwargs["required_inputs"] = merged_required

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -1852,7 +1852,59 @@ class MergeUpdateJobsTest(unittest.TestCase):
             )
         )
 
-    def test_safe_merge_zero_dim_falls_back_to_stack(self) -> None:
+    def test_scalar_required_input_expands_to_batch(self) -> None:
+        # Regression: a per-batch scalar required-input (e.g. a TensorWeightedAvg
+        # target) must expand to each job's batch size so it stays row-aligned with
+        # the per-example tensors after a K>1 merge, rather than stacking to (K,).
+        jobs = [
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.1, 0.2])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor(5.0)}},
+            ),
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.3, 0.4])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor(7.0)}},
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        target = merged.kwargs["required_inputs"]["target_tensor"]
+        self.assertEqual(merged.model_out["prediction"].shape, (4,))
+        self.assertEqual(target.shape, (4,))
+        self.assertTrue(torch.equal(target, torch.tensor([5.0, 5.0, 7.0, 7.0])))
+
+    def test_single_element_required_input_expands_to_batch(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.1, 0.2, 0.3])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor([5.0])}},
+            ),
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.4, 0.5, 0.6])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor([7.0])}},
+            ),
+        ]
+        merged = _merge_update_jobs(jobs)
+        target = merged.kwargs["required_inputs"]["target_tensor"]
+        self.assertEqual(target.shape, (6,))
+        self.assertTrue(
+            torch.equal(target, torch.tensor([5.0, 5.0, 5.0, 7.0, 7.0, 7.0]))
+        )
+
+    def test_unalignable_required_input_raises(self) -> None:
+        jobs = [
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.1, 0.2, 0.3])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor([5.0, 6.0])}},
+            ),
+            MetricUpdateJob(
+                model_out={"prediction": torch.tensor([0.4, 0.5, 0.6])},
+                kwargs={"required_inputs": {"target_tensor": torch.tensor([7.0, 8.0])}},
+            ),
+        ]
+        with self.assertRaises(RecMetricException):
+            _merge_update_jobs(jobs)
+
+    def test_scalar_model_out_expands_and_concats(self) -> None:
         jobs = [
             MetricUpdateJob(
                 model_out={"label": torch.tensor(1.0)},


### PR DESCRIPTION
Summary:

CPU-offloaded metric module batches K update calls into one by concatenating model outputs along the batch dimension. Per-batch scalar required-inputs (e.g. a TensorWeightedAvg target) have no batch axis, so they were stacked into a length-K vector that no longer aligned with the per-example tensors, crashing the metric update. Expand per-batch broadcast values across the batch before concatenating so the merged call is a faithful concatenation of K batches; results are numerically identical to per-call updates.

Reviewed By: yashasingh

Differential Revision: D112134251


