### PR TITLE
Add DeviceRo-specific KJT unwrap target

### DIFF
--- a/torchrec/distributed/fused_params.py
+++ b/torchrec/distributed/fused_params.py
@@ -26,6 +26,7 @@ FUSED_PARAM_BOUNDS_CHECK_MODE: str = "__register_tbe_bounds_check_mode"
 # Force lengths to offsets conversion before TBE lookup. Helps with performance
 # with certain ways to split models.
 FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP: str = "__register_lengths_to_offsets_lookup"
+FUSED_PARAM_IS_DEVICE_RO: str = "__register_is_device_ro"
 
 # Fused param storing list of cpu embedding tables offloaded to ssd to scale
 # the embedding table size
@@ -96,6 +97,15 @@ def fused_param_lengths_to_offsets_lookup(
         return fused_params[FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP]
 
 
+def is_fused_param_device_ro(fused_params: Optional[Dict[str, Any]]) -> bool:
+    return (
+        # pyrefly: ignore[bad-return]
+        fused_params
+        and FUSED_PARAM_IS_DEVICE_RO in fused_params
+        and fused_params[FUSED_PARAM_IS_DEVICE_RO]
+    )
+
+
 def is_fused_param_quant_state_dict_split_scale_bias(
     fused_params: Optional[Dict[str, Any]],
 ) -> bool:
@@ -124,6 +134,8 @@ def tbe_fused_params(
         fused_params_for_tbe.pop(FUSED_PARAM_BOUNDS_CHECK_MODE)
     if FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_LENGTHS_TO_OFFSETS_LOOKUP)
+    if FUSED_PARAM_IS_DEVICE_RO in fused_params_for_tbe:
+        fused_params_for_tbe.pop(FUSED_PARAM_IS_DEVICE_RO)
     if FUSED_PARAM_SSD_TABLE_LIST in fused_params_for_tbe:
         fused_params_for_tbe.pop(FUSED_PARAM_SSD_TABLE_LIST)
 

--- a/torchrec/distributed/quant_embedding_kernel.py
+++ b/torchrec/distributed/quant_embedding_kernel.py
@@ -35,6 +35,7 @@ from torchrec.distributed.embedding_types import (
 from torchrec.distributed.fused_params import (
     fused_param_bounds_check_mode,
     fused_param_lengths_to_offsets_lookup,
+    is_fused_param_device_ro,
     is_fused_param_quant_state_dict_split_scale_bias,
     is_fused_param_register_tbe,
     tbe_fused_params,
@@ -191,6 +192,15 @@ def _unwrap_kjt(
     )
 
 
+# Keep DeviceRo unwrap behavior identical to _unwrap_kjt, but give FX
+# tracing a distinct target for tagging DeviceRo lookups.
+@torch.fx.wrap
+def _unwrap_ro_kjt(
+    features: KeyedJaggedTensor,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    return _unwrap_kjt(features)
+
+
 def _unwrap_kjt_for_cpu(
     features: KeyedJaggedTensor, weighted: bool
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -277,6 +287,7 @@ class QuantBatchedEmbeddingBag(
         self._quant_state_dict_split_scale_bias: bool = (
             is_fused_param_quant_state_dict_split_scale_bias(fused_params)
         )
+        self._is_device_ro: bool = is_fused_param_device_ro(fused_params)
         bounds_check_mode: Optional[BoundsCheckMode] = fused_param_bounds_check_mode(
             fused_params
         )
@@ -435,7 +446,8 @@ class QuantBatchedEmbeddingBag(
             if self.lengths_to_tbe:
                 indices, lengths, per_sample_weights = _unwrap_kjt_lengths(features)
             else:
-                indices, offsets, per_sample_weights = _unwrap_kjt(features)
+                unwrap_kjt = _unwrap_ro_kjt if self._is_device_ro else _unwrap_kjt
+                indices, offsets, per_sample_weights = unwrap_kjt(features)
 
         return self._emb_module_forward(
             indices,

--- a/torchrec/distributed/tests/test_quant_embedding_kernel.py
+++ b/torchrec/distributed/tests/test_quant_embedding_kernel.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, cast, Dict
+from unittest.mock import MagicMock, patch
+
+import torch
+import torchrec.distributed.quant_embedding_kernel as qek
+from torchrec.distributed.fused_params import (
+    FUSED_PARAM_IS_DEVICE_RO,
+    is_fused_param_device_ro,
+    tbe_fused_params,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+
+
+class QuantBatchedEmbeddingBagDeviceRoTest(unittest.TestCase):
+    def _make_bag(
+        self,
+        *,
+        is_device_ro: bool,
+        lengths_to_tbe: bool = False,
+    ) -> qek.QuantBatchedEmbeddingBag:
+        bag = qek.QuantBatchedEmbeddingBag.__new__(qek.QuantBatchedEmbeddingBag)
+        bag._runtime_device = torch.device("cuda")
+        bag.lengths_to_tbe = lengths_to_tbe
+        bag._is_device_ro = is_device_ro
+        return bag
+
+    def test_forward_uses_ro_unwrap_for_cuda_devicero(self) -> None:
+        bag = self._make_bag(is_device_ro=True)
+        output = torch.tensor([3.0])
+        indices = torch.tensor([1])
+        offsets = torch.tensor([0, 1])
+        emb_forward = MagicMock(return_value=output)
+        bag._emb_module_forward = emb_forward
+        features = cast(KeyedJaggedTensor, object())
+
+        with patch.object(
+            qek, "_unwrap_ro_kjt", return_value=(indices, offsets, None)
+        ) as mock_ro_unwrap, patch.object(
+            qek, "_unwrap_kjt", return_value=(indices, offsets, None)
+        ) as mock_regular_unwrap:
+            result = bag.forward(features)
+
+        self.assertIs(result, output)
+        mock_ro_unwrap.assert_called_once_with(features)
+        mock_regular_unwrap.assert_not_called()
+        emb_forward.assert_called_once_with(indices, offsets, None)
+
+    def test_forward_uses_regular_unwrap_for_cuda_non_devicero(self) -> None:
+        bag = self._make_bag(is_device_ro=False)
+        output = torch.tensor([5.0])
+        indices = torch.tensor([2])
+        offsets = torch.tensor([0, 1])
+        emb_forward = MagicMock(return_value=output)
+        bag._emb_module_forward = emb_forward
+        features = cast(KeyedJaggedTensor, object())
+
+        with patch.object(
+            qek, "_unwrap_ro_kjt", return_value=(indices, offsets, None)
+        ) as mock_ro_unwrap, patch.object(
+            qek, "_unwrap_kjt", return_value=(indices, offsets, None)
+        ) as mock_regular_unwrap:
+            result = bag.forward(features)
+
+        self.assertIs(result, output)
+        mock_regular_unwrap.assert_called_once_with(features)
+        mock_ro_unwrap.assert_not_called()
+        emb_forward.assert_called_once_with(indices, offsets, None)
+
+    def test_lengths_to_tbe_uses_lengths_unwrap_for_devicero(self) -> None:
+        bag = self._make_bag(is_device_ro=True, lengths_to_tbe=True)
+        output = torch.tensor([7.0])
+        indices = torch.tensor([4])
+        lengths = torch.tensor([1])
+        emb_forward = MagicMock(return_value=output)
+        bag._emb_module_forward = emb_forward
+        features = cast(KeyedJaggedTensor, object())
+
+        with patch.object(
+            qek, "_unwrap_kjt_lengths", return_value=(indices, lengths, None)
+        ) as mock_lengths_unwrap, patch.object(
+            qek, "_unwrap_ro_kjt", return_value=(indices, lengths, None)
+        ) as mock_ro_unwrap:
+            result = bag.forward(features)
+
+        self.assertIs(result, output)
+        mock_lengths_unwrap.assert_called_once_with(features)
+        mock_ro_unwrap.assert_not_called()
+        emb_forward.assert_called_once_with(indices, lengths, None)
+
+    def test_device_ro_fused_param_is_internal_to_torchrec(self) -> None:
+        fused_params: Dict[str, Any] = {
+            FUSED_PARAM_IS_DEVICE_RO: True,
+            "output_dtype": object(),
+        }
+
+        self.assertTrue(is_fused_param_device_ro(fused_params))
+        self.assertFalse(is_fused_param_device_ro({}))
+        filtered_params = tbe_fused_params(fused_params)
+        self.assertIsNotNone(filtered_params)
+        self.assertNotIn(FUSED_PARAM_IS_DEVICE_RO, filtered_params)
+        self.assertIn("output_dtype", filtered_params)


### PR DESCRIPTION
Summary: Add an internal DeviceRo fused-param marker, filter it before FBGEMM TBE construction, and route CUDA DeviceRo `QuantBatchedEmbeddingBag` lookups through a distinct `_unwrap_ro_kjt` FX target so downstream passes can tag it independently.

Reviewed By: seanx92

Differential Revision: D112212237


