### PR TITLE
(2/N)[MPZCH] Require disable_fallback and no opt-in for a Region Split

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -521,6 +521,12 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         assert (
             0 <= self._percent_fresh_region < 100
         ), f"percent_fresh_region must be in [0, 100), got {self._percent_fresh_region}"
+        assert (
+            self._disable_fallback
+        ), "percent_fresh_region requires disable_fallback=True; otherwise a full Main region falls back into the Fresh tail"
+        assert (
+            self._opt_in_prob == -1
+        ), "percent_fresh_region is incompatible with opt-in; opt_in_prob must be -1"
         unique = torch.unique(size_per_rank[self._start_bucket : self._end_bucket])
         assert (
             unique.numel() == 1

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -255,6 +255,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         no_bag: bool = False,
         write_runtime_meta_dim: int = 0,
         persist_hash_zch_bucket: bool = True,
+        percent_fresh_region: float = 0,
     ) -> None:
         if output_segments is None:
             assert (
@@ -398,6 +399,14 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._enable_per_feature_lookups: bool = enable_per_feature_lookups
         self._no_bag = no_bag
 
+        self._percent_fresh_region: float = percent_fresh_region
+        self._main_size: Optional[int] = None
+        self._fresh_size: Optional[int] = None
+        if self._percent_fresh_region != 0:
+            self._main_size, self._fresh_size = self._compute_region_split(
+                size_per_rank
+            )
+
         logger.info(
             f"HashZchManagedCollisionModule: {self._name=}, {self.device=}, "
             f"{self._zch_size=}, {self._input_hash_size=}, {self._max_probe=}, "
@@ -409,7 +418,8 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, "
             f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
             f"{self._no_bag=}, {self._write_runtime_meta_dim=}, "
-            f"{self._persist_hash_zch_bucket=}"
+            f"{self._persist_hash_zch_bucket=}, {self._percent_fresh_region=}, "
+            f"{self._main_size=}, {self._fresh_size=}"
         )
 
     def _create_zch_buffer(
@@ -506,6 +516,25 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
     def is_sharded(self) -> bool:
         # For sharded hash mc module, the buckets are split across multiple ranks.
         return (self._end_bucket - self._start_bucket) < self._buckets
+
+    def _compute_region_split(self, size_per_rank: torch.Tensor) -> Tuple[int, int]:
+        assert (
+            0 <= self._percent_fresh_region < 100
+        ), f"percent_fresh_region must be in [0, 100), got {self._percent_fresh_region}"
+        unique = torch.unique(size_per_rank[self._start_bucket : self._end_bucket])
+        assert (
+            unique.numel() == 1
+        ), "cannot split non-uniform buckets into main/fresh regions"
+        bucket_size = int(unique.item())
+        fresh_size = math.floor(bucket_size * self._percent_fresh_region / 100)
+        main_size = bucket_size - fresh_size
+        assert not (
+            self._percent_fresh_region > 0 and (fresh_size <= 0 or main_size <= 0)
+        ), (
+            f"percent_fresh_region={self._percent_fresh_region} with bucket_size={bucket_size} "
+            f"yields ({main_size}, {fresh_size}); both regions must be non-empty"
+        )
+        return main_size, fresh_size
 
     # TODO: This is hacky as we are using parameters to go through publishing.
     # Can remove once working out buffer solution.
@@ -845,6 +874,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             no_bag=self._no_bag,
             write_runtime_meta_dim=self._write_runtime_meta_dim,
             persist_hash_zch_bucket=self._persist_hash_zch_bucket,
+            percent_fresh_region=self._percent_fresh_region,
         )
 
     def lookup_runtime_meta(

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2276,3 +2276,67 @@ class TestPersistHashZchBucket(unittest.TestCase):
         count = make_hash_zch_buckets_non_persistent(parent)
         self.assertGreaterEqual(count, 1)
         self.assertNotIn("child._hash_zch_bucket", parent.state_dict())
+
+
+class TestFreshRegionSplit(unittest.TestCase):
+    def _build(
+        self,
+        zch_size: int,
+        total_num_buckets: int,
+        percent_fresh_region: float,
+        output_segments: Optional[list[int]] = None,
+    ) -> HashZchManagedCollisionModule:
+        return HashZchManagedCollisionModule(
+            zch_size=zch_size,
+            device=torch.device("cpu"),
+            total_num_buckets=total_num_buckets,
+            percent_fresh_region=percent_fresh_region,
+            output_segments=output_segments,
+        )
+
+    def test_no_fresh_region_by_default(self) -> None:
+        m = self._build(1000, 2, 0)
+        self.assertIsNone(m._main_size)
+        self.assertIsNone(m._fresh_size)
+
+    def test_no_fresh_region_skips_validation(self) -> None:
+        # percent=0 skips the split, so an otherwise-rejected config (non-uniform
+        # buckets) still constructs — backward compatible for existing callers.
+        m = self._build(100, 3, 0, output_segments=[0, 34, 67, 100])
+        self.assertIsNone(m._main_size)
+        self.assertIsNone(m._fresh_size)
+
+    def test_region_sizes(self) -> None:
+        m = self._build(1000, 2, 20.0)  # bucket_size 500, 20% fresh
+        self.assertEqual(m._main_size, 400)
+        self.assertEqual(m._fresh_size, 100)
+
+    def test_split_floors_not_rounds(self) -> None:
+        m = self._build(10, 1, 39.0)  # bucket_size 10 -> 3.9 -> 3
+        self.assertEqual(m._main_size, 7)
+        self.assertEqual(m._fresh_size, 3)
+
+    def test_fractional_percent(self) -> None:
+        m = self._build(1000, 2, 12.5)  # bucket_size 500 -> 62.5 -> 62
+        self.assertEqual(m._main_size, 438)
+        self.assertEqual(m._fresh_size, 62)
+
+    def test_sharded_module_keeps_split(self) -> None:
+        shard = self._build(1000, 2, 20.0).rebuild_with_output_id_range((500, 1000))
+        self.assertEqual(shard._main_size, 400)
+        self.assertEqual(shard._fresh_size, 100)
+
+    def test_percent_out_of_range_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, -1.0)
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 100.0)
+
+    def test_percent_too_small_raises(self) -> None:
+        # 10% of a 4-slot bucket floors to 0 fresh slots.
+        with self.assertRaises(AssertionError):
+            self._build(4, 1, 10.0)
+
+    def test_non_uniform_buckets_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(100, 3, 20.0, output_segments=[0, 34, 67, 100])

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2285,6 +2285,8 @@ class TestFreshRegionSplit(unittest.TestCase):
         total_num_buckets: int,
         percent_fresh_region: float,
         output_segments: Optional[list[int]] = None,
