### PR TITLE
Enable supports_test_execution_caching for test_cpu_offloaded_metric_module

### DIFF
--- a/torchrec/metrics/tests/test_gpu.py
+++ b/torchrec/metrics/tests/test_gpu.py
@@ -11,6 +11,7 @@ import copy
 import unittest
 
 import torch
+from configerator.configerator_fake import ConfigeratorFake
 from torchrec.metrics.auc import AUCMetric
 from torchrec.metrics.metric_module import generate_metric_module, RecMetricModule
 from torchrec.metrics.metrics_config import (
@@ -20,6 +21,11 @@ from torchrec.metrics.metrics_config import (
 )
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.test_utils import gen_test_batch
+
+# Install a process-wide Configerator fake so JustKnobs config reads resolve
+# locally instead of each blocking ~55s on the unreachable Configerator under RE
+# network isolation (tpx-no-network use case + test caching).
+_CONFIGERATOR_FAKE: ConfigeratorFake = ConfigeratorFake().create()
 
 
 _CUDA_UNAVAILABLE: bool = not torch.cuda.is_available()

--- a/torchrec/metrics/tests/test_recmetric.py
+++ b/torchrec/metrics/tests/test_recmetric.py
@@ -12,12 +12,18 @@ from typing import Any, Dict
 from unittest.mock import patch
 
 import torch
+from configerator.configerator_fake import ConfigeratorFake
 from torchrec.metrics.metrics_config import BatchSizeStage, DefaultTaskInfo, RecTaskInfo
 from torchrec.metrics.model_utils import parse_task_model_outputs
 from torchrec.metrics.mse import MSEMetric
 from torchrec.metrics.ne import NEMetric
 from torchrec.metrics.rec_metric import RecComputeMode, RecMetric, RecMetricList
 from torchrec.metrics.test_utils import gen_test_batch, gen_test_tasks
+
+# Install a process-wide Configerator fake so JustKnobs config reads resolve
+# locally instead of each blocking ~55s on the unreachable Configerator under RE
+# network isolation (tpx-no-network use case + test caching).
+_CONFIGERATOR_FAKE: ConfigeratorFake = ConfigeratorFake().create()
 
 
 _CUDA_UNAVAILABLE: bool = not torch.cuda.is_available()


### PR DESCRIPTION
Summary:
Set supports_test_execution_caching = True on one target to try to see if there are any issues with it.
Picked this one because `buck2-user` use case actually blocks network access (by using the default in RE which is loopback for GPUs), so it should be safe to cache.

Differential Revision: D95567732


