### PR TITLE
Make ZORM metric-thread shutdown failures non-fatal

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -508,8 +508,11 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
     @override
     def shutdown(self) -> None:
         """Two-phase shutdown: stop the update thread, then the compute thread.
-        Idempotent — safe under explicit call + atexit, including the raise paths
-        below (thread-stuck and captured-exception)."""
+        Idempotent — safe under explicit call + atexit. Best-effort: a worker that
+        fails to join is logged (with a failure event), never raised, so metric
+        teardown cannot mask an in-flight training error or fail an otherwise
+        successful job. Both workers are daemon threads, so an abandoned one cannot
+        block process exit."""
 
         if self._shutdown_complete:
             return
@@ -593,7 +596,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 correctness_metadata,
                 error_message="update thread did not shut down gracefully",
             )
-            raise RecMetricException(
+            logger.warning(
                 f"update thread did not shut down gracefully. remaining queue size: {self.update_queue.qsize()}"
             )
         if self.compute_thread.is_alive():
@@ -603,7 +606,7 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
                 correctness_metadata,
                 error_message="compute thread did not shut down gracefully",
             )
-            raise RecMetricException(
+            logger.warning(
                 f"compute thread did not shut down gracefully. remaining queue size: {self.compute_queue.qsize()}"
             )
 

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -350,9 +350,9 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             mock_log_event.assert_not_called()
 
     def test_shutdown_logs_stack_when_compute_thread_will_not_exit(self) -> None:
-        """A compute thread still alive past the bounded join must not hang
-        teardown: shutdown() abandons the join, logs an error with the thread
-        stack, then raises so the job fails loudly."""
+        """A compute thread still alive past the bounded join must not hang or
+        fail teardown: shutdown() abandons the join, logs an error with the
+        thread stack, and warns (does not raise) so cleanup stays non-fatal."""
         with patch.object(
             self.cpu_module.compute_thread, "join", return_value=None
         ), patch.object(
@@ -362,13 +362,19 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
         ), patch(
             "torchrec.metrics.cpu_offloaded_metric_module.logger"
         ) as mock_logger:
-            with self.assertRaises(RecMetricException):
-                self.cpu_module.shutdown()
+            self.cpu_module.shutdown()  # must not raise
 
         mock_logger.error.assert_called_once()
         (msg,) = mock_logger.error.call_args[0]
         self.assertIn(f"did not exit within {_COMPUTE_SHUTDOWN_JOIN_TIMEOUT_SEC}", msg)
         self.assertIn("compute_thread stack", msg)
+        self.assertTrue(
+            any(
+                "did not shut down gracefully" in call.args[0]
+                for call in mock_logger.warning.call_args_list
+            ),
+            "expected a non-fatal 'did not shut down gracefully' warning",
+        )
 
     def test_format_thread_stack(self) -> None:
         # Not-started thread: ident is None.


### PR DESCRIPTION
Summary:
`CPUOffloadedRecMetricModule.shutdown()` raised `RecMetricException` when an update or compute worker thread failed to join within the teardown timeout. Because shutdown runs during teardown — often while a training exception is already propagating — that raise could replace the real, in-flight error (masking the true failure), and could fail an otherwise-successful job on metric cleanup alone.

Downgrade both worker-join failures from raise to a logged warning. The existing failure event is retained for observability, and the workers are daemon threads, so an abandoned one cannot block process exit. The captured-exception path (a worker that genuinely crashed) still re-raises, so real metric errors continue to surface. Metric teardown is now strictly best-effort.

Differential Revision: D112403142


