### PR TITLE
Construct CPUOffloadedRecMetricModule without an initialized process group

### DIFF
--- a/torchrec/metrics/cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/cpu_offloaded_metric_module.py
@@ -296,8 +296,12 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             target=self._compute_loop, name=metric_compute_thread_name, daemon=True
         )
 
+        # Created lazily on first compute so the module can be constructed without
+        # an initialized process group (e.g. single-process model validation).
         # pyrefly: ignore
-        self.cpu_process_group: dist.ProcessGroup = dist.new_group(backend="gloo")
+        self.cpu_process_group: Optional[dist.ProcessGroup] = (
+            dist.new_group(backend="gloo") if dist.is_initialized() else None
+        )
         self.comms_module: CPUCommsRecMetricModule = CPUCommsRecMetricModule(
             *args,
             **kwargs,
@@ -750,6 +754,8 @@ class CPUOffloadedRecMetricModule(RecMetricModule):
             with record_function("## cpu_all_gather ##"):
                 # Manual distributed sync (replaces TorchMetrics.metric.Metric.sync())
                 all_gather_start_ms = time.time()
+                if self.cpu_process_group is None:
+                    self.cpu_process_group = dist.new_group(backend="gloo")
                 aggregated_states = self.comms_module.get_pre_compute_states(
                     self.cpu_process_group
                 )

--- a/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
+++ b/torchrec/metrics/tests/test_cpu_offloaded_metric_module.py
@@ -141,6 +141,26 @@ class CPUOffloadedRecMetricModuleTest(unittest.TestCase):
             except Exception:
                 pass
 
+    def test_construct_without_process_group(self) -> None:
+        """Constructs with no initialized PG (e.g. single-process model validation);
+        the gloo group is deferred to first compute."""
+        with patch(
+            "torchrec.metrics.cpu_offloaded_metric_module.dist.is_initialized",
+            return_value=False,
+        ), patch(
+            "torchrec.metrics.cpu_offloaded_metric_module.dist.new_group"
+        ) as mock_new_group:
+            module = self._make_module(
+                throughput_metric=ThroughputMetric(
+                    world_size=self.world_size,
+                    batch_size=self.batch_size,
+                    window_seconds=1,
+                ),
+            )
+        mock_new_group.assert_not_called()
+        self.assertIsNone(module.cpu_process_group)
+        module.shutdown()
+
     @unittest.skipIf(
         torch.cuda.device_count() < 1,
         "Not enough GPUs, this test requires at least one GPU",


### PR DESCRIPTION
Summary:
`CPUOffloadedRecMetricModule.__init__` eagerly called `dist.new_group(backend="gloo")`, which requires an initialized process group. Constructing the module in a single-process context (no `init_process_group`) therefore raised `Default process group has not been initialized` whenever the CPU-offloaded module was selected.

Create the gloo group lazily: skip it at construction when no process group is initialized, and create it on first `compute()` (where a distributed job is always up). This matches `RecMetricModule`, which already constructs distributed-free.

Differential Revision: D112904360