+        disable_fallback: bool = True,
+        opt_in_prob: int = -1,
     ) -> HashZchManagedCollisionModule:
         return HashZchManagedCollisionModule(
             zch_size=zch_size,
@@ -2292,6 +2294,8 @@ class TestFreshRegionSplit(unittest.TestCase):
             total_num_buckets=total_num_buckets,
             percent_fresh_region=percent_fresh_region,
             output_segments=output_segments,
+            disable_fallback=disable_fallback,
+            opt_in_prob=opt_in_prob,
         )
 
     def test_no_fresh_region_by_default(self) -> None:
@@ -2340,3 +2344,11 @@ class TestFreshRegionSplit(unittest.TestCase):
     def test_non_uniform_buckets_raises(self) -> None:
         with self.assertRaises(AssertionError):
             self._build(100, 3, 20.0, output_segments=[0, 34, 67, 100])
+
+    def test_requires_disable_fallback(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 20.0, disable_fallback=False)
+
+    def test_rejects_opt_in(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 20.0, opt_in_prob=0)


### PR DESCRIPTION
Summary:
Follow-up to the Main/Fresh region split. When a Fresh region is configured (`percent_fresh_region > 0`), the region contract requires two conditions on the module, enforced here at construction:

- `disable_fallback=True` — otherwise a full Main region falls back into the reserved Fresh tail, breaking the Main-only guarantee.
- opt-in disabled (`opt_in_prob == -1`) — region control is a dedicated mechanism and must not be combined with the training-time opt-in / reserved-slot path.

Both are checked where the split is derived, so a misconfigured module fails fast at construction instead of producing wrong reads at serve time. No effect when `percent_fresh_region == 0` (the default).

Differential Revision: D111814588


