### PR TITLE
Model per-SKU host layout in dry-run topology (#4452)

### DIFF
--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+from typing import Dict, List, Mapping, Optional
+
+import torch.distributed as dist
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ShardingPlannerAPI(abc.ABC):
+    """Abstract base for sharding planner orchestrators.
+
+    Owns the shared per-target planning loop as a template method (``plan``):
+    for each target it delegates to the injected PlannerExecutor — which builds
+    the topology, resolves the storage reservation, and constructs and runs the
+    planner for that SKU — aggregating per-target ShardingPlanResults onto
+    ``ctx.results`` and into the returned map.
+
+    Subclasses supply only what differs — the set of targets — via ``_targets``:
+    ``ProductionPlannerOrchestrator`` resolves launcher_hardware -> concrete SKU;
+    ``DryRunOrchestrator`` expands the request's SKU list. The executor is
+    injected (its PlannerProvider selects OSS vs Meta topology/storage/planner),
+    and the broadcast process group is owned here.
+
+    (There is intentionally no separate concrete "orchestrator" class beyond the
+    prod/dry-run subclasses — the shared loop lives here, so the subclasses stay
+    thin and there is a single contract.)
+    """
+
+    def __init__(
+        self,
+        executor: PlannerExecutor,
+        broadcast_pg: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        self._executor = executor
+        # Optional caller-injected process group for the rank-0 plan + broadcast.
+        # APF passes its Gloo control group (cpu_ctl_dist_pg) here to avoid NCCL
+        # object-broadcast corruption on some SKUs (e.g. GB300). When None,
+        # _get_broadcast_pg falls back to the default WORLD group (offline -> None).
+        self._broadcast_pg = broadcast_pg
+
+    def plan(
+        self,
+        request: ShardingPlanRequest,
+        ctx: PlannerSessionContext,
+    ) -> Mapping[str, ShardingPlanResult]:
+        """Run the shared per-target planning loop and aggregate the results.
+
+        Returns a Mapping (read-only, covariant in the value type) keyed by SKU,
+        so subclasses may narrow the result type — e.g. DryRunOrchestrator
+        returns Mapping[str, DryRunResult].
+
+        Invariant: ``request`` must be the same object carried by ``ctx``
+        (``ctx.request``). This method reads only the target set from ``request``
+        (via ``_targets``); the executor reads model/sharders/constraints/config
+        from ``ctx.request``. Callers build ``ctx = PlannerSessionContext(request=
+        request, ...)`` so the two never diverge.
+
+        Distributed transfer: only the ShardingPlan is broadcast to all ranks —
+        that is all a rank needs to build DMP. The rich ShardingPlanResult
+        metadata (sharding_options, peak estimates, solve time) is produced only
+        on the planning rank (rank 0) and is intentionally NOT broadcast; it is
+        for logging/observability, which is a rank-0 concern. So on non-zero
+        ranks the result carries the plan with empty metadata.
+        """
+        # request is ctx.request by construction (see the invariant above); the
+        # executor reads model/sharders/constraints/config from ctx.request and
+        # builds the topology, storage reservation, and planner for each SKU.
+        # Enforce it so a caller passing a divergent request fails fast rather
+        # than silently planning targets from one request against another. A raise
+        # (not assert) so the check survives ``python -O``.
+        if request is not ctx.request:
+            raise ValueError("request must be the same object as ctx.request")
+        pg = self._get_broadcast_pg()
+        results: Dict[str, ShardingPlanResult] = {}
+        # dict.fromkeys dedups while preserving order: a subclass returning a
+        # duplicate SKU would otherwise trigger a redundant executor.run and
+        # silently overwrite the earlier result.
+        for sku in dict.fromkeys(self._targets(request)):
+            try:
+                result = self._executor.run(sku=sku, ctx=ctx, pg=pg)
+                result = self._finalize_result(sku, result, request)
+            except Exception as e:
+                # Fail-fast by default (production plans a single SKU: a broken
+                # plan must surface, not be swallowed). ``DryRunOrchestrator``
+                # opts into collect-and-continue so one bad SKU (model factory,
+                # enum coercion, HUM lookup, ...) does not lose the rest of the
+                # what-if sweep -- it is recorded as an unsuccessful result and
+                # the loop keeps going. (``PlannerError`` is already turned into a
+                # success=False result inside the executor; this governs only the
+                # unexpected errors that would otherwise propagate.)
+                if not self._isolate_target_errors():
+                    raise
+                logger.warning(
+                    "[planner] target sku=%s failed; recording as unsuccessful "
+                    "and continuing the sweep",
+                    sku,
+                    exc_info=True,
+                )
+                result = self._finalize_result(
+                    sku, self._failed_result(sku, ctx, e), request
+                )
+            ctx.results[sku] = result
+            results[sku] = result
+        return results
+
+    def _isolate_target_errors(self) -> bool:
+        """Whether a single target's unexpected failure is isolated to that target.
+
+        Base returns False: production fails fast (it plans one SKU and any
+        unexpected error must surface). ``DryRunOrchestrator`` overrides to True
+        so a multi-SKU sweep returns partial results instead of aborting on the
+        first bad SKU. Governs only non-``PlannerError`` exceptions; the executor
+        already converts ``PlannerError`` into a success=False result on both paths.
+        """
+        return False
+
+    def _failed_result(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        error: Exception,
+    ) -> ShardingPlanResult:
+        """Build a success=False result for a target that raised an unexpected error.
+
+        Used only on the collect-and-continue path so the failing SKU is surfaced
+        (with its error as ``planner_failure_reason``) rather than lost.
+        """
+        return ShardingPlanResult(
+            sku=sku,
+            success=False,
+            sharding_plan=None,
+            planner_failure_reason=f"{type(error).__name__}: {error}",
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+            request_hash=ctx.request.request_hash,
+            request_id=ctx.request.request_id,
+        )
+
+    def _finalize_result(
+        self,
+        sku: str,
+        result: ShardingPlanResult,
+        request: ShardingPlanRequest,
+    ) -> ShardingPlanResult:
+        """Post-process the per-SKU result before it is aggregated.
+
+        Base implementation returns the result unchanged. Subclasses may enrich
+        it — e.g. DryRunOrchestrator returns a DryRunResult that adds the per-SKU
+        request fingerprint. The return type is covariant, so a subclass returning
+        a ShardingPlanResult subclass narrows the whole result map accordingly.
+        """
+        return result
+
+    @abc.abstractmethod
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        """Concrete GPU-SKUs to plan for.
+
+        Each value becomes a ShardingPlanResult.sku and a key in the result map,
+        so it must be a GPU-SKU (e.g. "H100"/"GB200") — not a launcher_hardware
+        value ("ZIONEX"/"TC_ANY"). ProductionPlannerOrchestrator resolves
+        launcher_hardware -> SKU; DryRunOrchestrator returns the request's
+        sku_list.
+        """
+        ...
+
+    def _get_broadcast_pg(self) -> Optional[dist.ProcessGroup]:
+        """Process group for the plan broadcast, owned by the API.
+
+        Returns a group in a distributed context so the executor runs
+        ``collective_plan`` (rank-0 plan + broadcast); returns None offline /
+        single-rank so the executor runs a local ``plan``.
+
+        Process-group *initialization* is intentionally NOT done here — it is the
+        caller's (trainer/framework's) responsibility, via
+        ``torch.distributed.init_process_group`` during training setup, before
+        planning. This method never initializes ``dist`` (doing so would clash
+        with the trainer's own PG/backend/timeout); it only detects whether a
+        distributed context already exists via ``dist.is_initialized()``. When it
+        is not initialized (offline / dry-run / single process) it returns None
+        and the executor plans locally.
+
+        The plan is broadcast as a pickled Python object, and NCCL
+        object-broadcast is known to corrupt on some SKUs (e.g. GB300). To avoid
+        that, a caller in a distributed context should inject a dedicated Gloo/CPU
+        group via the constructor (``broadcast_pg``) — APF passes its existing Gloo
+        control group (``cpu_ctl_dist_pg``), validated to span the same ranks as
+        WORLD. When an injected group is present it is used; otherwise this falls
+        back to the default (NCCL) WORLD group when distributed is initialized, and
+        None offline (single-rank / dry-run -> local plan).
+        """
+        if self._broadcast_pg is not None:
+            return self._broadcast_pg
+        if dist.is_available() and dist.is_initialized():
+            return dist.group.WORLD
+        return None
+
+
+class ProductionPlannerOrchestrator(ShardingPlannerAPI):
+    """Production orchestrator: plans for the single concrete SKU the job runs on.
+
+    The concrete GPU-SKU is resolved by the caller and passed at construction;
+    ``_targets`` simply returns it. Resolving launcher_hardware -> SKU goes through
+    HUM hardware detection, which is fb-only, so it happens outside this OSS class:
+    the Meta ``create_sharding_plan`` entrypoint resolves the SKU via
+    ``get_training_hardware`` before constructing this orchestrator, keeping the
+    OSS layer free of any fb/HUM import.
+    """
+
+    def __init__(
+        self,
+        executor: PlannerExecutor,
+        sku: str,
+        broadcast_pg: Optional[dist.ProcessGroup] = None,
+    ) -> None:
+        super().__init__(executor, broadcast_pg=broadcast_pg)
+        self._sku = sku
+
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        return [self._sku]

--- a/torchrec/distributed/planner/api.py
+++ b/torchrec/distributed/planner/api.py
@@ -8,18 +8,40 @@
 # pyre-strict
 
 import abc
+import dataclasses
 import logging
-from typing import Dict, List, Mapping, Optional
+from typing import cast, Dict, List, Mapping, Optional
 
 import torch.distributed as dist
 from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
 from torchrec.distributed.planner.types import (
     PlannerSessionContext,
     ShardingPlanRequest,
     ShardingPlanResult,
+    Stats,
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _plan_dump_location(stats: Optional[List[Stats]]) -> Optional[str]:
+    """Best-effort persisted-plan location from a stats sink, if one provides it.
+
+    A sink that uploads the plan (e.g. the fb ``ManifoldStats``) exposes
+    ``get_most_recent_sharding_plan_dump_location``; read it duck-typed so the OSS
+    layer needs no fb import (the OSS console sink simply lacks it). Returns None
+    when no sink persisted a plan.
+    """
+    for sink in stats or []:
+        getter = getattr(sink, "get_most_recent_sharding_plan_dump_location", None)
+        if callable(getter):
+            # Duck-typed sink -> getter() is untyped; the sink returns the plan's
+            # str location, so cast to satisfy the declared Optional[str] return.
+            location = getter()
+            if location:
+                return cast(str, location)
+    return None
 
 
 class ShardingPlannerAPI(abc.ABC):
@@ -45,9 +67,15 @@ class ShardingPlannerAPI(abc.ABC):
     def __init__(
         self,
         executor: PlannerExecutor,
+        reporter: Optional[PlanReporter] = None,
         broadcast_pg: Optional[dist.ProcessGroup] = None,
     ) -> None:
         self._executor = executor
+        # Observability seam, owned here so dry-run and production share it; OSS
+        # default is console-only, Meta injects the Manifold/Scuba reporter.
+        self._reporter: PlanReporter = (
+            reporter if reporter is not None else DefaultPlanReporter()
+        )
         # Optional caller-injected process group for the rank-0 plan + broadcast.
         # APF passes its Gloo control group (cpu_ctl_dist_pg) here to avoid NCCL
         # object-broadcast corruption on some SKUs (e.g. GB300). When None,
@@ -93,7 +121,41 @@ class ShardingPlannerAPI(abc.ABC):
         # silently overwrite the earlier result.
         for sku in dict.fromkeys(self._targets(request)):
             try:
+                # ctx.stats is reporter-managed (not a caller input): rebuild fresh
+                # sinks per target so a multi-SKU dry-run sweep never reuses stateful
+                # sinks across SKUs. The executor forwards them (via ctx) to the
+                # SKU's planner. Owned here so all paths report alike. Observability
+                # is fail-isolated: building the sinks is best-effort so a telemetry
+                # failure never aborts planning -- on failure we plan with no sinks.
+                try:
+                    ctx.stats = self._reporter.build_stats(ctx, sku)
+                except Exception:
+                    logger.warning(
+                        "[planner] reporter build_stats failed for sku=%s; "
+                        "planning without stats sinks",
+                        sku,
+                        exc_info=True,
+                    )
+                    ctx.stats = []
                 result = self._executor.run(sku=sku, ctx=ctx, pg=pg)
+                # Surface where this SKU's plan was persisted (e.g. the Manifold
+                # upload path) onto the result so callers can locate each plan; the
+                # sink recorded it during executor.run. Result is frozen -> replace.
+                # Best-effort: reading a sink's dump location must not fail the
+                # (already-computed) plan.
+                try:
+                    plan_url = _plan_dump_location(ctx.stats)
+                except Exception:
+                    logger.warning(
+                        "[planner] reading plan dump location failed for sku=%s",
+                        sku,
+                        exc_info=True,
+                    )
+                    plan_url = None
+                if plan_url:
+                    result = dataclasses.replace(
+                        result, sharding_plan_manifold_url=plan_url
+                    )
                 result = self._finalize_result(sku, result, request)
             except Exception as e:
                 # Fail-fast by default (production plans a single SKU: a broken
@@ -103,7 +165,9 @@ class ShardingPlannerAPI(abc.ABC):
                 # what-if sweep -- it is recorded as an unsuccessful result and
                 # the loop keeps going. (``PlannerError`` is already turned into a
                 # success=False result inside the executor; this governs only the
-                # unexpected errors that would otherwise propagate.)
+                # unexpected errors that would otherwise propagate. Observability
+                # failures are already swallowed above, so this catches planning
+                # errors only.)
                 if not self._isolate_target_errors():
                     raise
                 logger.warning(
@@ -226,9 +290,10 @@ class ProductionPlannerOrchestrator(ShardingPlannerAPI):
         self,
         executor: PlannerExecutor,
         sku: str,
+        reporter: Optional[PlanReporter] = None,
         broadcast_pg: Optional[dist.ProcessGroup] = None,
     ) -> None:
-        super().__init__(executor, broadcast_pg=broadcast_pg)
+        super().__init__(executor, reporter, broadcast_pg=broadcast_pg)
         self._sku = sku
 
     def _targets(self, request: ShardingPlanRequest) -> List[str]:

--- a/torchrec/distributed/planner/dry_run/__init__.py
+++ b/torchrec/distributed/planner/dry_run/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/distributed/planner/dry_run/__init__.py
+++ b/torchrec/distributed/planner/dry_run/__init__.py
@@ -6,3 +6,30 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+
+from torchrec.distributed.planner.dry_run.api import DryRunOrchestrator  # noqa: F401
+from torchrec.distributed.planner.dry_run.protocols import (  # noqa: F401
+    CacheMetadata,
+    PlanCache,
+    PlannerExecutor,
+)
+from torchrec.distributed.planner.dry_run.types import (  # noqa: F401
+    CacheConfig,
+    DryRunRequest,
+    DryRunResult,
+    SkuOverride,
+)
+
+# Explicit public API: marks these names as first-class re-exports for strict
+# type checkers (mypy --no-implicit-reexport, pyright strict), which otherwise
+# treat imported-but-unassigned names as private to this module.
+__all__ = [
+    "CacheConfig",
+    "CacheMetadata",
+    "DryRunOrchestrator",
+    "DryRunRequest",
+    "DryRunResult",
+    "PlanCache",
+    "PlannerExecutor",
+    "SkuOverride",
+]

--- a/torchrec/distributed/planner/dry_run/api.py
+++ b/torchrec/distributed/planner/dry_run/api.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import cast, List, Mapping
+
+from torchrec.distributed.planner.api import ShardingPlannerAPI
+from torchrec.distributed.planner.dry_run.types import DryRunRequest, DryRunResult
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+
+class DryRunOrchestrator(ShardingPlannerAPI):
+    """Dry-run orchestrator: plans every SKU in the request's ``sku_list``.
+
+    Reuses the shared template ``plan`` from ShardingPlannerAPI and supplies the
+    dry-run target set via ``_targets`` — the DryRunRequest's concrete sku_list —
+    mirroring ProductionPlannerOrchestrator (which resolves launcher_hardware to a
+    single SKU). The executor is injected at construction; its PlannerProvider
+    selects OSS vs Meta topology/storage/planner.
+
+    Lives in ``dry_run/api.py`` (not ``protocols.py``) because it is a concrete
+    orchestrator, not a Protocol -- mirroring the base ``ShardingPlannerAPI`` in
+    ``planner/api.py`` -- so ``protocols.py`` stays protocol-only and consumers
+    that only need ``PlanCache`` don't transitively pull in ``planner:api``.
+    """
+
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        if not isinstance(request, DryRunRequest):
+            raise TypeError(
+                "DryRunOrchestrator requires a DryRunRequest; got "
+                f"{type(request).__name__}"
+            )
+        # Defensive copy: callers/the shared template may sort or filter the
+        # returned list, which must not mutate the request's sku_list in place.
+        return list(request.sku_list)
+
+    def _isolate_target_errors(self) -> bool:
+        # A dry-run is a what-if sweep across SKUs: one bad SKU (model factory,
+        # enum coercion, HUM lookup, ...) should be recorded as an unsuccessful
+        # result and the remaining SKUs still planned -- collect-and-continue --
+        # rather than aborting the whole sweep. (Production keeps the base
+        # fail-fast, since it plans a single SKU and a broken plan must surface.)
+        return True
+
+    def plan(
+        self,
+        request: ShardingPlanRequest,
+        ctx: PlannerSessionContext,
+    ) -> Mapping[str, DryRunResult]:
+        # Runs the shared template; every value is a DryRunResult (see
+        # _finalize_result), so narrow the return type for dry-run callers.
+        return cast(Mapping[str, DryRunResult], super().plan(request, ctx))
+
+    def _finalize_result(
+        self,
+        sku: str,
+        result: ShardingPlanResult,
+        request: ShardingPlanRequest,
+    ) -> DryRunResult:
+        """Enrich the per-SKU result with its (request, SKU) fingerprint."""
+        # _targets already validated the request is a DryRunRequest. from_result
+        # derives request_fingerprint from (request, sku), so the top-level sku
+        # and the SKU encoded in the fingerprint cannot disagree.
+        return DryRunResult.from_result(cast(DryRunRequest, request), sku, result)

--- a/torchrec/distributed/planner/dry_run/cli.py
+++ b/torchrec/distributed/planner/dry_run/cli.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Command-line tool for offline dry-run sharding-plan generation.
+
+Parses dry-run arguments, builds a ``DryRunRequest``, runs it through the
+dry-run orchestrator (one plan per SKU in ``--sku-list``), and prints the
+per-SKU ``DryRunResult`` inline. Uses the OSS provider; a Meta counterpart can
+reuse ``build_request`` / ``print_results`` and pass an orchestrator wired with
+``FbPlannerProvider`` for HUM topology + LinearProgramming/Manifold.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import cast, List, Mapping, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.dry_run.api import DryRunOrchestrator
+from torchrec.distributed.planner.dry_run.types import DryRunRequest, DryRunResult
+from torchrec.distributed.planner.executor import DefaultPlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerConfig,
+    PlannerSessionContext,
+    PlannerVariant,
+    StorageReservationPolicy,
+    TrainingFramework,
+)
+from torchrec.distributed.types import ModuleSharder
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+from torchrec.modules.embedding_modules import EmbeddingBagCollection
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run offline dry-run sharding planning across SKUs."
+    )
+    parser.add_argument(
+        "--sku-list",
+        required=True,
+        help="Comma-separated SKUs to plan for (TrainingHardware names for the "
+        "fb provider, e.g. 'GRANDTETON,GB200').",
+    )
+    parser.add_argument("--world-size", type=int, required=True)
+    parser.add_argument(
+        "--local-world-size",
+        type=int,
+        default=None,
+        help="Devices per host; defaults to --world-size.",
+    )
+    parser.add_argument("--batch-size", type=int, default=512)
+    parser.add_argument(
+        "--training-framework",
+        choices=["apf", "pyper", "mvai"],
+        default="apf",
+    )
+    parser.add_argument("--hbm-gb", type=float, default=None)
+    parser.add_argument("--ddr-gb", type=float, default=None)
+    parser.add_argument(
+        "--planner-variant",
+        choices=["oss", "linear_programming", "manifold"],
+        default="oss",
+    )
+    parser.add_argument(
+        "--storage-reservation-policy",
+        choices=["heuristical", "fixed_percentage", "inference"],
+        default=None,
+    )
+    parser.add_argument("--storage-reservation-percentage", type=float, default=None)
+    parser.add_argument("--manifold-path", default=None)
+    # Synthetic-model knobs (used by the default build_model_and_sharders).
+    parser.add_argument("--num-tables", type=int, default=4)
+    parser.add_argument("--num-embeddings", type=int, default=100_000)
+    parser.add_argument("--embedding-dim", type=int, default=128)
+    return parser
+
+
+def build_model_and_sharders(
+    args: argparse.Namespace,
+) -> Tuple[nn.Module, List[ModuleSharder[nn.Module]]]:
+    """Build a synthetic EmbeddingBagCollection so the CLI runs standalone."""
+    tables = [
+        EmbeddingBagConfig(
+            name=f"table_{i}",
+            embedding_dim=args.embedding_dim,
+            num_embeddings=args.num_embeddings,
+            feature_names=[f"feature_{i}"],
+        )
+        for i in range(args.num_tables)
+    ]
+    model = EmbeddingBagCollection(tables=tables, device=torch.device("meta"))
+    sharders = cast(List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()])
+    return model, sharders
+
+
+def build_planner_config(args: argparse.Namespace) -> PlannerConfig:
+    policy = (
+        StorageReservationPolicy(args.storage_reservation_policy)
+        if args.storage_reservation_policy is not None
+        else StorageReservationPolicy.UNSET
+    )
+    return PlannerConfig(
+        planner_variant=PlannerVariant(args.planner_variant),
+        storage_reservation_policy=policy,
+        storage_reservation_percentage=args.storage_reservation_percentage,
+        manifold_path=args.manifold_path,
+    )
+
+
+def build_request(
+    args: argparse.Namespace,
+    model: nn.Module,
+    sharders: List[ModuleSharder[nn.Module]],
+) -> DryRunRequest:
+    sku_list = [s.strip() for s in args.sku_list.split(",") if s.strip()]
+    return DryRunRequest(
+        model=model,
+        sharders=sharders,
+        sku_list=sku_list,
+        training_framework=TrainingFramework(args.training_framework),
+        world_size=args.world_size,
+        local_world_size=(
+            args.local_world_size
+            if args.local_world_size is not None
+            else args.world_size
+        ),
+        batch_size=args.batch_size,
+        hbm_gb=args.hbm_gb,
+        ddr_gb=args.ddr_gb,
+        planner_config=build_planner_config(args),
+    )
+
+
+def run(
+    args: argparse.Namespace,
+    orchestrator: Optional[DryRunOrchestrator] = None,
+) -> Mapping[str, DryRunResult]:
+    """Plan every SKU and return the per-SKU results.
+
+    ``orchestrator`` defaults to the OSS ``DefaultPlannerExecutor``; a Meta
+    caller passes one wired with ``FbPlannerProvider``.
+    """
+    model, sharders = build_model_and_sharders(args)
+    request = build_request(args, model, sharders)
+    ctx = PlannerSessionContext(request=request, results={})
+    orchestrator = orchestrator or DryRunOrchestrator(DefaultPlannerExecutor())
+    return orchestrator.plan(request, ctx)
+
+
+def print_results(results: Mapping[str, DryRunResult]) -> None:
+    print(f"Dry-run sharding plan: {len(results)} SKU(s)")
+    for sku in sorted(results):
+        result = results[sku]
+        status = "OK" if result.success else "FAIL"
+        print(
+            f"  [{status}] {sku} "
+            f"peak_hbm_bytes={result.estimated_max_hbm_bytes} "
+            f"peak_ddr_bytes={result.estimated_max_ddr_bytes} "
+            f"tables={len(result.sharding_options)} "
+            f"fingerprint={result.request_fingerprint}"
+        )
+        if not result.success:
+            print(f"    reason: {result.planner_failure_reason}")
+
+
+def main(
+    argv: Optional[List[str]] = None,
+    orchestrator: Optional[DryRunOrchestrator] = None,
+) -> int:
+    args = build_arg_parser().parse_args(argv)
+    results = run(args, orchestrator=orchestrator)
+    print_results(results)
+    # Non-zero exit if any SKU failed to plan, so scripts can gate on it.
+    return 0 if all(r.success for r in results.values()) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/torchrec/distributed/planner/dry_run/cli.py
+++ b/torchrec/distributed/planner/dry_run/cli.py
@@ -19,7 +19,8 @@ reuse ``build_request`` / ``print_results`` and pass an orchestrator wired with
 from __future__ import annotations
 
 import argparse
-from typing import cast, List, Mapping, Optional, Tuple
+import os
+from typing import Callable, cast, List, Mapping, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -47,7 +48,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--sku-list",
         required=True,
         help="Comma-separated SKUs to plan for (TrainingHardware names for the "
-        "fb provider, e.g. 'GRANDTETON,GB200').",
+        "fb provider, e.g. 'GRANDTETON,GB200'). The Meta CLI additionally accepts "
+        "abstract fungible pools (e.g. 'TC_ANY', 'TC_ANY_80G', 'GTT_ANY'), which "
+        "it expands into their candidate SKUs.",
     )
     parser.add_argument("--world-size", type=int, required=True)
     parser.add_argument(
@@ -80,6 +83,19 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--num-tables", type=int, default=4)
     parser.add_argument("--num-embeddings", type=int, default=100_000)
     parser.add_argument("--embedding-dim", type=int, default=128)
+    parser.add_argument(
+        "--print-plan",
+        action="store_true",
+        help="After the per-SKU summary, print the full sharding plan (table -> "
+        "sharding_type/kernel -> per-rank shards) for each successful SKU.",
+    )
+    parser.add_argument(
+        "--save-plan-dir",
+        default=None,
+        help="Directory to write each successful SKU's plan to, as "
+        "<dir>/<sku>_sharding_plan.txt. Local files only (this synthetic CLI does "
+        "not persist to Manifold; use the real-model CLI for that).",
+    )
     return parser
 
 
@@ -119,8 +135,14 @@ def build_request(
     args: argparse.Namespace,
     model: nn.Module,
     sharders: List[ModuleSharder[nn.Module]],
+    sku_resolver: Optional[Callable[[List[str]], List[str]]] = None,
 ) -> DryRunRequest:
     sku_list = [s.strip() for s in args.sku_list.split(",") if s.strip()]
+    # A Meta caller injects a resolver that expands abstract fungible pools
+    # (e.g. TC_ANY) into their concrete candidate SKUs. OSS default is identity:
+    # the list must already be concrete SKUs (OSS has no notion of the pools).
+    if sku_resolver is not None:
+        sku_list = sku_resolver(sku_list)
     return DryRunRequest(
         model=model,
         sharders=sharders,
@@ -142,21 +164,29 @@ def build_request(
 def run(
     args: argparse.Namespace,
     orchestrator: Optional[DryRunOrchestrator] = None,
+    sku_resolver: Optional[Callable[[List[str]], List[str]]] = None,
 ) -> Mapping[str, DryRunResult]:
     """Plan every SKU and return the per-SKU results.
 
     ``orchestrator`` defaults to the OSS ``DefaultPlannerExecutor``; a Meta
-    caller passes one wired with ``FbPlannerProvider``.
+    caller passes one wired with ``FbPlannerProvider``. ``sku_resolver`` is an
+    optional hook to expand abstract fungible pools into concrete SKUs.
     """
     model, sharders = build_model_and_sharders(args)
-    request = build_request(args, model, sharders)
+    request = build_request(args, model, sharders, sku_resolver=sku_resolver)
     ctx = PlannerSessionContext(request=request, results={})
     orchestrator = orchestrator or DryRunOrchestrator(DefaultPlannerExecutor())
     return orchestrator.plan(request, ctx)
 
 
-def print_results(results: Mapping[str, DryRunResult]) -> None:
+def print_results(
+    results: Mapping[str, DryRunResult],
+    print_plan: bool = False,
+    save_plan_dir: Optional[str] = None,
+) -> None:
     print(f"Dry-run sharding plan: {len(results)} SKU(s)")
+    if save_plan_dir is not None:
+        os.makedirs(save_plan_dir, exist_ok=True)
     for sku in sorted(results):
         result = results[sku]
         status = "OK" if result.success else "FAIL"
@@ -169,15 +199,30 @@ def print_results(results: Mapping[str, DryRunResult]) -> None:
         )
         if not result.success:
             print(f"    reason: {result.planner_failure_reason}")
+            continue
+        # The synthetic CLI does not persist, so the plan is only surfaced on
+        # request: printed inline and/or written to a local file per SKU.
+        plan = result.sharding_plan
+        if plan is None:
+            continue
+        if print_plan:
+            print(f"    plan for {sku}:")
+            print(plan)
+        if save_plan_dir is not None:
+            path = os.path.join(save_plan_dir, f"{sku}_sharding_plan.txt")
+            with open(path, "w") as f:
+                f.write(str(plan))
+            print(f"    saved plan: {path}")
 
 
 def main(
     argv: Optional[List[str]] = None,
     orchestrator: Optional[DryRunOrchestrator] = None,
+    sku_resolver: Optional[Callable[[List[str]], List[str]]] = None,
 ) -> int:
     args = build_arg_parser().parse_args(argv)
-    results = run(args, orchestrator=orchestrator)
-    print_results(results)
+    results = run(args, orchestrator=orchestrator, sku_resolver=sku_resolver)
+    print_results(results, print_plan=args.print_plan, save_plan_dir=args.save_plan_dir)
     # Non-zero exit if any SKU failed to plan, so scripts can gate on it.
     return 0 if all(r.success for r in results.values()) else 1
 

--- a/torchrec/distributed/planner/dry_run/protocols.py
+++ b/torchrec/distributed/planner/dry_run/protocols.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from torchrec.distributed.types import ShardingPlan
+
+
+@dataclass(frozen=True)
+class CacheMetadata:
+    """Metadata associated with a cached sharding plan entry."""
+
+    # Identity of the process or user that created this cache entry
+    created_by: str = ""
+    # Hardware SKU this cached plan was generated for
+    sku: str = ""
+    # World size the cached plan was generated with
+    world_size: int = 0
+    # Additional key-value metadata for debugging and tracing. Note: frozen=True
+    # only blocks rebinding fields; this dict is still mutable in place, so treat
+    # it as read-only after construction.
+    extra: dict[str, str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class PlanCache(Protocol):
+    """Protocol for caching and retrieving sharding plans by request fingerprint.
+
+    Implementations may back the cache with in-memory stores, Manifold,
+    or other persistent storage.
+
+    The ``request_fingerprint`` key is exactly the value returned by
+    ``DryRunRequest.fingerprint(sku)`` (``request_hash`` + the SKU + that SKU's
+    override) -- there is no extra runtime state -- so the cache keys on the same
+    per-(request, SKU) identity carried by ``DryRunResult.request_fingerprint``.
+    """
+
+    def get(
+        self, request_fingerprint: str
+    ) -> tuple[ShardingPlan, CacheMetadata] | None:
+        """Return the cached ``(plan, metadata)`` for a fingerprint, or None.
+
+        The metadata is returned alongside the plan so a cache hit can be
+        attributed (which SKU/world_size it was generated for, who created it)
+        without a second lookup.
+        """
+        ...
+
+    def put(
+        self,
+        request_fingerprint: str,
+        plan: ShardingPlan,
+        metadata: CacheMetadata,
+    ) -> None: ...

--- a/torchrec/distributed/planner/dry_run/protocols.py
+++ b/torchrec/distributed/planner/dry_run/protocols.py
@@ -10,6 +10,11 @@
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
+# Re-exported for dry-run consumers (see dry_run/__init__); the redundant alias
+# marks it as an intentional re-export for type checkers, noqa for flake8.
+from torchrec.distributed.planner.protocols import (  # noqa: F401
+    PlannerExecutor as PlannerExecutor,
+)
 from torchrec.distributed.types import ShardingPlan
 
 

--- a/torchrec/distributed/planner/dry_run/tests/__init__.py
+++ b/torchrec/distributed/planner/dry_run/tests/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict

--- a/torchrec/distributed/planner/dry_run/tests/test_api.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_api.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Optional
+
+import torch.nn as nn
+from torchrec.distributed.planner.api import ShardingPlannerAPI
+from torchrec.distributed.planner.dry_run.api import DryRunOrchestrator
+from torchrec.distributed.planner.dry_run.types import DryRunRequest, DryRunResult
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+
+class _RecordingExecutor:
+    """PlannerExecutor test double returning a successful result per SKU.
+
+    The executor builds topology/storage/planner internally (via its provider);
+    the double simply returns a result, so the DryRunOrchestrator can be
+    exercised without a real provider.
+    """
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: object = None,
+    ) -> ShardingPlanResult:
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+        )
+
+
+class _FailingExecutor:
+    """Test double returning a FAILED result per SKU (planner could not fit)."""
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: object = None,
+    ) -> ShardingPlanResult:
+        return ShardingPlanResult(
+            sku=sku,
+            success=False,
+            sharding_plan=None,
+            planner_failure_reason="OOM_HBM",
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+        )
+
+
+class _RaisingExecutor:
+    """Test double that raises for a specific SKU (models an executor blowup)."""
+
+    def __init__(self, raise_on: str) -> None:
+        self._raise_on = raise_on
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: object = None,
+    ) -> ShardingPlanResult:
+        if sku == self._raise_on:
+            raise RuntimeError(f"executor blew up on {sku}")
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+        )
+
+
+class DryRunOrchestratorTest(unittest.TestCase):
+    def _request(self, **kwargs: object) -> DryRunRequest:
+        defaults: dict[str, object] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "sku_list": ["H100"],
+            "training_framework": "apf",
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return DryRunRequest(**defaults)  # pyre-ignore[6]
+
+    def _orchestrator(
+        self, executor: Optional[PlannerExecutor] = None
+    ) -> DryRunOrchestrator:
+        return DryRunOrchestrator(executor or _RecordingExecutor())
+
+    def test_is_subclass_of_sharding_planner_api(self) -> None:
+        self.assertTrue(issubclass(DryRunOrchestrator, ShardingPlannerAPI))
+
+    def test_targets_returns_sku_list(self) -> None:
+        request = self._request(sku_list=["H100", "GB200"])
+        self.assertEqual(self._orchestrator()._targets(request), ["H100", "GB200"])
+
+    def test_targets_rejects_non_dry_run_request(self) -> None:
+        request = ShardingPlanRequest(
+            model=nn.Linear(10, 10),
+            sharders=[],
+            world_size=8,
+            local_world_size=8,
+            batch_size=512,
+        )
+        with self.assertRaisesRegex(TypeError, "DryRunRequest"):
+            self._orchestrator()._targets(request)
+
+    def test_plan_runs_every_sku_via_template(self) -> None:
+        # E2E through the shared ShardingPlannerAPI.plan template: one result per
+        # SKU in the request's sku_list, aggregated into the returned map and
+        # onto ctx.results.
+        request = self._request(sku_list=["H100", "GB200"])
+        ctx = PlannerSessionContext(request=request, results={})
+        results = self._orchestrator().plan(request, ctx)
+        self.assertEqual(set(results), {"H100", "GB200"})
+        self.assertTrue(results["H100"].success)
+        self.assertEqual(results["GB200"].sku, "GB200")
+        self.assertIs(ctx.results["H100"], results["H100"])
+
+    def test_plan_produces_dry_run_result_with_fingerprint(self) -> None:
+        # The dry-run orchestrator enriches each result into a DryRunResult
+        # carrying the per-(request, SKU) fingerprint.
+        request = self._request(sku_list=["H100", "GB200"])
+        ctx = PlannerSessionContext(request=request, results={})
+        results = self._orchestrator().plan(request, ctx)
+        for sku in ("H100", "GB200"):
+            self.assertIsInstance(results[sku], DryRunResult)
+            self.assertEqual(results[sku].request_fingerprint, request.fingerprint(sku))
+        # Distinct SKUs get distinct fingerprints.
+        self.assertNotEqual(
+            results["H100"].request_fingerprint, results["GB200"].request_fingerprint
+        )
+
+    def test_plan_finalizes_failed_result(self) -> None:
+        # A failed per-SKU result must still be finalized into a DryRunResult with
+        # its fingerprint (DryRunResult.from_result accepts success=False), not
+        # dropped -- so a caller sees which SKUs could not be planned.
+        request = self._request(sku_list=["H100", "GB200"])
+        ctx = PlannerSessionContext(request=request, results={})
+        results = self._orchestrator(_FailingExecutor()).plan(request, ctx)
+        for sku in ("H100", "GB200"):
+            self.assertIsInstance(results[sku], DryRunResult)
+            self.assertFalse(results[sku].success)
+            self.assertEqual(results[sku].planner_failure_reason, "OOM_HBM")
+            self.assertEqual(results[sku].request_fingerprint, request.fingerprint(sku))
+
+    def test_plan_isolates_executor_exception_and_continues(self) -> None:
+        # A dry-run is a what-if sweep: if the executor raises an unexpected error
+        # (not a PlannerError it converts to a failed result) on one SKU, that SKU
+        # is recorded as an unsuccessful DryRunResult (with the error as its
+        # failure reason) and the remaining SKUs are still planned -- rather than
+        # aborting the whole sweep. This is the DryRunOrchestrator override of the
+        # base fail-fast contract (_isolate_target_errors).
+        request = self._request(sku_list=["H100", "GB200"])
+        ctx = PlannerSessionContext(request=request, results={})
+        results = self._orchestrator(_RaisingExecutor(raise_on="H100")).plan(
+            request, ctx
+        )
+        self.assertEqual(set(results), {"H100", "GB200"})
+        # The failing SKU: an unsuccessful DryRunResult carrying the error, with
+        # its fingerprint preserved so the caller sees which SKU could not plan.
+        self.assertIsInstance(results["H100"], DryRunResult)
+        self.assertFalse(results["H100"].success)
+        self.assertIn("RuntimeError", results["H100"].planner_failure_reason or "")
+        self.assertIn(
+            "executor blew up on H100", results["H100"].planner_failure_reason or ""
+        )
+        self.assertEqual(
+            results["H100"].request_fingerprint, request.fingerprint("H100")
+        )
+        # The other SKU still planned successfully.
+        self.assertTrue(results["GB200"].success)
+
+    def test_production_path_still_fails_fast(self) -> None:
+        # The isolation is dry-run-only: the base contract stays fail-fast so a
+        # broken production plan is never silently swallowed.
+        from torchrec.distributed.planner.api import ProductionPlannerOrchestrator
+
+        request = ShardingPlanRequest(
+            model=nn.Linear(10, 10),
+            sharders=[],
+            world_size=8,
+            local_world_size=8,
+            batch_size=512,
+        )
+        ctx = PlannerSessionContext(request=request, results={})
+        with self.assertRaisesRegex(RuntimeError, "executor blew up on H100"):
+            ProductionPlannerOrchestrator(
+                _RaisingExecutor(raise_on="H100"), "H100"
+            ).plan(request, ctx)

--- a/torchrec/distributed/planner/dry_run/tests/test_cli.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_cli.py
@@ -7,6 +7,8 @@
 
 # pyre-strict
 
+import os
+import tempfile
 import unittest
 
 from torchrec.distributed.planner.dry_run import cli
@@ -39,6 +41,38 @@ class DryRunCLITest(unittest.TestCase):
         rc = cli.main(["--sku-list", "H100", "--world-size", "2", *_SMALL_MODEL_ARGS])
         self.assertEqual(rc, 0)
 
+    def test_print_plan_exits_zero(self) -> None:
+        rc = cli.main(
+            [
+                "--sku-list",
+                "H100",
+                "--world-size",
+                "2",
+                "--print-plan",
+                *_SMALL_MODEL_ARGS,
+            ]
+        )
+        self.assertEqual(rc, 0)
+
+    def test_save_plan_dir_writes_a_file_per_sku(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            rc = cli.main(
+                [
+                    "--sku-list",
+                    "H100,GB200",
+                    "--world-size",
+                    "2",
+                    "--save-plan-dir",
+                    d,
+                    *_SMALL_MODEL_ARGS,
+                ]
+            )
+            self.assertEqual(rc, 0)
+            for sku in ("H100", "GB200"):
+                path = os.path.join(d, f"{sku}_sharding_plan.txt")
+                self.assertTrue(os.path.exists(path), path)
+                self.assertGreater(os.path.getsize(path), 0)
+
     def test_local_world_size_defaults_to_world_size(self) -> None:
         args = cli.build_arg_parser().parse_args(
             ["--sku-list", "H100", "--world-size", "4", *_SMALL_MODEL_ARGS]
@@ -47,3 +81,26 @@ class DryRunCLITest(unittest.TestCase):
         request = cli.build_request(args, model, sharders)
         self.assertEqual(request.local_world_size, 4)
         self.assertEqual(request.sku_list, ["H100"])
+
+    def test_sku_resolver_expands_sku_list(self) -> None:
+        # The resolver hook lets a Meta caller expand abstract pools; OSS itself
+        # stays agnostic and just applies whatever callable is injected.
+        args = cli.build_arg_parser().parse_args(
+            ["--sku-list", "POOL", "--world-size", "2", *_SMALL_MODEL_ARGS]
+        )
+        model, sharders = cli.build_model_and_sharders(args)
+        request = cli.build_request(
+            args,
+            model,
+            sharders,
+            sku_resolver=lambda skus: ["H100", "GB200"] if skus == ["POOL"] else skus,
+        )
+        self.assertEqual(request.sku_list, ["H100", "GB200"])
+
+    def test_no_sku_resolver_is_identity(self) -> None:
+        args = cli.build_arg_parser().parse_args(
+            ["--sku-list", "H100,GB200", "--world-size", "2", *_SMALL_MODEL_ARGS]
+        )
+        model, sharders = cli.build_model_and_sharders(args)
+        request = cli.build_request(args, model, sharders)
+        self.assertEqual(request.sku_list, ["H100", "GB200"])

--- a/torchrec/distributed/planner/dry_run/tests/test_cli.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_cli.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from torchrec.distributed.planner.dry_run import cli
+from torchrec.distributed.planner.dry_run.types import DryRunResult
+
+# Small synthetic model so the real OSS planner runs quickly offline.
+_SMALL_MODEL_ARGS = [
+    "--num-tables",
+    "2",
+    "--num-embeddings",
+    "100",
+    "--embedding-dim",
+    "16",
+]
+
+
+class DryRunCLITest(unittest.TestCase):
+    def test_run_returns_dry_run_result_per_sku(self) -> None:
+        args = cli.build_arg_parser().parse_args(
+            ["--sku-list", "H100,GB200", "--world-size", "2", *_SMALL_MODEL_ARGS]
+        )
+        results = cli.run(args)
+        self.assertEqual(set(results), {"H100", "GB200"})
+        for sku in ("H100", "GB200"):
+            self.assertIsInstance(results[sku], DryRunResult)
+            self.assertTrue(results[sku].success, results[sku].planner_failure_reason)
+            self.assertTrue(results[sku].request_fingerprint)
+
+    def test_main_prints_report_and_exits_zero(self) -> None:
+        rc = cli.main(["--sku-list", "H100", "--world-size", "2", *_SMALL_MODEL_ARGS])
+        self.assertEqual(rc, 0)
+
+    def test_local_world_size_defaults_to_world_size(self) -> None:
+        args = cli.build_arg_parser().parse_args(
+            ["--sku-list", "H100", "--world-size", "4", *_SMALL_MODEL_ARGS]
+        )
+        model, sharders = cli.build_model_and_sharders(args)
+        request = cli.build_request(args, model, sharders)
+        self.assertEqual(request.local_world_size, 4)
+        self.assertEqual(request.sku_list, ["H100"])

--- a/torchrec/distributed/planner/dry_run/tests/test_init.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_init.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torchrec.distributed.planner.dry_run as dry_run
+
+
+class InitReExportTest(unittest.TestCase):
+    """Verify that all public types and protocols are re-exported from __init__.py."""
+
+    def test_types_reexported(self) -> None:
+        expected_types = [
+            "CacheConfig",
+            "DryRunRequest",
+            "DryRunResult",
+            "SkuOverride",
+        ]
+        for name in expected_types:
+            self.assertTrue(
+                hasattr(dry_run, name),
+                f"{name} not re-exported from dry_run.__init__",
+            )
+
+    def test_protocols_reexported(self) -> None:
+        expected_protocols = [
+            "CacheMetadata",
+            "DryRunOrchestrator",
+            "PlanCache",
+            "PlannerExecutor",
+        ]
+        for name in expected_protocols:
+            self.assertTrue(
+                hasattr(dry_run, name),
+                f"{name} not re-exported from dry_run.__init__",
+            )
+
+    def test_import_from_package_directly(self) -> None:
+        from torchrec.distributed.planner.dry_run import (
+            DryRunRequest,
+            DryRunResult,
+            PlanCache,
+            PlannerExecutor,
+        )
+
+        self.assertIsNotNone(DryRunRequest)
+        self.assertIsNotNone(DryRunResult)
+        self.assertIsNotNone(PlanCache)
+        self.assertIsNotNone(PlannerExecutor)
+
+    def test_types_are_same_objects(self) -> None:
+        from torchrec.distributed.planner.dry_run.types import DryRunRequest
+
+        self.assertIs(dry_run.DryRunRequest, DryRunRequest)
+
+    def test_protocols_are_same_objects(self) -> None:
+        from torchrec.distributed.planner.dry_run.protocols import PlanCache
+
+        self.assertIs(dry_run.PlanCache, PlanCache)

--- a/torchrec/distributed/planner/dry_run/tests/test_protocols.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_protocols.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import dataclasses
+import unittest
+
+from torchrec.distributed.planner.dry_run.protocols import CacheMetadata, PlanCache
+from torchrec.distributed.types import ShardingPlan
+
+
+class MockPlanCache:
+    """Test implementation of PlanCache."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[ShardingPlan, CacheMetadata]] = {}
+
+    def get(
+        self, request_fingerprint: str
+    ) -> tuple[ShardingPlan, CacheMetadata] | None:
+        return self._store.get(request_fingerprint)
+
+    def put(
+        self,
+        request_fingerprint: str,
+        plan: ShardingPlan,
+        metadata: CacheMetadata,
+    ) -> None:
+        self._store[request_fingerprint] = (plan, metadata)
+
+
+class CacheMetadataTest(unittest.TestCase):
+    def test_defaults(self) -> None:
+        meta = CacheMetadata()
+        self.assertEqual(meta.created_by, "")
+        self.assertEqual(meta.sku, "")
+        self.assertEqual(meta.world_size, 0)
+        self.assertEqual(meta.extra, {})
+
+    def test_with_all_fields(self) -> None:
+        meta = CacheMetadata(
+            created_by="dry_run_service",
+            sku="H100",
+            world_size=16,
+            extra={"version": "2"},
+        )
+        self.assertEqual(meta.created_by, "dry_run_service")
+        self.assertEqual(meta.sku, "H100")
+        self.assertEqual(meta.world_size, 16)
+        self.assertEqual(meta.extra, {"version": "2"})
+
+    def test_frozen(self) -> None:
+        meta = CacheMetadata()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            meta.created_by = "x"  # pyre-ignore[41]
+
+    def test_equality(self) -> None:
+        m1 = CacheMetadata(created_by="a", sku="H100")
+        m2 = CacheMetadata(created_by="a", sku="H100")
+        self.assertEqual(m1, m2)
+
+
+class PlanCacheTest(unittest.TestCase):
+    def test_runtime_checkable(self) -> None:
+        cache = MockPlanCache()
+        self.assertIsInstance(cache, PlanCache)
+
+    def test_get_miss(self) -> None:
+        cache = MockPlanCache()
+        self.assertIsNone(cache.get("nonexistent"))
+
+    def test_put_and_get(self) -> None:
+        cache = MockPlanCache()
+        plan = ShardingPlan(plan={})
+        meta = CacheMetadata(created_by="test", sku="H100", world_size=8)
+        cache.put("hash123", plan, meta)
+        result = cache.get("hash123")
+        self.assertIsNotNone(result)
+        # get() returns (plan, metadata) so a hit is self-describing.
+        assert result is not None
+        self.assertIs(result[0], plan)
+        self.assertIs(result[1], meta)
+
+    def test_put_overwrites(self) -> None:
+        cache = MockPlanCache()
+        plan1 = ShardingPlan(plan={})
+        plan2 = ShardingPlan(plan={})
+        meta = CacheMetadata()
+        cache.put("h", plan1, meta)
+        cache.put("h", plan2, meta)
+        # plan1 and plan2 compare equal (both empty), so assert identity to prove
+        # the second put actually replaced the first rather than relying on ==.
+        hit = cache.get("h")
+        assert hit is not None
+        self.assertIs(hit[0], plan2)
+        self.assertIsNot(hit[0], plan1)
+
+    def test_non_conforming_class_not_instance(self) -> None:
+        class NoPlanCache:
+            pass
+
+        self.assertNotIsInstance(NoPlanCache(), PlanCache)
+
+    def test_class_with_get_put_is_instance(self) -> None:
+        class HasGetPut:
+            def get(
+                self, request_fingerprint: str
+            ) -> tuple[ShardingPlan, CacheMetadata] | None:
+                return None
+
+            def put(
+                self,
+                request_fingerprint: str,
+                plan: ShardingPlan,
+                metadata: CacheMetadata,
+            ) -> None:
+                pass
+
+        self.assertIsInstance(HasGetPut(), PlanCache)

--- a/torchrec/distributed/planner/dry_run/tests/test_types.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_types.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import Any, Dict
+
+import torch.nn as nn
+from torchrec.distributed.planner.dry_run.types import (
+    CacheConfig,
+    DryRunRequest,
+    SkuOverride,
+)
+from torchrec.distributed.planner.types import ParameterConstraints, ShardingPlanRequest
+
+
+class DryRunRequestTest(unittest.TestCase):
+    def _create_request(self, **kwargs: Any) -> DryRunRequest:
+        defaults: Dict[str, Any] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "sku_list": ["H100"],
+            "training_framework": "apf",
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return DryRunRequest(**defaults)
+
+    def test_valid_request_construction(self) -> None:
+        override = SkuOverride(hbm_gb=80.0, ddr_gb=512.0)
+        cache = CacheConfig(enabled=True, ttl_seconds=3600, manifold_bucket="test")
+        request = self._create_request(
+            pod_size=8,
+            hbm_gb=80.0,
+            ddr_gb=512.0,
+            per_sku_overrides={"H100": override},
+            cache_config=cache,
+        )
+        self.assertEqual(request.world_size, 8)
+        self.assertEqual(request.hbm_gb, 80.0)
+        self.assertIsNotNone(request.per_sku_overrides)
+        self.assertIsNotNone(request.cache_config)
+        self.assertTrue(request.cache_config.enabled)
+
+    def test_empty_sku_list_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sku_list must not be empty"):
+            self._create_request(sku_list=[])
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"world_size": 0}, "world_size must be positive"),
+            ({"world_size": -1}, "world_size must be positive"),
+            ({"local_world_size": 0}, "local_world_size must be positive"),
+            ({"batch_size": 0}, "batch_size must be positive"),
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -10.0}, "ddr_gb must be non-negative"),
+            ({"pod_size": 0}, "pod_size must be positive"),
+            ({"pod_size": -1}, "pod_size must be positive"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_request(**overrides)
+
+    def test_cross_field_validation(self) -> None:
+        with self.subTest("local exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "local_world_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=4, local_world_size=8)
+        with self.subTest("world not divisible by local"):
+            with self.assertRaisesRegex(
+                ValueError, "world_size.*must be divisible by local_world_size"
+            ):
+                self._create_request(world_size=10, local_world_size=3)
+
+    def test_zero_hbm_gb_allowed(self) -> None:
+        request = self._create_request(hbm_gb=0.0)
+        self.assertEqual(request.hbm_gb, 0.0)
+
+    def test_model_callable_factory(self) -> None:
+        constructed = nn.Linear(10, 10)
+        factory = lambda: constructed  # noqa: E731
+        request = self._create_request(model=factory)
+        self.assertNotIsInstance(request.model, nn.Module)
+        # pyre-ignore[29]: factory is callable
+        self.assertIs(request.model(), constructed)
+
+    def test_model_module_vs_factory_disambiguation(self) -> None:
+        module = nn.Linear(10, 10)
+        factory = lambda: module  # noqa: E731
+        req_module = self._create_request(model=module)
+        req_factory = self._create_request(model=factory)
+        self.assertIsInstance(req_module.model, nn.Module)
+        self.assertNotIsInstance(req_factory.model, nn.Module)
+
+    def test_multi_sku_with_per_sku_overrides(self) -> None:
+        request = self._create_request(
+            sku_list=["H100", "GB200"],
+            per_sku_overrides={
+                "H100": SkuOverride(hbm_gb=80.0),
+                "GB200": SkuOverride(hbm_gb=192.0),
+            },
+        )
+        self.assertEqual(len(request.sku_list), 2)
+        assert request.per_sku_overrides is not None
+        self.assertEqual(request.per_sku_overrides["H100"].hbm_gb, 80.0)
+        self.assertEqual(request.per_sku_overrides["GB200"].hbm_gb, 192.0)
+
+    def test_fingerprint_deterministic(self) -> None:
+        req = self._create_request()
+        self.assertEqual(req.fingerprint("H100"), req.fingerprint("H100"))
+
+    def test_fingerprint_differs_by_sku(self) -> None:
+        req = self._create_request(sku_list=["H100", "GB200"])
+        self.assertNotEqual(req.fingerprint("H100"), req.fingerprint("GB200"))
+
+    def test_fingerprint_differs_by_config(self) -> None:
+        req1 = self._create_request(batch_size=512)
+        req2 = self._create_request(batch_size=1024)
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_includes_per_sku_override(self) -> None:
+        req_no_override = self._create_request()
+        req_with_override = self._create_request(
+            per_sku_overrides={"H100": SkuOverride(hbm_gb=80.0)},
+        )
+        self.assertNotEqual(
+            req_no_override.fingerprint("H100"),
+            req_with_override.fingerprint("H100"),
+        )
+
+    def test_fingerprint_differs_by_constraints(self) -> None:
+        # Constraints change the resulting plan, so they must change the
+        # fingerprint. They participate via the composed request_hash; before
+        # that composition, constraint-only differences collided.
+        req1 = self._create_request()
+        req2 = self._create_request(
+            constraints={"t1": ParameterConstraints(min_partition=8)},
+        )
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_differs_by_launcher_hardware(self) -> None:
+        req1 = self._create_request(launcher_hardware="ZIONEX")
+        req2 = self._create_request(launcher_hardware="GRANDTETON")
+        self.assertNotEqual(req1.fingerprint("H100"), req2.fingerprint("H100"))
+
+    def test_fingerprint_length(self) -> None:
+        req = self._create_request()
+        self.assertEqual(len(req.fingerprint("H100")), 16)
+
+    def test_inherits_sharding_plan_request(self) -> None:
+        req = self._create_request()
+        self.assertIsInstance(req, ShardingPlanRequest)
+
+    def test_empty_training_framework_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "training_framework is required for dry-run"
+        ):
+            self._create_request(training_framework="")
+
+    def test_base_fields_accessible(self) -> None:
+        req = self._create_request(
+            launcher_hardware="ZIONEX",
+        )
+        self.assertEqual(req.launcher_hardware, "ZIONEX")
+        self.assertEqual(req.training_framework, "apf")
+
+
+class SkuOverrideTest(unittest.TestCase):
+    def test_negative_value_rejected(self) -> None:
+        cases = [
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -512.0}, "ddr_gb must be non-negative"),
+            ({"intra_host_bw": -100.0}, "intra_host_bw must be non-negative"),
+            ({"inter_host_bw": -50.0}, "inter_host_bw must be non-negative"),
+        ]
+        for kwargs, expected_msg in cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    SkuOverride(**kwargs)
+
+    def test_zero_values_allowed(self) -> None:
+        override = SkuOverride(hbm_gb=0.0, ddr_gb=0.0)
+        self.assertEqual(override.hbm_gb, 0.0)
+        self.assertEqual(override.ddr_gb, 0.0)
+
+
+class CacheConfigTest(unittest.TestCase):
+    def test_enabled_requires_manifold_bucket(self) -> None:
+        with self.assertRaisesRegex(ValueError, "manifold_bucket is required"):
+            CacheConfig(enabled=True, manifold_bucket="")
+
+    def test_enabled_with_bucket_valid(self) -> None:
+        config = CacheConfig(
+            enabled=True, ttl_seconds=3600, manifold_bucket="dry_run_cache"
+        )
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.manifold_bucket, "dry_run_cache")
+
+    def test_disabled_without_bucket_valid(self) -> None:
+        config = CacheConfig(enabled=False)
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.manifold_bucket, "")
+
+    def test_invalid_ttl_rejected(self) -> None:
+        for ttl in (0, -1):
+            with self.subTest(ttl=ttl):
+                with self.assertRaisesRegex(ValueError, "ttl_seconds must be positive"):
+                    CacheConfig(ttl_seconds=ttl)

--- a/torchrec/distributed/planner/dry_run/tests/test_types.py
+++ b/torchrec/distributed/planner/dry_run/tests/test_types.py
@@ -14,9 +14,14 @@ import torch.nn as nn
 from torchrec.distributed.planner.dry_run.types import (
     CacheConfig,
     DryRunRequest,
+    DryRunResult,
     SkuOverride,
 )
-from torchrec.distributed.planner.types import ParameterConstraints, ShardingPlanRequest
+from torchrec.distributed.planner.types import (
+    ParameterConstraints,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
 
 
 class DryRunRequestTest(unittest.TestCase):
@@ -215,3 +220,101 @@ class CacheConfigTest(unittest.TestCase):
             with self.subTest(ttl=ttl):
                 with self.assertRaisesRegex(ValueError, "ttl_seconds must be positive"):
                     CacheConfig(ttl_seconds=ttl)
+
+
+class DryRunResultTest(unittest.TestCase):
+    def _create_success_result(self, **kwargs: Any) -> DryRunResult:
+        defaults: Dict[str, Any] = {
+            "sku": "H100",
+            "success": True,
+            "sharding_plan": None,
+            "planner_failure_reason": None,
+            "estimated_max_hbm_bytes": 40 * 1024**3,
+            "estimated_max_ddr_bytes": 200 * 1024**3,
+            "request_fingerprint": "abc123def456ab00",
+        }
+        defaults.update(kwargs)
+        return DryRunResult(**defaults)
+
+    def _create_failure_result(self, **kwargs: Any) -> DryRunResult:
+        defaults: Dict[str, Any] = {
+            "sku": "H100",
+            "success": False,
+            "sharding_plan": None,
+            "planner_failure_reason": "OOM_HBM",
+            "estimated_max_hbm_bytes": 90 * 1024**3,
+            "estimated_max_ddr_bytes": 200 * 1024**3,
+            "request_fingerprint": "abc123def456ab00",
+        }
+        defaults.update(kwargs)
+        return DryRunResult(**defaults)
+
+    def test_empty_sku_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sku must not be empty"):
+            self._create_success_result(sku="")
+
+    def test_request_fingerprint_stored(self) -> None:
+        # Positive path: a supplied fingerprint is retained and retrievable.
+        result = self._create_success_result(request_fingerprint="fp_deadbeef00")
+        self.assertEqual(result.request_fingerprint, "fp_deadbeef00")
+
+    def test_empty_request_fingerprint_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "request_fingerprint must not be empty"
+        ):
+            self._create_success_result(request_fingerprint="")
+
+    def test_negative_hbm_bytes_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "estimated_max_hbm_bytes must be non-negative"
+        ):
+            self._create_success_result(estimated_max_hbm_bytes=-1)
+
+    def test_negative_ddr_bytes_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "estimated_max_ddr_bytes must be non-negative"
+        ):
+            self._create_success_result(estimated_max_ddr_bytes=-1)
+
+    def test_success_with_failure_reason_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "planner_failure_reason must be None when success is True"
+        ):
+            self._create_success_result(planner_failure_reason="OOM_HBM")
+
+    def test_failure_without_reason_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "planner_failure_reason is required when success is False"
+        ):
+            self._create_failure_result(planner_failure_reason=None)
+
+    def test_negative_estimated_qps_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "estimated_qps must be non-negative"):
+            self._create_success_result(estimated_qps=-1.0)
+
+    def test_negative_critical_path_ms_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "critical_path_ms must be non-negative"
+        ):
+            self._create_success_result(critical_path_ms=-0.5)
+
+    def test_validation_warnings_tuple(self) -> None:
+        result = self._create_success_result()
+        self.assertEqual(result.validation_warnings, ())
+        warnings = ("high HBM usage", "close to DDR limit", "untested SKU")
+        result_with = self._create_success_result(validation_warnings=warnings)
+        self.assertEqual(len(result_with.validation_warnings), 3)
+        self.assertIn("untested SKU", result_with.validation_warnings)
+
+    def test_manifold_url(self) -> None:
+        # Uses the inherited sharding_plan_manifold_url (no DryRunResult-specific
+        # manifold_url field).
+        result = self._create_success_result()
+        self.assertIsNone(result.sharding_plan_manifold_url)
+        url = "manifold://tbe_benchmarking/tree/dry_run/plans/abc.json"
+        result_with = self._create_success_result(sharding_plan_manifold_url=url)
+        self.assertEqual(result_with.sharding_plan_manifold_url, url)
+
+    def test_inherits_sharding_plan_result(self) -> None:
+        result = self._create_success_result()
+        self.assertIsInstance(result, ShardingPlanResult)

--- a/torchrec/distributed/planner/dry_run/types.py
+++ b/torchrec/distributed/planner/dry_run/types.py
@@ -9,10 +9,10 @@
 
 import hashlib
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Optional
 
-from torchrec.distributed.planner.types import ShardingPlanRequest
+from torchrec.distributed.planner.types import ShardingPlanRequest, ShardingPlanResult
 
 
 @dataclass(frozen=True)
@@ -146,3 +146,54 @@ class DryRunRequest(ShardingPlanRequest):
         }
         canonical = json.dumps(parts, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class DryRunResult(ShardingPlanResult):
+    """Immutable result of dry-run sharding plan validation for a single SKU.
+
+    Extends ShardingPlanResult with the per-SKU request fingerprint. The
+    uploaded-plan URL reuses the inherited sharding_plan_manifold_url; the
+    request-level identity reuses the inherited request_hash (by content) and
+    request_id (by instance).
+
+    Invariant: ``request_fingerprint == request.fingerprint(sku)`` -- the SKU the
+    fingerprint encodes must match the top-level ``sku``. Build via
+    ``DryRunResult.from_result(request, sku, base_result)``, which guarantees it;
+    direct construction is allowed but must uphold it.
+    """
+
+    # Per-(request, SKU) key from DryRunRequest.fingerprint(sku); keys the
+    # per-SKU results map and correlates TUO iterative validation runs.
+    # Distinct from the inherited request-level fields: it composes request_hash
+    # with the SKU and per-SKU override, so each SKU's result gets a unique key
+    # (the request-level request_hash/request_id are the same across SKUs).
+    # Effectively required: the "" default exists only because the base class has
+    # defaulted fields (so every subclass field must default too); __post_init__
+    # rejects an empty value, so callers must always supply a real fingerprint.
+    request_fingerprint: str = ""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.request_fingerprint:
+            raise ValueError("request_fingerprint must not be empty")
+
+    @classmethod
+    def from_result(
+        cls,
+        request: DryRunRequest,
+        sku: str,
+        result: ShardingPlanResult,
+    ) -> "DryRunResult":
+        """Wrap a base ShardingPlanResult as a DryRunResult for ``sku``.
+
+        The sanctioned constructor: it derives ``request_fingerprint =
+        request.fingerprint(sku)`` and forces ``sku=sku``, so the top-level SKU
+        and the SKU encoded in the fingerprint cannot disagree -- the mismatch is
+        unrepresentable through this path.
+        """
+        base_fields = {
+            f.name: getattr(result, f.name) for f in fields(ShardingPlanResult)
+        }
+        base_fields["sku"] = sku
+        return cls(**base_fields, request_fingerprint=request.fingerprint(sku))

--- a/torchrec/distributed/planner/dry_run/types.py
+++ b/torchrec/distributed/planner/dry_run/types.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional
+
+from torchrec.distributed.planner.types import ShardingPlanRequest
+
+
+@dataclass(frozen=True)
+class SkuOverride:
+    """Per-SKU hardware overrides for dry-run topology building.
+
+    HARDWARE_CAPABILITIES registry values can be stale vs MAST runtime.
+    Overrides enable what-if exploration and stricter dry runs for APS,
+    and support TC_ANY multi-SKU validation with per-SKU tuning.
+    """
+
+    # Override HBM capacity (GB) when registry values are stale or for what-if testing
+    hbm_gb: Optional[float] = None
+    # Override DDR capacity (GB) — DDR varies inversely with HBM on many SKUs
+    ddr_gb: Optional[float] = None
+    # Override intra-host bandwidth (GB/s) for NVLink/NVSwitch topology modeling
+    intra_host_bw: Optional[float] = None
+    # Override inter-host bandwidth (GB/s) for cross-node communication modeling
+    inter_host_bw: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("hbm_gb", "ddr_gb", "intra_host_bw", "inter_host_bw"):
+            val = getattr(self, name)
+            if val is not None and val < 0:
+                raise ValueError(f"{name} must be non-negative, got {val}")
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Configuration for dry-run plan caching.
+
+    Same topology+model params produce the same sharding plan, so caching
+    avoids re-running the expensive ILP solver on repeated requests.
+    """
+
+    # Master switch — disabled by default to avoid stale plans during development
+    enabled: bool = False
+    # Cache TTL — None means entries never expire; set for production use
+    ttl_seconds: Optional[int] = None
+    # Manifold bucket for persistent cross-session caching
+    manifold_bucket: str = ""
+
+    def __post_init__(self) -> None:
+        if self.ttl_seconds is not None and self.ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive, got {self.ttl_seconds}")
+        if self.enabled and not self.manifold_bucket:
+            raise ValueError("manifold_bucket is required when caching is enabled")
+
+
+@dataclass(frozen=True)
+class DryRunRequest(ShardingPlanRequest):
+    """Immutable request for dry-run sharding plan validation across SKUs.
+
+    Extends ShardingPlanRequest with dry-run-specific fields for multi-SKU
+    validation, per-SKU hardware overrides, plan caching, and safety margins.
+    The planner runs offline (no GPU required) against each SKU in sku_list.
+
+    sku_list vs the inherited launcher_hardware -- why both exist:
+        - launcher_hardware (base ShardingPlanRequest): the single hardware the
+          job will actually launch on. It may be a *concrete* type ("ZIONEX",
+          "GRANDTETON") or an *abstract/fungible* umbrella ("TC_ANY"), which
+          means "could land on any of several SKUs".
+        - sku_list (here): the *concrete* set of SKUs to validate offline. When
+          launcher_hardware is abstract (e.g. TC_ANY), it expands one-to-many
+          into the candidate SKUs to check; when concrete it maps one-to-one.
+        They are different layers, not duplicates: launcher_hardware is the
+        upstream launch intent (one value, possibly abstract), while sku_list is
+        the dry-run sweep set (concrete, possibly many) the orchestrator iterates
+        over to produce one result per SKU. The abstract->concrete expansion is a
+        framework/resolver concern, so both are kept: the base carries the launch
+        intent; the dry-run request carries the resolved candidates.
+    """
+
+    # Concrete SKUs to validate offline, one ShardingPlanResult per SKU. This is
+    # the resolved/expanded form of the inherited launcher_hardware (see the
+    # class docstring): an abstract launcher_hardware like "TC_ANY" expands to
+    # many SKUs here; a concrete one maps to a single-element list. Enables
+    # multi-SKU (TC_ANY) and cartesian (AVT) validation.
+    sku_list: List[str] = field(default_factory=list)
+    # Per-SKU hardware overrides for topology tuning
+    per_sku_overrides: Optional[Dict[str, SkuOverride]] = None
+    # Plan caching configuration
+    cache_config: Optional[CacheConfig] = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.sku_list:
+            raise ValueError("sku_list must not be empty")
+        if not self.training_framework:
+            raise ValueError("training_framework is required for dry-run requests")
+        if self.per_sku_overrides:
+            unknown = set(self.per_sku_overrides) - set(self.sku_list)
+            if unknown:
+                raise ValueError(
+                    "per_sku_overrides references SKUs not in sku_list: "
+                    f"{sorted(unknown)}"
+                )
+
+    def fingerprint(self, sku: str) -> str:
+        """Stable hash identifying a single (request, SKU) planning unit.
+
+        Composes the request-level identity (ShardingPlanRequest.request_hash)
+        with the SKU and its per-SKU override. request_hash already covers every
+        base planner-affecting param -- world_size, local_world_size, batch_size,
+        pod_size, hbm_gb, ddr_gb, training_framework, launcher_hardware,
+        constraints, and the full PlannerConfig (including storage_reservation_policy
+        and storage_reservation_percentage) -- so this method only adds the
+        SKU-specific delta. Because storage reservation participates in
+        request_hash, two requests that differ only in storage-reservation policy
+        (which changes the plan) get different fingerprints -- no cache collision.
+        Building on request_hash (rather than re-listing the base params) keeps the
+        two in sync and ensures constraints/launcher_hardware/storage-reservation
+        participate in the hash; omitting them previously let configs that produce
+        different plans collide.
+
+        Used as the correlation key between request configs and results — enables
+        TUO iterative validation (same SKU, different configs), plan cache keys,
+        and debugging which config produced which result.
+        """
+        if sku not in self.sku_list:
+            raise ValueError(f"sku {sku!r} is not in sku_list {self.sku_list}")
+        override = None
+        if self.per_sku_overrides and sku in self.per_sku_overrides:
+            # asdict so a newly added SkuOverride field automatically enters the
+            # hash; hand-listing fields would silently drop it -> cache collisions.
+            override = asdict(self.per_sku_overrides[sku])
+        parts = {
+            "request_hash": self.request_hash,
+            "sku": sku,
+            "override": override,
+        }
+        canonical = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()[:16]

--- a/torchrec/distributed/planner/executor.py
+++ b/torchrec/distributed/planner/executor.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import time
+from typing import Dict, List, Optional, Tuple
+
+import torch.distributed as dist
+import torch.nn as nn
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.provider import (
+    DefaultPlannerProvider,
+    PlannerProvider,
+)
+from torchrec.distributed.planner.types import (
+    PlannerError,
+    PlannerSessionContext,
+    ShardingOption,
+    ShardingOptionDetail,
+    ShardingPlanResult,
+)
+
+
+def _peak_per_rank_storage(best_plan: List[ShardingOption]) -> Tuple[int, int]:
+    """Peak per-rank (HBM, DDR) in bytes across the chosen shards.
+
+    Aggregates each shard's storage onto its assigned rank and returns the
+    maximum over ranks — the memory the tightest device must hold, which is what
+    ShardingPlanResult.estimated_max_*_bytes reports. Shards without resolved
+    storage or rank are skipped, so the reported peak is a lower bound if the
+    planner left any chosen shard un-costed.
+    """
+    hbm_by_rank: Dict[int, int] = {}
+    ddr_by_rank: Dict[int, int] = {}
+    for option in best_plan:
+        for shard in option.shards:
+            if shard.storage is None or shard.rank is None:
+                continue
+            hbm_by_rank[shard.rank] = hbm_by_rank.get(shard.rank, 0) + shard.storage.hbm
+            ddr_by_rank[shard.rank] = ddr_by_rank.get(shard.rank, 0) + shard.storage.ddr
+    return (
+        max(hbm_by_rank.values(), default=0),
+        max(ddr_by_rank.values(), default=0),
+    )
+
+
+class DefaultPlannerExecutor(PlannerExecutor):
+    """The single concrete PlannerExecutor behind ShardingPlannerAPI.
+
+    There is intentionally ONE executor, not one per planner variant: ``run`` is
+    the single integration point that builds the topology, storage reservation,
+    and planner for the request's SKU (via the injected PlannerProvider), runs it
+    (collectively when the API supplies a process group, else locally), and
+    returns a ShardingPlanResult — including the per-table ``sharding_options``
+    breakdown and per-rank memory estimates. This is the single place that
+    replaces the topology/storage/planner-selection-and-invocation block each
+    framework (Pyper/MVAI/APS) currently duplicates.
+
+    The PlannerProvider is the OSS-vs-Meta seam: ``DefaultPlannerProvider`` (OSS)
+    builds the OSS topology + EmbeddingShardingPlanner; ``FbPlannerProvider``
+    (torchrec/fb) overrides it for HUM topology and the LinearProgramming/Manifold
+    planners — so this OSS executor never imports fb, and variant support is
+    injected (not registered by import side effect). Inherits the
+    ``PlannerExecutor`` protocol so conformance is explicit, not just structural.
+    """
+
+    def __init__(self, provider: Optional[PlannerProvider] = None) -> None:
+        # Default to the OSS provider; Meta binaries inject FbPlannerProvider
+        # (e.g. via the fb create_sharding_plan entrypoint).
+        self._provider: PlannerProvider = (
+            provider if provider is not None else DefaultPlannerProvider()
+        )
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        # model/sharders come from the request (not passed separately);
+        # materialize the model if it is a factory.
+        model = ctx.request.model
+        if not isinstance(model, nn.Module):
+            # Guard callable first so a non-module, non-factory value gets the
+            # intended message instead of a bare "X object is not callable".
+            if not callable(model):
+                raise TypeError(
+                    "request.model must be an nn.Module or a factory callable "
+                    f"returning one, got {type(model).__name__}"
+                )
+            model = model()
+            if not isinstance(model, nn.Module):
+                raise TypeError(
+                    "request.model factory must return an nn.Module, got "
+                    f"{type(model).__name__}"
+                )
+        sharders = ctx.request.sharders
+
+        # On the collective path only rank 0 plans and populates the per-shard
+        # breakdown; other ranks get the broadcast plan but no breakdown/estimates.
+        # Flag which result is authoritative so aggregators can filter. Local path
+        # (pg=None) always plans on the caller's rank. Use pg.rank() (rank within
+        # the broadcast group) rather than dist.get_rank(pg): the latter routes
+        # through _get_default_group() and so requires an initialized default WORLD
+        # group, a dependency the legacy path never had.
+        is_planning_rank = pg is None or pg.rank() == 0
+
+        # Build every per-SKU input and the planner itself via the injected
+        # provider — the single dispatch point across OSS/LP/Manifold variants.
+        topology = self._provider.build_topology(sku, ctx.request)
+        storage_reservation = self._provider.build_storage_reservation(sku, ctx.request)
+        planner = self._provider.build_planner(
+            topology=topology,
+            storage_reservation=storage_reservation,
+            ctx=ctx,
+        )
+
+        start = time.perf_counter()
+        try:
+            # pg is owned by the API: present -> collective (rank-0 plan +
+            # broadcast); None -> local single-rank plan.
+            if pg is not None:
+                sharding_plan = planner.collective_plan(model, sharders, pg)
+            else:
+                sharding_plan = planner.plan(model, sharders)
+        except PlannerError as e:
+            return ShardingPlanResult(
+                sku=sku,
+                success=False,
+                sharding_plan=None,
+                planner_failure_reason=str(e),
+                estimated_max_hbm_bytes=0,
+                estimated_max_ddr_bytes=0,
+                request_id=ctx.request.request_id,
+                request_hash=ctx.request.request_hash,
+                solve_time_ms=(time.perf_counter() - start) * 1000.0,
+                is_planning_rank=is_planning_rank,
+            )
+        solve_time_ms = (time.perf_counter() - start) * 1000.0
+
+        # get_selected_options() is the chosen List[ShardingOption] with per-shard
+        # storage/perf populated; it is the only source of the full cost breakdown
+        # that the deployment-facing ShardingPlan drops. It is a documented planner
+        # contract (EmbeddingPlannerBase.get_selected_options), so a planner that
+        # doesn't expose its plan fails loudly here rather than silently returning
+        # empty options + zero-byte estimates (the old getattr(_best_plan) read).
+        #
+        # In the collective path only the planning rank (rank 0) computes the
+        # plan, so on other ranks this is empty: those ranks return the
+        # authoritative broadcast sharding_plan but an empty sharding_options
+        # breakdown and zero estimates (the per-shard cost detail is not carried
+        # in the broadcast ShardingPlan, so it cannot be recomputed off-rank).
+        # Consumers that need the breakdown/estimates should read the planning
+        # rank's result.
+        best_plan: List[ShardingOption] = planner.get_selected_options()
+        sharding_options = tuple(
+            ShardingOptionDetail.from_sharding_option(option) for option in best_plan
+        )
+        max_hbm_bytes, max_ddr_bytes = _peak_per_rank_storage(best_plan)
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=sharding_plan,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=max_hbm_bytes,
+            estimated_max_ddr_bytes=max_ddr_bytes,
+            request_id=ctx.request.request_id,
+            request_hash=ctx.request.request_hash,
+            sharding_options=sharding_options,
+            solve_time_ms=solve_time_ms,
+            is_planning_rank=is_planning_rank,
+        )

--- a/torchrec/distributed/planner/executor.py
+++ b/torchrec/distributed/planner/executor.py
@@ -115,6 +115,7 @@ class DefaultPlannerExecutor(PlannerExecutor):
         topology = self._provider.build_topology(sku, ctx.request)
         storage_reservation = self._provider.build_storage_reservation(sku, ctx.request)
         planner = self._provider.build_planner(
+            sku,
             topology=topology,
             storage_reservation=storage_reservation,
             ctx=ctx,

--- a/torchrec/distributed/planner/planners.py
+++ b/torchrec/distributed/planner/planners.py
@@ -636,6 +636,21 @@ class EmbeddingPlannerBase(ShardingPlanner):
             self._constraints,
         )
 
+    def get_selected_options(self) -> List[ShardingOption]:
+        """The chosen per-shard ShardingOptions from the most recent ``plan()``.
+
+        The unified PlannerExecutor reads this to build the per-table breakdown
+        and the peak per-rank storage estimates on the ShardingPlanResult. Every
+        planner run under that executor must override it to return the plan it
+        selected. The base raises (rather than returning ``[]``) so a planner that
+        forgets to expose its plan fails loudly instead of silently reporting
+        empty options and zero-byte estimates on a successful plan.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement get_selected_options() to expose "
+            "its selected ShardingOptions to the planner executor."
+        )
+
 
 class EmbeddingShardingPlanner(EmbeddingPlannerBase):
     """
@@ -721,6 +736,11 @@ class EmbeddingShardingPlanner(EmbeddingPlannerBase):
         self._num_proposals: int = 0
         self._num_plans: int = 0
         self._best_plan: Optional[List[ShardingOption]] = None
+
+    def get_selected_options(self) -> List[ShardingOption]:
+        # The winning proposal from the last plan(); None until plan() runs (or
+        # [] on a failed plan whose shards were reset to rank -1).
+        return self._best_plan or []
 
     @EventLoggingHandler.event_logger(TorchrecComponent.PLANNER)
     def collective_plan(

--- a/torchrec/distributed/planner/protocols.py
+++ b/torchrec/distributed/planner/protocols.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Extension-point protocols (structural interfaces) for the sharding planner.
+
+These live in their own module — separate from the data types (``types.py``) and
+the concrete implementations (``api.py``, ``executor.py``) — on purpose:
+
+- Dependency inversion / leaf module: a Protocol is the seam that consumers
+  depend on and implementers conform to. This module imports only ``types`` (and
+  torch), so both the consumer (``api.py`` takes these as constructor deps) and
+  the implementers (``executor.py`` conforms to ``PlannerExecutor``;
+  ``dry_run/protocols.py`` re-exports them) can import the contract without
+  pulling in the heavier api/executor modules — which keeps the import graph
+  acyclic (defining these in ``api.py`` would risk an api<->executor cycle).
+- Separation of concerns / discoverability: the planner's pluggable seams live
+  in one place, distinct from data (``types.py``) and behavior (``api``/``executor``).
+- Fine-grained build target: the ``:protocols`` Buck target depends only on
+  ``:types`` + torch, so consumers pull just the lightweight contract rather than
+  the concrete implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+import torch.distributed as dist
+from torchrec.distributed.planner.types import PlannerSessionContext, ShardingPlanResult
+
+
+@runtime_checkable
+class PlannerExecutor(Protocol):
+    """Protocol for building and running the planner for a single target (SKU).
+
+    Implementations construct the planner for ``ctx.request``'s variant (via an
+    injected PlannerProvider that also builds the topology and resolves the
+    storage reservation), run it, and return a ShardingPlanResult with the
+    sharding plan or failure details.
+    """
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        """Build and run the planner for one target (``sku``); return its result.
+
+        Only the per-target inputs are passed explicitly: ``sku`` (the target
+        being planned; it labels/keys the result) and ``pg``. Everything else is
+        read from ``ctx.request`` — model, sharders, constraints, batch size, and
+        planner config — rather than duplicated as parameters; the implementation
+        materializes ``ctx.request.model`` if it is a factory. The topology,
+        storage reservation, and planner for this SKU are all built inside ``run``
+        (the implementation owns a PlannerProvider), so no pre-built topology or
+        reservation is passed in.
+
+        ``pg`` is supplied and owned by the ShardingPlannerAPI, not the caller:
+        when provided (distributed prod) the implementation runs the planner
+        collectively (``collective_plan``); when None (offline/dry-run, single
+        rank) it runs locally (``plan``).
+        """
+        ...

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Platform-specific construction seam for the sharding planner.
+
+The orchestrator (``ShardingPlannerAPI``) owns the planning *flow* and the
+executor owns planner *invocation*; neither knows how to build the
+platform-specific inputs a planner needs. Those live behind ``PlannerProvider``:
+given the request/context it builds the ``Topology`` and constructs the planner
+for the request's ``PlannerVariant``.
+
+``DefaultPlannerProvider`` is the OSS implementation — it builds a topology from
+the request's explicit caps and constructs the OSS ``EmbeddingShardingPlanner``.
+The Meta-internal provider (``torchrec/fb``) subclasses it to add HUM-based
+topology and the LinearProgramming/Manifold planners, so the OSS layer never
+imports fb. The provider is *injected* (not registered by import side effect),
+so the wiring is explicit, typed, and testable.
+"""
+
+from typing import Callable, Dict, Optional, Protocol, runtime_checkable
+
+from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
+from torchrec.distributed.planner.planners import (
+    EmbeddingPlannerBase,
+    EmbeddingShardingPlanner,
+)
+from torchrec.distributed.planner.proposers import (
+    GreedyProposer,
+    GridSearchProposer,
+    UniformProposer,
+)
+from torchrec.distributed.planner.storage_reservations import (
+    FixedPercentageStorageReservation,
+    HeuristicalStorageReservation,
+    InferenceStorageReservation,
+)
+from torchrec.distributed.planner.types import (
+    HardwareConfig,
+    KernelConfig,
+    Partitioner,
+    PlannerConfig,
+    PlannerSessionContext,
+    PlannerVariant,
+    Proposer,
+    ShardingPlanRequest,
+    StorageReservation,
+    StorageReservationPolicy,
+    Topology,
+    TopologyFactory,
+    TrainerConfig,
+)
+
+_BYTES_PER_GB: int = 1024**3
+# Matches EmbeddingShardingPlanner's own heuristical default, so an unset
+# percentage reserves the same fraction the OSS planner would by default.
+_DEFAULT_RESERVATION_PERCENTAGE: float = 0.15
+
+
+@runtime_checkable
+class PlannerProvider(Protocol):
+    """Builds the platform-specific pieces the planner flow needs.
+
+    Injected into the orchestrator so the OSS layer never imports fb: the OSS
+    default is ``DefaultPlannerProvider``; Meta overrides it (HUM topology,
+    LinearProgramming/Manifold planners) via ``FbPlannerProvider`` in
+    ``torchrec/fb``.
+    """
+
+    def build_topology(self, sku: str, request: ShardingPlanRequest) -> Topology:
+        """Build the ``Topology`` for ``sku`` (the target GPU-SKU)."""
+        ...
+
+    def build_storage_reservation(
+        self, sku: str, request: ShardingPlanRequest
+    ) -> StorageReservation:
+        """Resolve the StorageReservation for ``sku`` from the request."""
+        ...
+
+    def build_planner(
+        self,
+        *,
+        topology: Topology,
+        storage_reservation: StorageReservation,
+        ctx: PlannerSessionContext,
+    ) -> EmbeddingPlannerBase:
+        """Construct the planner for ``ctx.request``'s ``planner_variant``."""
+        ...
+
+
+# Component factories: map PlannerConfig scalar selectors -> concrete OSS
+# components. Selectors naming fb-only components (e.g. "dynamic_col_dim",
+# "memory_balanced") return None so the OSS planner keeps its default; the fb
+# provider maps those in torchrec/fb.
+_OSS_PROPOSERS: Dict[str, Callable[[], Proposer]] = {
+    "greedy": GreedyProposer,
+    "grid_search": GridSearchProposer,
+    "uniform": UniformProposer,
+}
+
+
+def _build_proposer(cfg: PlannerConfig) -> Optional[Proposer]:
+    if cfg.proposer_type is None:
+        return None  # keep the planner's default proposer set
+    factory = _OSS_PROPOSERS.get(cfg.proposer_type)
+    return factory() if factory is not None else None
+
+
+def _build_partitioner(cfg: PlannerConfig) -> Optional[Partitioner]:
+    if cfg.partitioner_type == "greedy_perf":
+        return GreedyPerfPartitioner()
+    return None  # None / fb-only selectors -> planner default (GreedyPerfPartitioner)
+
+
+class DefaultPlannerProvider(PlannerProvider):
+    """OSS provider: a topology from the request's caps + the OSS planner.
+
+    Inherits the ``PlannerProvider`` protocol so conformance is explicit (not
+    just structural). Meta's ``FbPlannerProvider`` (``torchrec/fb``) subclasses
+    this, overriding ``build_topology`` (HUM) and ``build_planner`` (LP/Manifold)
+    while delegating the OSS variants back here via ``super()``.
+    """
+
+    def build_topology(self, sku: str, request: ShardingPlanRequest) -> Topology:
+        # OSS builds from the request's explicit caps; the SKU -> hardware mapping
+        # is a Meta (HUM) concern handled by FbPlannerProvider. ``sku`` is unused
+        # here but is part of the seam the fb override keys on.
+        trainer_config = TrainerConfig(
+            world_size=request.world_size,
+            local_world_size=request.local_world_size,
+            pod_size=request.pod_size,
+            hbm_cap_bytes=(
+                int(request.hbm_gb * _BYTES_PER_GB)
+                if request.hbm_gb is not None
+                else None
+            ),
+            ddr_cap_bytes=(
+                int(request.ddr_gb * _BYTES_PER_GB)
+                if request.ddr_gb is not None
+                else None
+            ),
+        )
+        return TopologyFactory.create_topology(
+            trainer_config=trainer_config,
+            hardware_config=HardwareConfig(),
+            kernel_config=KernelConfig(),
+        )
+
+    def build_storage_reservation(
+        self, sku: str, request: ShardingPlanRequest
+    ) -> StorageReservation:
+        # A caller-supplied reservation wins; otherwise map the config policy to
+        # the matching OSS StorageReservation. ``sku`` is unused here but is part
+        # of the seam (fb may reserve per-SKU).
+        if request.storage_reservation is not None:
+            return request.storage_reservation
+        cfg = request.planner_config
+        percentage = (
+            cfg.storage_reservation_percentage
+            if cfg.storage_reservation_percentage is not None
+            else _DEFAULT_RESERVATION_PERCENTAGE
+        )
+        policy = cfg.storage_reservation_policy
+        if policy in (
+            StorageReservationPolicy.UNSET,
+            StorageReservationPolicy.HEURISTICAL,
+        ):
+            return HeuristicalStorageReservation(percentage=percentage)
+        if policy == StorageReservationPolicy.FIXED_PERCENTAGE:
+            return FixedPercentageStorageReservation(percentage=percentage)
+        if policy == StorageReservationPolicy.INFERENCE:
+            return InferenceStorageReservation(percentage=percentage)
+        raise NotImplementedError(
+            f"storage_reservation_policy {policy.value!r} ({policy.name}) is not "
+            "buildable by DefaultPlannerProvider (SKU_AWARE is planned)."
+        )
+
+    def build_planner(
+        self,
+        *,
+        topology: Topology,
+        storage_reservation: StorageReservation,
+        ctx: PlannerSessionContext,
+    ) -> EmbeddingPlannerBase:
+        variant = ctx.request.planner_config.planner_variant
+        if variant not in (PlannerVariant.UNSET, PlannerVariant.OSS):
+            raise NotImplementedError(
+                f"DefaultPlannerProvider (OSS) does not build planner_variant "
+                f"{variant.value!r} ({variant.name}); LinearProgramming/Manifold "
+                "live in torchrec/fb and are built by FbPlannerProvider. Inject "
+                "the fb provider (e.g. via the fb create_sharding_plan entrypoint)."
+            )
+        cfg = ctx.request.planner_config
+        return EmbeddingShardingPlanner(
+            topology=topology,
+            batch_size=ctx.request.batch_size,
+            storage_reservation=storage_reservation,
+            constraints=ctx.request.constraints,
+            proposer=_build_proposer(cfg),
+            partitioner=_build_partitioner(cfg),
+            debug=cfg.debug,
+            timeout_seconds=cfg.timeout_seconds,
+        )

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -15,25 +15,38 @@ platform-specific inputs a planner needs. Those live behind ``PlannerProvider``:
 given the request/context it builds the ``Topology`` and constructs the planner
 for the request's ``PlannerVariant``.
 
-``DefaultPlannerProvider`` is the OSS implementation — it builds a topology from
-the request's explicit caps and constructs the OSS ``EmbeddingShardingPlanner``.
-The Meta-internal provider (``torchrec/fb``) subclasses it to add HUM-based
-topology and the LinearProgramming/Manifold planners, so the OSS layer never
-imports fb. The provider is *injected* (not registered by import side effect),
-so the wiring is explicit, typed, and testable.
+``DefaultPlannerProvider`` is the OSS implementation — it faithfully reconstructs
+the planner object graph (enumerator + estimators, partitioner, perf model,
+proposers) from ``PlannerConfig`` so the plan is deterministic and matches what
+the frameworks build today. The Meta-internal provider (``torchrec/fb``)
+subclasses it, overriding only the fb-specific pieces (HUM topology, HW-based
+perf estimator, fb proposers/partitioner, LinearProgramming/Manifold planners) —
+so the OSS layer never imports fb. The provider is *injected* (not registered by
+import side effect), so the wiring is explicit, typed, and testable.
 """
 
-from typing import Callable, Dict, Optional, Protocol, runtime_checkable
+from typing import Callable, Dict, List, Optional, Protocol, runtime_checkable, Union
 
-from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
+from torchrec.distributed.planner.enumerators import EmbeddingEnumerator
+from torchrec.distributed.planner.partitioners import (
+    GreedyPerfPartitioner,
+    MemoryBalancedPartitioner,
+    SortBy,
+)
+from torchrec.distributed.planner.perf_models import NoopStorageModel
 from torchrec.distributed.planner.planners import (
     EmbeddingPlannerBase,
     EmbeddingShardingPlanner,
 )
 from torchrec.distributed.planner.proposers import (
+    EmbeddingOffloadScaleupProposer,
     GreedyProposer,
     GridSearchProposer,
     UniformProposer,
+)
+from torchrec.distributed.planner.shard_estimators import (
+    EmbeddingPerfEstimator,
+    EmbeddingStorageEstimator,
 )
 from torchrec.distributed.planner.storage_reservations import (
     FixedPercentageStorageReservation,
@@ -41,13 +54,17 @@ from torchrec.distributed.planner.storage_reservations import (
     InferenceStorageReservation,
 )
 from torchrec.distributed.planner.types import (
+    Enumerator,
     HardwareConfig,
     KernelConfig,
+    ParameterConstraints,
     Partitioner,
+    PerfModel,
     PlannerConfig,
     PlannerSessionContext,
     PlannerVariant,
     Proposer,
+    ShardEstimator,
     ShardingPlanRequest,
     StorageReservation,
     StorageReservationPolicy,
@@ -55,11 +72,20 @@ from torchrec.distributed.planner.types import (
     TopologyFactory,
     TrainerConfig,
 )
+from torchrec.distributed.types import PipelineType
 
 _BYTES_PER_GB: int = 1024**3
 # Matches EmbeddingShardingPlanner's own heuristical default, so an unset
 # percentage reserves the same fraction the OSS planner would by default.
 _DEFAULT_RESERVATION_PERCENTAGE: float = 0.15
+
+# OSS proposer_type selectors -> factory (legacy simple selection path; the
+# richer proposer_config path is handled in _build_proposer).
+_OSS_PROPOSERS: Dict[str, Callable[[], Proposer]] = {
+    "greedy": GreedyProposer,
+    "grid_search": GridSearchProposer,
+    "uniform": UniformProposer,
+}
 
 
 @runtime_checkable
@@ -84,46 +110,29 @@ class PlannerProvider(Protocol):
 
     def build_planner(
         self,
+        sku: str,
         *,
         topology: Topology,
         storage_reservation: StorageReservation,
         ctx: PlannerSessionContext,
     ) -> EmbeddingPlannerBase:
-        """Construct the planner for ``ctx.request``'s ``planner_variant``."""
+        """Construct the planner for ``ctx.request``'s ``planner_variant``.
+
+        ``sku`` is the target being planned (the fb provider uses it to resolve
+        the hardware capability for the HW-based perf estimator).
+        """
         ...
 
 
-# Component factories: map PlannerConfig scalar selectors -> concrete OSS
-# components. Selectors naming fb-only components (e.g. "dynamic_col_dim",
-# "memory_balanced") return None so the OSS planner keeps its default; the fb
-# provider maps those in torchrec/fb.
-_OSS_PROPOSERS: Dict[str, Callable[[], Proposer]] = {
-    "greedy": GreedyProposer,
-    "grid_search": GridSearchProposer,
-    "uniform": UniformProposer,
-}
-
-
-def _build_proposer(cfg: PlannerConfig) -> Optional[Proposer]:
-    if cfg.proposer_type is None:
-        return None  # keep the planner's default proposer set
-    factory = _OSS_PROPOSERS.get(cfg.proposer_type)
-    return factory() if factory is not None else None
-
-
-def _build_partitioner(cfg: PlannerConfig) -> Optional[Partitioner]:
-    if cfg.partitioner_type == "greedy_perf":
-        return GreedyPerfPartitioner()
-    return None  # None / fb-only selectors -> planner default (GreedyPerfPartitioner)
-
-
 class DefaultPlannerProvider(PlannerProvider):
-    """OSS provider: a topology from the request's caps + the OSS planner.
+    """OSS provider: topology from the request's caps + a faithfully-reconstructed
+    OSS ``EmbeddingShardingPlanner``.
 
-    Inherits the ``PlannerProvider`` protocol so conformance is explicit (not
-    just structural). Meta's ``FbPlannerProvider`` (``torchrec/fb``) subclasses
-    this, overriding ``build_topology`` (HUM) and ``build_planner`` (LP/Manifold)
-    while delegating the OSS variants back here via ``super()``.
+    Inherits the ``PlannerProvider`` protocol so conformance is explicit. Meta's
+    ``FbPlannerProvider`` (``torchrec/fb``) subclasses this, overriding the
+    fb-specific hooks (HUM topology, HW perf estimator, fb proposers/partitioner,
+    fb perf model) and ``build_planner`` (LP/Manifold), delegating OSS variants
+    back here via ``super()``.
     """
 
     def build_topology(self, sku: str, request: ShardingPlanRequest) -> Topology:
@@ -187,8 +196,124 @@ class DefaultPlannerProvider(PlannerProvider):
             "buildable by DefaultPlannerProvider (SKU_AWARE is planned)."
         )
 
+    # ---- Overridable construction hooks (fb overrides the fb-specific ones) ----
+
+    def _build_perf_estimator(
+        self,
+        sku: str,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        ctx: PlannerSessionContext,
+    ) -> ShardEstimator:
+        # OSS uses the default perf estimator; fb overrides with the HW-capability
+        # estimator when use_hardware_based_compute is set.
+        return EmbeddingPerfEstimator(
+            topology=topology,
+            constraints=constraints,  # pyre-ignore[6]
+        )
+
+    def _build_storage_estimator(
+        self,
+        topology: Topology,
+        constraints: Optional[Dict[str, ParameterConstraints]],
+        cfg: PlannerConfig,
+    ) -> ShardEstimator:
+        pipeline_type = (
+            PipelineType(cfg.pipeline_type)
+            if cfg.pipeline_type is not None
+            else PipelineType.NONE
+        )
+        return EmbeddingStorageEstimator(
+            topology=topology,
+            constraints=constraints,  # pyre-ignore[6]
+            pipeline_type=pipeline_type,
+        )
+
+    def _build_enumerator(
+        self, sku: str, topology: Topology, ctx: PlannerSessionContext
+    ) -> Enumerator:
+        cfg = ctx.request.planner_config
+        constraints = ctx.request.constraints
+        return EmbeddingEnumerator(
+            topology=topology,
+            batch_size=ctx.request.batch_size,
+            constraints=constraints,
+            estimator=[
+                self._build_perf_estimator(sku, topology, constraints, ctx),
+                self._build_storage_estimator(topology, constraints, cfg),
+            ],
+        )
+
+    def _build_partitioner(self, cfg: PlannerConfig) -> Optional[Partitioner]:
+        if cfg.partitioner_type == "greedy_perf":
+            sort_by = (
+                SortBy(cfg.partitioner_sort_by)
+                if cfg.partitioner_sort_by is not None
+                else SortBy.STORAGE
+            )
+            return GreedyPerfPartitioner(
+                sort_by=sort_by, balance_modules=cfg.balance_modules
+            )
+        if cfg.partitioner_type == "memory_balanced":
+            kwargs: Dict[str, object] = {"balance_modules": cfg.balance_modules}
+            if cfg.memory_balanced_max_search_count is not None:
+                kwargs["max_search_count"] = cfg.memory_balanced_max_search_count
+            if cfg.memory_balanced_tolerance is not None:
+                kwargs["tolerance"] = cfg.memory_balanced_tolerance
+            return MemoryBalancedPartitioner(**kwargs)  # pyre-ignore[6]
+        return None  # None / fb-only selectors -> planner default / fb override
+
+    def _build_performance_model(
+        self, cfg: PlannerConfig, topology: Topology
+    ) -> Optional[PerfModel]:
+        if cfg.performance_model == "storage":
+            return NoopStorageModel(topology)
+        # "table_size" (NoopTableSizeModel) is fb -> handled by the fb override.
+        return None
+
+    def _build_proposer(
+        self, cfg: PlannerConfig, local_world_size: int
+    ) -> Optional[Union[Proposer, List[Proposer]]]:
+        # local_world_size is unused by the OSS proposers here; it is part of the
+        # hook signature so the fb override (DynamicColDim / grouped-DCD, which take
+        # local_world_size) can consume it without a signature divergence.
+        # (proposer_type / proposer_config mutual exclusion is enforced upstream by
+        # PlannerConfig.__post_init__, so it is not re-checked here.)
+        pc = cfg.proposer_config
+        if pc is None:
+            # Legacy simple selection via proposer_type. Unrecognized / fb-only
+            # values return None (planner default / fb override) rather than raising,
+            # since the OSS base cannot distinguish an fb selector from a typo.
+            if cfg.proposer_type is not None:
+                factory = _OSS_PROPOSERS.get(cfg.proposer_type)
+                return factory() if factory is not None else None
+            return None
+        if pc.kind == "default":
+            return None  # keep the planner's default proposer set
+        if pc.kind == "greedy":
+            return GreedyProposer()
+        if pc.kind == "uniform":
+            return UniformProposer()
+        if pc.kind == "grid_search":
+            return (
+                GridSearchProposer(max_proposals=pc.max_proposals)
+                if pc.max_proposals is not None
+                else GridSearchProposer()
+            )
+        if pc.kind == "embedding_offload_scaleup":
+            # Only forward use_depth when set, so an unset value keeps the
+            # proposer's own default rather than hardcoding it here.
+            eos_kwargs: Dict[str, object] = {}
+            if pc.use_depth is not None:
+                eos_kwargs["use_depth"] = pc.use_depth
+            return EmbeddingOffloadScaleupProposer(**eos_kwargs)  # pyre-ignore[6]
+        # dynamic_col_dim / embedding_offload_cache_scaling / grouped_dynamic_col_dim
+        # are fb -> fb override.
+        return None
+
     def build_planner(
         self,
+        sku: str,
         *,
         topology: Topology,
         storage_reservation: StorageReservation,
@@ -206,10 +331,12 @@ class DefaultPlannerProvider(PlannerProvider):
         return EmbeddingShardingPlanner(
             topology=topology,
             batch_size=ctx.request.batch_size,
+            enumerator=self._build_enumerator(sku, topology, ctx),
             storage_reservation=storage_reservation,
+            proposer=self._build_proposer(cfg, ctx.request.local_world_size),
+            partitioner=self._build_partitioner(cfg),
+            performance_model=self._build_performance_model(cfg, topology),
             constraints=ctx.request.constraints,
-            proposer=_build_proposer(cfg),
-            partitioner=_build_partitioner(cfg),
             debug=cfg.debug,
             timeout_seconds=cfg.timeout_seconds,
         )

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -337,6 +337,7 @@ class DefaultPlannerProvider(PlannerProvider):
             partitioner=self._build_partitioner(cfg),
             performance_model=self._build_performance_model(cfg, topology),
             constraints=ctx.request.constraints,
+            stats=ctx.stats,  # built by the orchestrator's reporter; None -> default
             debug=cfg.debug,
             timeout_seconds=cfg.timeout_seconds,
         )

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -145,10 +145,17 @@ class DefaultPlannerProvider(PlannerProvider):
                 else None
             ),
         )
+        # Honor the caller's runtime device so the plan's shard placements match
+        # the model's device (cpu/cuda/mtia); unset -> KernelConfig's own default.
+        kernel_config = (
+            KernelConfig(compute_device=request.compute_device)
+            if request.compute_device
+            else KernelConfig()
+        )
         return TopologyFactory.create_topology(
             trainer_config=trainer_config,
             hardware_config=HardwareConfig(),
-            kernel_config=KernelConfig(),
+            kernel_config=kernel_config,
         )
 
     def build_storage_reservation(

--- a/torchrec/distributed/planner/provider.py
+++ b/torchrec/distributed/planner/provider.py
@@ -186,7 +186,10 @@ class DefaultPlannerProvider(PlannerProvider):
             StorageReservationPolicy.UNSET,
             StorageReservationPolicy.HEURISTICAL,
         ):
-            return HeuristicalStorageReservation(percentage=percentage)
+            return HeuristicalStorageReservation(
+                percentage=percentage,
+                dense_tensor_estimate=cfg.dense_tensor_estimate,
+            )
         if policy == StorageReservationPolicy.FIXED_PERCENTAGE:
             return FixedPercentageStorageReservation(percentage=percentage)
         if policy == StorageReservationPolicy.INFERENCE:

--- a/torchrec/distributed/planner/reporter.py
+++ b/torchrec/distributed/planner/reporter.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Observability seam for the sharding planner.
+
+Plan reporting (the Stats sinks the planner logs to) is a cross-cutting concern
+owned by the orchestrator — written once in the shared ``plan`` loop and reused
+by dry-run and production, independent of the provider. ``PlanReporter`` builds
+the sinks; the OSS default is console-only (``EmbeddingStats``). Meta's
+``FbPlanReporter`` (``torchrec/fb``) adds Manifold + Scuba from
+``PlanReportMetadata``. Injected into the orchestrator (not the provider), so
+observability lives in one place.
+"""
+
+from typing import List, Protocol, runtime_checkable
+
+from torchrec.distributed.planner.stats import EmbeddingStats
+from torchrec.distributed.planner.types import PlannerSessionContext, Stats
+
+
+@runtime_checkable
+class PlanReporter(Protocol):
+    """Builds the Stats sinks the planner logs to for a planning session."""
+
+    def build_stats(self, ctx: PlannerSessionContext, sku: str) -> List[Stats]:
+        """Return the stats sinks for the SKU about to be planned.
+
+        ``sku`` is the target being planned next; a reporter that persists a
+        per-SKU artifact (e.g. the Manifold plan upload) uses it to give each SKU
+        in a multi-SKU sweep its own destination instead of colliding on one path.
+        Reads ``ctx.report_metadata`` if it needs framework provenance.
+        """
+        ...
+
+
+class DefaultPlanReporter(PlanReporter):
+    """OSS reporter: console stats only (``EmbeddingStats``).
+
+    Meta's ``FbPlanReporter`` subclasses this to add the Manifold/Scuba sinks
+    from ``ctx.report_metadata``; the console sink is common to both.
+    """
+
+    def build_stats(self, ctx: PlannerSessionContext, sku: str) -> List[Stats]:
+        # Console stats are SKU-independent (no persisted artifact), so sku is
+        # unused here; it is part of the seam for reporters that write per-SKU.
+        return [EmbeddingStats()]

--- a/torchrec/distributed/planner/tests/test_api.py
+++ b/torchrec/distributed/planner/tests/test_api.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, Dict, List, Optional
+
+import torch.distributed as dist
+import torch.nn as nn
+from torchrec.distributed.planner.api import (
+    ProductionPlannerOrchestrator,
+    ShardingPlannerAPI,
+)
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+    ShardingPlanResult,
+)
+
+
+class _RecordingExecutor:
+    """PlannerExecutor test double that records how the API invokes it.
+
+    The executor builds topology/storage/planner internally now, so the API only
+    hands it ``sku``/``ctx``/``pg``; the double records those.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, object]] = []
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        self.calls.append({"sku": sku, "pg": pg})
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=123,
+            estimated_max_ddr_bytes=456,
+        )
+
+
+class _RaisingExecutor:
+    """PlannerExecutor double that raises a non-PlannerError for one SKU.
+
+    Models an unexpected failure (model factory, enum coercion, HUM lookup, ...)
+    that is not a ``PlannerError`` and so is not already turned into a
+    success=False result inside the executor.
+    """
+
+    def __init__(self, fail_sku: str) -> None:
+        self.calls: List[str] = []
+        self._fail_sku = fail_sku
+
+    def run(
+        self,
+        sku: str,
+        ctx: PlannerSessionContext,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> ShardingPlanResult:
+        self.calls.append(sku)
+        if sku == self._fail_sku:
+            raise RuntimeError(f"boom for {sku}")
+        return ShardingPlanResult(
+            sku=sku,
+            success=True,
+            sharding_plan=None,
+            planner_failure_reason=None,
+            estimated_max_hbm_bytes=1,
+            estimated_max_ddr_bytes=1,
+        )
+
+
+class _FixedTargetsOrchestrator(ShardingPlannerAPI):
+    """Concrete ShardingPlannerAPI whose _targets is a fixed SKU list.
+
+    Exercises the shared template loop in ShardingPlannerAPI.plan without the
+    (pending) production launcher_hardware -> SKU resolution.
+    """
+
+    def __init__(self, executor: PlannerExecutor, targets: List[str]) -> None:
+        super().__init__(executor)
+        self._fixed_targets = targets
+
+    def _targets(self, request: ShardingPlanRequest) -> List[str]:
+        return self._fixed_targets
+
+
+class _IsolatingOrchestrator(_FixedTargetsOrchestrator):
+    """Orchestrator that opts into per-target error isolation (like dry-run)."""
+
+    def _isolate_target_errors(self) -> bool:
+        return True
+
+
+class ShardingPlannerAPITest(unittest.TestCase):
+    def _request(self, **kwargs: object) -> ShardingPlanRequest:
+        defaults: Dict[str, object] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanRequest(**defaults)  # pyre-ignore[6]
+
+    def _orchestrator(
+        self, executor: PlannerExecutor, targets: List[str]
+    ) -> _FixedTargetsOrchestrator:
+        return _FixedTargetsOrchestrator(executor, targets)
+
+    def test_plan_delegates_and_aggregates_each_target(self) -> None:
+        # The template loop delegates to the executor per target and aggregates
+        # into both the returned map and ctx.results.
+        executor = _RecordingExecutor()
+        request = self._request()
+        ctx = PlannerSessionContext(request=request, results={})
+
+        results = self._orchestrator(executor, ["H100", "GB200"]).plan(request, ctx)
+
+        self.assertEqual(set(results), {"H100", "GB200"})
+        self.assertEqual(results["H100"].sku, "H100")
+        self.assertEqual(results["GB200"].estimated_max_hbm_bytes, 123)
+        self.assertIs(ctx.results["GB200"], results["GB200"])
+        self.assertEqual(len(executor.calls), 2)
+        self.assertEqual({c["sku"] for c in executor.calls}, {"H100", "GB200"})
+
+    def test_plan_runs_local_when_not_distributed(self) -> None:
+        # Offline (no initialized process group) => API passes pg=None so the
+        # executor runs a local plan rather than collective_plan.
+        self.assertFalse(dist.is_available() and dist.is_initialized())
+        executor = _RecordingExecutor()
+        request = self._request()
+        self._orchestrator(executor, ["H100"]).plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertIsNone(executor.calls[0]["pg"])
+
+    def test_isolation_disabled_by_default(self) -> None:
+        # Base default is fail-fast (production must not swallow an unexpected error).
+        self.assertFalse(
+            self._orchestrator(_RecordingExecutor(), [])._isolate_target_errors()
+        )
+
+    def test_fail_fast_propagates_unexpected_error(self) -> None:
+        # Without isolation, an unexpected error aborts the whole sweep.
+        executor = _RaisingExecutor(fail_sku="H100")
+        request = self._request()
+        with self.assertRaises(RuntimeError):
+            self._orchestrator(executor, ["H100", "GB200"]).plan(
+                request, PlannerSessionContext(request=request, results={})
+            )
+
+    def test_isolate_errors_collects_and_continues(self) -> None:
+        # With isolation on, a failing SKU becomes a success=False result and the
+        # remaining SKUs still plan (collect-and-continue sweep).
+        executor = _RaisingExecutor(fail_sku="H100")
+        request = self._request()
+        ctx = PlannerSessionContext(request=request, results={})
+        results = _IsolatingOrchestrator(executor, ["H100", "GB200"]).plan(request, ctx)
+        self.assertEqual(set(results), {"H100", "GB200"})
+        self.assertFalse(results["H100"].success)
+        self.assertIn("RuntimeError", results["H100"].planner_failure_reason or "")
+        self.assertTrue(results["GB200"].success)
+        self.assertEqual(executor.calls, ["H100", "GB200"])
+
+    def test_injected_broadcast_pg_is_used(self) -> None:
+        # A caller-injected broadcast PG (e.g. APF's Gloo cpu_ctl_dist_pg) is
+        # preferred over the default WORLD group and threaded to the executor,
+        # so the rank-0 plan broadcast runs over the injected group.
+        fake_pg = cast(dist.ProcessGroup, object())
+        executor = _RecordingExecutor()
+        request = self._request()
+        ProductionPlannerOrchestrator(executor, "H100", broadcast_pg=fake_pg).plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertIs(executor.calls[0]["pg"], fake_pg)
+
+    def test_production_orchestrator_plans_resolved_sku(self) -> None:
+        # The SKU is resolved by the caller (the fb entrypoint via HUM) and passed
+        # at construction; the prod orchestrator plans for exactly that SKU.
+        executor = _RecordingExecutor()
+        request = self._request()
+        results = ProductionPlannerOrchestrator(executor, "GRANDTETON").plan(
+            request, PlannerSessionContext(request=request, results={})
+        )
+        self.assertEqual(set(results), {"GRANDTETON"})
+        self.assertEqual(len(executor.calls), 1)
+        self.assertEqual(executor.calls[0]["sku"], "GRANDTETON")

--- a/torchrec/distributed/planner/tests/test_dry_run_e2e.py
+++ b/torchrec/distributed/planner/tests/test_dry_run_e2e.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, List
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.dry_run.api import DryRunOrchestrator
+from torchrec.distributed.planner.dry_run.types import DryRunRequest
+from torchrec.distributed.planner.executor import DefaultPlannerExecutor
+from torchrec.distributed.planner.types import PlannerSessionContext, TrainingFramework
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.types import ModuleSharder
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+
+class DryRunEndToEndTest(unittest.TestCase):
+    """End-to-end dry run through the real stack.
+
+    DryRunOrchestrator + the real DefaultPlannerExecutor + the OSS
+    DefaultPlannerProvider produce one real ShardingPlanResult per SKU in
+    sku_list. Runs offline (pg=None), so the executor plans locally for each
+    candidate SKU. This exercises the whole template loop end to end (no mocks),
+    complementing test_executor (single SKU, direct) and test_api (mocked loop).
+    """
+
+    def _model(self) -> TestSparseNN:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name=f"table_{i}",
+                feature_names=[f"feature_{i}"],
+            )
+            for i in range(4)
+        ]
+        return TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+
+    def _sharders(self) -> List[ModuleSharder[nn.Module]]:
+        return cast(List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()])
+
+    def _request(
+        self, sku_list: List[str], model: object | None = None
+    ) -> DryRunRequest:
+        return DryRunRequest(
+            model=model if model is not None else self._model(),  # pyre-ignore[6]
+            sharders=self._sharders(),
+            sku_list=sku_list,
+            training_framework=TrainingFramework.APF,
+            world_size=2,
+            local_world_size=2,
+            batch_size=512,
+        )
+
+    def test_plans_every_sku_end_to_end(self) -> None:
+        request = self._request(["H100", "GB200"])
+        ctx = PlannerSessionContext(request=request, results={})
+
+        results = DryRunOrchestrator(DefaultPlannerExecutor()).plan(request, ctx)
+
+        self.assertEqual(set(results), {"H100", "GB200"})
+        for sku in ("H100", "GB200"):
+            result = results[sku]
+            self.assertTrue(result.success, result.planner_failure_reason)
+            self.assertEqual(result.sku, sku)
+            self.assertIsNotNone(result.sharding_plan)
+            # Real plan -> per-table breakdown and a positive peak-HBM estimate.
+            self.assertTrue(result.sharding_options)
+            self.assertGreater(result.estimated_max_hbm_bytes, 0)
+            # Aggregated onto the session context as well as the returned map.
+            self.assertIs(ctx.results[sku], result)
+
+    def test_plans_with_model_factory(self) -> None:
+        # A factory model on the request is materialized by the executor.
+        built = self._model()
+        request = self._request(["H100"], model=lambda: built)
+        ctx = PlannerSessionContext(request=request, results={})
+
+        results = DryRunOrchestrator(DefaultPlannerExecutor()).plan(request, ctx)
+
+        self.assertTrue(results["H100"].success, results["H100"].planner_failure_reason)
+        self.assertTrue(results["H100"].sharding_options)

--- a/torchrec/distributed/planner/tests/test_executor.py
+++ b/torchrec/distributed/planner/tests/test_executor.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import cast, List
+
+import torch
+import torch.nn as nn
+from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
+from torchrec.distributed.planner.executor import DefaultPlannerExecutor
+from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
+from torchrec.distributed.planner.proposers import GreedyProposer, UniformProposer
+from torchrec.distributed.planner.protocols import PlannerExecutor
+from torchrec.distributed.planner.provider import _build_partitioner, _build_proposer
+from torchrec.distributed.planner.types import (
+    PlannerConfig,
+    PlannerSessionContext,
+    PlannerVariant,
+    ShardingPlanRequest,
+)
+from torchrec.distributed.test_utils.test_model import TestSparseNN
+from torchrec.distributed.types import ModuleSharder
+from torchrec.modules.embedding_configs import EmbeddingBagConfig
+
+
+class DefaultPlannerExecutorTest(unittest.TestCase):
+    def _model(self) -> TestSparseNN:
+        tables = [
+            EmbeddingBagConfig(
+                num_embeddings=100,
+                embedding_dim=64,
+                name=f"table_{i}",
+                feature_names=[f"feature_{i}"],
+            )
+            for i in range(4)
+        ]
+        return TestSparseNN(tables=tables, sparse_device=torch.device("meta"))
+
+    def _sharders(self) -> List[ModuleSharder[nn.Module]]:
+        return cast(List[ModuleSharder[nn.Module]], [EmbeddingBagCollectionSharder()])
+
+    def _ctx(self, model: nn.Module, **cfg: object) -> PlannerSessionContext:
+        request = ShardingPlanRequest(
+            model=model,
+            sharders=self._sharders(),
+            world_size=2,
+            local_world_size=2,
+            batch_size=512,
+            planner_config=PlannerConfig(**cfg),  # pyre-ignore[6]
+        )
+        return PlannerSessionContext(request=request, results={})
+
+    def test_conforms_to_protocol(self) -> None:
+        self.assertIsInstance(DefaultPlannerExecutor(), PlannerExecutor)
+
+    def test_embedding_plan_end_to_end(self) -> None:
+        # The executor builds topology + storage reservation + planner from the
+        # request via its (default OSS) provider; only sku/ctx/pg are passed.
+        model = self._model()
+        result = DefaultPlannerExecutor().run(sku="H100", ctx=self._ctx(model), pg=None)
+        self.assertTrue(result.success, result.planner_failure_reason)
+        self.assertEqual(result.sku, "H100")
+        self.assertIsNotNone(result.sharding_plan)
+        self.assertIsNone(result.planner_failure_reason)
+        # The per-table sharding-option table is populated from the chosen plan.
+        self.assertTrue(result.sharding_options)
+        self.assertTrue(all(so.fqn for so in result.sharding_options))
+        # Peak per-rank HBM is a positive estimate for a non-empty plan.
+        self.assertGreater(result.estimated_max_hbm_bytes, 0)
+        self.assertIsNotNone(result.solve_time_ms)
+
+    def test_embedding_plan_materializes_model_factory(self) -> None:
+        # A factory model on the request is materialized by the executor
+        # (model is read from ctx.request, not passed to run()).
+        built = self._model()
+        request = ShardingPlanRequest(
+            model=lambda: built,
+            sharders=self._sharders(),
+            world_size=2,
+            local_world_size=2,
+            batch_size=512,
+        )
+        ctx = PlannerSessionContext(request=request, results={})
+        result = DefaultPlannerExecutor().run(sku="H100", ctx=ctx, pg=None)
+        self.assertTrue(result.success, result.planner_failure_reason)
+        self.assertTrue(result.sharding_options)
+
+    def test_unsupported_variant_raises(self) -> None:
+        # The OSS provider only builds OSS variants; LinearProgramming/Manifold
+        # live in torchrec/fb (FbPlannerProvider), so the OSS default rejects them.
+        model = self._model()
+        with self.assertRaisesRegex(
+            NotImplementedError, "does not build planner_variant"
+        ):
+            DefaultPlannerExecutor().run(
+                sku="H100",
+                ctx=self._ctx(model, planner_variant=PlannerVariant.LINEAR_PROGRAMMING),
+                pg=None,
+            )
+
+
+class BuildComponentsFromConfigTest(unittest.TestCase):
+    """The provider turns PlannerConfig scalar selectors into concrete OSS
+    components (rather than taking pre-built objects)."""
+
+    def test_build_proposer_maps_known_selectors(self) -> None:
+        self.assertIsInstance(
+            _build_proposer(PlannerConfig(proposer_type="greedy")), GreedyProposer
+        )
+        self.assertIsInstance(
+            _build_proposer(PlannerConfig(proposer_type="uniform")), UniformProposer
+        )
+
+    def test_build_proposer_none_and_fb_selectors_use_default(self) -> None:
+        # None -> planner default set; fb-only selectors aren't OSS-buildable.
+        self.assertIsNone(_build_proposer(PlannerConfig()))
+        self.assertIsNone(
+            _build_proposer(PlannerConfig(proposer_type="dynamic_col_dim"))
+        )
+
+    def test_build_partitioner(self) -> None:
+        self.assertIsInstance(
+            _build_partitioner(PlannerConfig(partitioner_type="greedy_perf")),
+            GreedyPerfPartitioner,
+        )
+        self.assertIsNone(_build_partitioner(PlannerConfig()))
+        self.assertIsNone(
+            _build_partitioner(PlannerConfig(partitioner_type="memory_balanced"))
+        )

--- a/torchrec/distributed/planner/tests/test_executor.py
+++ b/torchrec/distributed/planner/tests/test_executor.py
@@ -14,10 +14,13 @@ import torch
 import torch.nn as nn
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner.executor import DefaultPlannerExecutor
-from torchrec.distributed.planner.partitioners import GreedyPerfPartitioner
+from torchrec.distributed.planner.partitioners import (
+    GreedyPerfPartitioner,
+    MemoryBalancedPartitioner,
+)
 from torchrec.distributed.planner.proposers import GreedyProposer, UniformProposer
 from torchrec.distributed.planner.protocols import PlannerExecutor
-from torchrec.distributed.planner.provider import _build_partitioner, _build_proposer
+from torchrec.distributed.planner.provider import DefaultPlannerProvider
 from torchrec.distributed.planner.types import (
     PlannerConfig,
     PlannerSessionContext,
@@ -106,30 +109,48 @@ class DefaultPlannerExecutorTest(unittest.TestCase):
 
 
 class BuildComponentsFromConfigTest(unittest.TestCase):
-    """The provider turns PlannerConfig scalar selectors into concrete OSS
-    components (rather than taking pre-built objects)."""
+    """The OSS provider turns PlannerConfig scalar selectors into concrete OSS
+    components (overridable hooks; fb-only selectors fall through to fb)."""
+
+    def setUp(self) -> None:
+        self.provider = DefaultPlannerProvider()
 
     def test_build_proposer_maps_known_selectors(self) -> None:
         self.assertIsInstance(
-            _build_proposer(PlannerConfig(proposer_type="greedy")), GreedyProposer
+            self.provider._build_proposer(
+                PlannerConfig(proposer_type="greedy"), local_world_size=8
+            ),
+            GreedyProposer,
         )
         self.assertIsInstance(
-            _build_proposer(PlannerConfig(proposer_type="uniform")), UniformProposer
+            self.provider._build_proposer(
+                PlannerConfig(proposer_type="uniform"), local_world_size=8
+            ),
+            UniformProposer,
         )
 
     def test_build_proposer_none_and_fb_selectors_use_default(self) -> None:
         # None -> planner default set; fb-only selectors aren't OSS-buildable.
-        self.assertIsNone(_build_proposer(PlannerConfig()))
         self.assertIsNone(
-            _build_proposer(PlannerConfig(proposer_type="dynamic_col_dim"))
+            self.provider._build_proposer(PlannerConfig(), local_world_size=8)
+        )
+        self.assertIsNone(
+            self.provider._build_proposer(
+                PlannerConfig(proposer_type="dynamic_col_dim"), local_world_size=8
+            )
         )
 
     def test_build_partitioner(self) -> None:
         self.assertIsInstance(
-            _build_partitioner(PlannerConfig(partitioner_type="greedy_perf")),
+            self.provider._build_partitioner(
+                PlannerConfig(partitioner_type="greedy_perf")
+            ),
             GreedyPerfPartitioner,
         )
-        self.assertIsNone(_build_partitioner(PlannerConfig()))
-        self.assertIsNone(
-            _build_partitioner(PlannerConfig(partitioner_type="memory_balanced"))
+        self.assertIsInstance(
+            self.provider._build_partitioner(
+                PlannerConfig(partitioner_type="memory_balanced")
+            ),
+            MemoryBalancedPartitioner,
         )
+        self.assertIsNone(self.provider._build_partitioner(PlannerConfig()))

--- a/torchrec/distributed/planner/tests/test_reporter.py
+++ b/torchrec/distributed/planner/tests/test_reporter.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch.nn as nn
+from torchrec.distributed.planner.reporter import DefaultPlanReporter, PlanReporter
+from torchrec.distributed.planner.stats import EmbeddingStats
+from torchrec.distributed.planner.types import (
+    PlannerSessionContext,
+    ShardingPlanRequest,
+)
+
+
+def _ctx() -> PlannerSessionContext:
+    request = ShardingPlanRequest(
+        model=nn.Linear(4, 4),
+        sharders=[],
+        world_size=2,
+        local_world_size=2,
+        batch_size=512,
+    )
+    return PlannerSessionContext(request=request, results={})
+
+
+class DefaultPlanReporterTest(unittest.TestCase):
+    def test_conforms_to_protocol(self) -> None:
+        self.assertIsInstance(DefaultPlanReporter(), PlanReporter)
+
+    def test_build_stats_console_only(self) -> None:
+        stats = DefaultPlanReporter().build_stats(_ctx(), "H100")
+        self.assertEqual(len(stats), 1)
+        self.assertIsInstance(stats[0], EmbeddingStats)
+
+    def test_build_stats_returns_fresh_instances_per_call(self) -> None:
+        # The per-target loop calls build_stats once per SKU; each call must
+        # return fresh (stateful) sinks so a multi-SKU sweep never reuses them.
+        reporter = DefaultPlanReporter()
+        ctx = _ctx()
+        first = reporter.build_stats(ctx, "H100")
+        second = reporter.build_stats(ctx, "GB200")
+        self.assertIsNot(first[0], second[0])

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -27,6 +27,7 @@ from torchrec.distributed.planner.storage_reservations import (
 from torchrec.distributed.planner.types import (
     BasicCommsBandwidths,
     CustomTopologyData,
+    EmoConfig,
     HardwareConfig,
     hash_planner_context_inputs,
     KernelConfig,
@@ -35,6 +36,7 @@ from torchrec.distributed.planner.types import (
     Perf,
     PlannerConfig,
     PlannerVariant,
+    ProposerConfig,
     Shard,
     ShardDetail,
     ShardingOption,
@@ -47,6 +49,7 @@ from torchrec.distributed.planner.types import (
     TopologyFactory,
     TrainerConfig,
     TrainingFramework,
+    TuneClfConfig,
 )
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
@@ -2064,6 +2067,46 @@ class ShardingPlanRequestTest(unittest.TestCase):
                 )
             ).request_hash,
         )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    proposer_config=ProposerConfig(kind="dynamic_col_dim", step_size=4)
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    lp_config=LpPlannerConfig(
+                        emo_config=EmoConfig(integration_type="add_as_constraint")
+                    )
+                )
+            ).request_hash,
+        )
+        # EMO CLF-tuning knobs participate too: two requests differing only in
+        # tune_clf_config must fingerprint differently, else the cache returns one
+        # config's plan for the other.
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    lp_config=LpPlannerConfig(
+                        emo_config=EmoConfig(tune_clf_config=TuneClfConfig(max_clf=0.5))
+                    )
+                )
+            ).request_hash,
+        )
+
+    def test_proposer_type_and_config_mutually_exclusive(self) -> None:
+        # Both set would hash distinctly for the same intent and let OSS vs fb
+        # builders pick differently, so PlannerConfig rejects it.
+        with self.assertRaisesRegex(ValueError, "only one of proposer_type"):
+            PlannerConfig(
+                proposer_type="greedy",
+                proposer_config=ProposerConfig(kind="dynamic_col_dim"),
+            )
 
     def test_request_hash_constraints_order_independent(self) -> None:
         # constraints is a dict; two requests with the same entries inserted in
@@ -2111,6 +2154,8 @@ class PlannerConfigTest(unittest.TestCase):
         self.assertIsNone(cfg.memory_balanced_max_search_count)
         self.assertIsNone(cfg.memory_balanced_tolerance)
         self.assertIsNone(cfg.performance_model)
+        self.assertIsNone(cfg.proposer_config)
+        self.assertIsNone(cfg.lp_config)
 
     def test_percentage_range_validated(self) -> None:
         for bad in (-0.1, 1.1):

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -9,10 +9,11 @@
 
 import unittest
 from copy import deepcopy
-from typing import cast, Dict, Optional
+from typing import Any, Callable, cast, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import torch
+import torch.nn as nn
 from torch import multiprocessing
 from torchrec.distributed.embedding_types import EmbeddingComputeKernel
 from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
@@ -29,13 +30,19 @@ from torchrec.distributed.planner.types import (
     HardwareConfig,
     hash_planner_context_inputs,
     KernelConfig,
+    LpPlannerConfig,
     ParameterConstraints,
+    PlannerConfig,
+    PlannerVariant,
     Shard,
     ShardingOption,
+    ShardingPlanRequest,
     Storage,
+    StorageReservationPolicy,
     Topology,
     TopologyFactory,
     TrainerConfig,
+    TrainingFramework,
 )
 from torchrec.distributed.test_utils.multi_process import (
     MultiProcessContext,
@@ -1879,3 +1886,245 @@ class TestTopologyFactory(unittest.TestCase):
             self.assertEqual(topology.ddr_mem_bw, 200.0)
             self.assertEqual(topology.hbm_to_ddr_mem_bw, 50.0)
             self.assertEqual(topology.ssd_mem_bw, 10.0)
+
+
+class ShardingPlanRequestTest(unittest.TestCase):
+    def _create_request(self, **kwargs: Any) -> ShardingPlanRequest:
+        defaults: Dict[str, Any] = {
+            "model": nn.Linear(10, 10),
+            "sharders": [],
+            "world_size": 8,
+            "local_world_size": 8,
+            "batch_size": 512,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanRequest(**defaults)
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"world_size": 0}, "world_size must be positive"),
+            ({"world_size": -1}, "world_size must be positive"),
+            ({"local_world_size": 0}, "local_world_size must be positive"),
+            ({"batch_size": 0}, "batch_size must be positive"),
+            ({"hbm_gb": -1.0}, "hbm_gb must be non-negative"),
+            ({"ddr_gb": -10.0}, "ddr_gb must be non-negative"),
+            ({"pod_size": 0}, "pod_size must be positive"),
+            ({"pod_size": -1}, "pod_size must be positive"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_request(**overrides)
+
+    def test_cross_field_validation(self) -> None:
+        with self.subTest("local exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "local_world_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=4, local_world_size=8)
+
+        with self.subTest("world not divisible by local"):
+            with self.assertRaisesRegex(
+                ValueError, "world_size.*must be divisible by local_world_size"
+            ):
+                self._create_request(world_size=10, local_world_size=3)
+
+        with self.subTest("pod_size exceeds world"):
+            with self.assertRaisesRegex(
+                ValueError, "pod_size.*must not exceed world_size"
+            ):
+                self._create_request(world_size=8, pod_size=16)
+
+    def test_zero_hbm_gb_allowed(self) -> None:
+        request = self._create_request(hbm_gb=0.0)
+        self.assertEqual(request.hbm_gb, 0.0)
+
+    def test_training_framework_enum_accepted(self) -> None:
+        for framework in TrainingFramework:
+            with self.subTest(framework=framework):
+                request = self._create_request(training_framework=framework)
+                self.assertIs(request.training_framework, framework)
+
+    def test_training_framework_string_coerced_to_enum(self) -> None:
+        # A plain string value (e.g. from config) is normalized to the enum so
+        # downstream always reads a TrainingFramework.
+        request = self._create_request(training_framework="apf")
+        self.assertIs(request.training_framework, TrainingFramework.APF)
+
+    def test_invalid_training_framework_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "training_framework must be"):
+            self._create_request(training_framework="tensorflow")
+
+    def test_model_callable_factory(self) -> None:
+        constructed = nn.Linear(10, 10)
+
+        def factory() -> nn.Module:
+            return constructed
+
+        request = self._create_request(model=factory)
+        self.assertNotIsInstance(request.model, nn.Module)
+        # Not an nn.Module, so the Union holds the factory; cast to call it.
+        stored_factory = cast(Callable[[], nn.Module], request.model)
+        self.assertIs(stored_factory(), constructed)
+
+    def test_request_hash_is_deterministic_for_same_params(self) -> None:
+        # Content hash: identical planner-affecting params -> identical hash.
+        self.assertTrue(self._create_request().request_hash)
+        self.assertEqual(
+            self._create_request().request_hash,
+            self._create_request().request_hash,
+        )
+
+    def test_request_hash_differs_for_different_params(self) -> None:
+        base = self._create_request().request_hash
+        self.assertNotEqual(base, self._create_request(batch_size=1024).request_hash)
+        self.assertNotEqual(base, self._create_request(world_size=16).request_hash)
+        self.assertNotEqual(
+            base, self._create_request(training_framework="apf").request_hash
+        )
+
+    def test_default_planner_config(self) -> None:
+        cfg = self._create_request().planner_config
+        self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
+        self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
+
+    def test_request_hash_includes_planner_config(self) -> None:
+        # planner_config is plan-affecting, so it participates in the content hash.
+        base = self._create_request().request_hash
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    planner_variant=PlannerVariant.LINEAR_PROGRAMMING
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    storage_reservation_policy=StorageReservationPolicy.FIXED_PERCENTAGE
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    manifold_path="manifold://tree/sharding/plan.json"
+                )
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(planner_config=PlannerConfig(debug=True)).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(timeout_seconds=1200)
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    lp_config=LpPlannerConfig(objective="max_total_perf")
+                )
+            ).request_hash,
+        )
+        # The APF-reconstruction scalar knobs also participate in the hash.
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(pipeline_type="train_sparse_dist")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(partitioner_sort_by="storage")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(performance_model="table_size")
+            ).request_hash,
+        )
+        self.assertNotEqual(
+            base,
+            self._create_request(
+                planner_config=PlannerConfig(
+                    use_batch_inputs_for_expected_cache_fetches=True
+                )
+            ).request_hash,
+        )
+
+    def test_request_hash_constraints_order_independent(self) -> None:
+        # constraints is a dict; two requests with the same entries inserted in
+        # different orders must share a hash (a dict's repr is insertion-ordered,
+        # so the hash normalizes by sorting keys).
+        first = self._create_request(
+            constraints={
+                "table_a": ParameterConstraints(sharding_types=["table_wise"]),
+                "table_b": ParameterConstraints(sharding_types=["row_wise"]),
+            }
+        )
+        second = self._create_request(
+            constraints={
+                "table_b": ParameterConstraints(sharding_types=["row_wise"]),
+                "table_a": ParameterConstraints(sharding_types=["table_wise"]),
+            }
+        )
+        self.assertEqual(first.request_hash, second.request_hash)
+
+    def test_request_id_is_unique_per_instance(self) -> None:
+        # request_id is per-instance (UUID); request_hash is per-content. Two
+        # requests with identical params therefore share a hash but get
+        # distinct ids.
+        first = self._create_request()
+        second = self._create_request()
+        self.assertTrue(first.request_id)
+        self.assertNotEqual(first.request_id, second.request_id)
+        self.assertEqual(first.request_hash, second.request_hash)
+
+
+class PlannerConfigTest(unittest.TestCase):
+    def test_defaults(self) -> None:
+        cfg = PlannerConfig()
+        self.assertIs(cfg.planner_variant, PlannerVariant.UNSET)
+        self.assertIs(cfg.storage_reservation_policy, StorageReservationPolicy.UNSET)
+        self.assertIsNone(cfg.storage_reservation_percentage)
+        self.assertFalse(cfg.use_hardware_based_compute)
+        self.assertFalse(cfg.use_hardware_based_bandwidth)
+        # APF-reconstruction knobs default to "unset / planner default".
+        self.assertIsNone(cfg.pipeline_type)
+        self.assertFalse(cfg.use_batch_inputs_for_expected_cache_fetches)
+        self.assertFalse(cfg.use_linear_regression_prefetch_estimate)
+        self.assertFalse(cfg.balance_modules)
+        self.assertIsNone(cfg.partitioner_sort_by)
+        self.assertIsNone(cfg.memory_balanced_max_search_count)
+        self.assertIsNone(cfg.memory_balanced_tolerance)
+        self.assertIsNone(cfg.performance_model)
+
+    def test_percentage_range_validated(self) -> None:
+        for bad in (-0.1, 1.1):
+            with self.subTest(pct=bad):
+                with self.assertRaisesRegex(
+                    ValueError, "storage_reservation_percentage must be between"
+                ):
+                    PlannerConfig(storage_reservation_percentage=bad)
+        # Both boundaries are allowed.
+        for good in (0.0, 1.0):
+            with self.subTest(pct=good):
+                self.assertEqual(
+                    PlannerConfig(
+                        storage_reservation_percentage=good
+                    ).storage_reservation_percentage,
+                    good,
+                )
+
+    def test_negative_bwd_multiplier_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "bwd_compute_multiplier must be"):
+            PlannerConfig(bwd_compute_multiplier=-1.0)

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -36,6 +36,7 @@ from torchrec.distributed.planner.types import (
     Perf,
     PlannerConfig,
     PlannerVariant,
+    PlanReportMetadata,
     ProposerConfig,
     Shard,
     ShardDetail,
@@ -2177,6 +2178,28 @@ class PlannerConfigTest(unittest.TestCase):
     def test_negative_bwd_multiplier_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "bwd_compute_multiplier must be"):
             PlannerConfig(bwd_compute_multiplier=-1.0)
+
+
+class PlanReportMetadataTest(unittest.TestCase):
+    def test_defaults(self) -> None:
+        md = PlanReportMetadata()
+        self.assertIsNone(md.trainer)
+        self.assertIsNone(md.pipeline)
+        self.assertIsNone(md.embedding_hash)
+        self.assertIsNone(md.proposer_types)
+        self.assertTrue(md.log_plan)
+
+    def test_carries_provenance(self) -> None:
+        md = PlanReportMetadata(
+            trainer="apf",
+            pipeline="train_sparse_dist",
+            total_model_param_size=100,
+            proposer_types=("dynamic_col_dim",),
+            num_parallel_worlds=2,
+        )
+        self.assertEqual(md.trainer, "apf")
+        self.assertEqual(md.proposer_types, ("dynamic_col_dim",))
+        self.assertEqual(md.num_parallel_worlds, 2)
 
 
 class ShardingPlanResultTest(unittest.TestCase):

--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -32,11 +32,15 @@ from torchrec.distributed.planner.types import (
     KernelConfig,
     LpPlannerConfig,
     ParameterConstraints,
+    Perf,
     PlannerConfig,
     PlannerVariant,
     Shard,
+    ShardDetail,
     ShardingOption,
+    ShardingOptionDetail,
     ShardingPlanRequest,
+    ShardingPlanResult,
     Storage,
     StorageReservationPolicy,
     Topology,
@@ -2128,3 +2132,202 @@ class PlannerConfigTest(unittest.TestCase):
     def test_negative_bwd_multiplier_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "bwd_compute_multiplier must be"):
             PlannerConfig(bwd_compute_multiplier=-1.0)
+
+
+class ShardingPlanResultTest(unittest.TestCase):
+    def _create_result(self, **kwargs: Any) -> ShardingPlanResult:
+        defaults: Dict[str, Any] = {
+            "sku": "H100",
+            "success": True,
+            "sharding_plan": None,
+            "planner_failure_reason": None,
+            "estimated_max_hbm_bytes": 1_000_000,
+            "estimated_max_ddr_bytes": 2_000_000,
+        }
+        defaults.update(kwargs)
+        return ShardingPlanResult(**defaults)
+
+    def test_success_result_holds_optional_metrics(self) -> None:
+        result = self._create_result(
+            estimated_qps=1000.0,
+            critical_path_ms=5.0,
+            validation_warnings=("close to HBM limit",),
+        )
+        self.assertTrue(result.success)
+        self.assertIsNone(result.planner_failure_reason)
+        self.assertEqual(result.estimated_qps, 1000.0)
+        self.assertEqual(result.critical_path_ms, 5.0)
+        self.assertEqual(result.validation_warnings, ("close to HBM limit",))
+
+    def test_failure_result_carries_reason(self) -> None:
+        result = self._create_result(success=False, planner_failure_reason="OOM_HBM")
+        self.assertFalse(result.success)
+        self.assertEqual(result.planner_failure_reason, "OOM_HBM")
+
+    def test_invalid_single_field_rejected(self) -> None:
+        cases = [
+            ({"sku": ""}, "sku must not be empty"),
+            ({"estimated_max_hbm_bytes": -1}, "estimated_max_hbm_bytes must be"),
+            ({"estimated_max_ddr_bytes": -1}, "estimated_max_ddr_bytes must be"),
+            ({"estimated_qps": -1.0}, "estimated_qps must be non-negative"),
+            ({"critical_path_ms": -1.0}, "critical_path_ms must be non-negative"),
+            ({"solve_time_ms": -1.0}, "solve_time_ms must be non-negative"),
+        ]
+        for overrides, expected_msg in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, expected_msg):
+                    self._create_result(**overrides)
+
+    def test_success_failure_reason_consistency(self) -> None:
+        with self.subTest("success with reason"):
+            with self.assertRaisesRegex(
+                ValueError, "planner_failure_reason must be None when success is True"
+            ):
+                self._create_result(success=True, planner_failure_reason="OOM")
+        with self.subTest("failure without reason"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "planner_failure_reason is required when success is False",
+            ):
+                self._create_result(success=False, planner_failure_reason=None)
+
+    def test_zero_memory_allowed(self) -> None:
+        result = self._create_result(
+            estimated_max_hbm_bytes=0,
+            estimated_max_ddr_bytes=0,
+        )
+        self.assertEqual(result.estimated_max_hbm_bytes, 0)
+        self.assertEqual(result.estimated_max_ddr_bytes, 0)
+
+
+class ShardingOptionDetailTest(unittest.TestCase):
+    def test_from_sharding_option_projects_per_shard_detail(self) -> None:
+        # from_sharding_option captures the per-shard storage/perf the
+        # deployment-facing ShardingPlan drops, and aggregates the totals.
+        shards = [
+            Shard(
+                size=[5000, 80],
+                offset=[0, 0],
+                storage=Storage(hbm=600, ddr=10, ssd=5),
+                perf=Perf(
+                    fwd_compute=1.0, fwd_comms=2.0, bwd_compute=3.0, bwd_comms=4.0
+                ),
+                rank=0,
+            ),
+            Shard(
+                size=[5000, 80],
+                offset=[5000, 0],
+                storage=Storage(hbm=400, ddr=20, ssd=15),
+                perf=Perf(
+                    fwd_compute=0.5, fwd_comms=0.5, bwd_compute=0.5, bwd_comms=0.5
+                ),
+                rank=1,
+            ),
+        ]
+        sharding_option = ShardingOption(
+            name="table_0",
+            tensor=torch.empty(
+                (10000, 80), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.ROW_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=shards,
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertEqual(detail.fqn, "ebc.table_0")
+        self.assertEqual(detail.sharding_type, ShardingType.ROW_WISE.value)
+        self.assertEqual(detail.compute_kernel, EmbeddingComputeKernel.FUSED.value)
+        self.assertEqual(len(detail.shards), 2)
+        self.assertEqual(detail.shards[0].rank, 0)
+        self.assertEqual(detail.shards[0].size, (5000, 80))
+        self.assertEqual(detail.shards[0].offset, (0, 0))
+        self.assertEqual(detail.shards[0].hbm_bytes, 600)
+        self.assertEqual(detail.shards[0].ddr_bytes, 10)
+        self.assertEqual(detail.shards[0].ssd_bytes, 5)
+        self.assertEqual(detail.shards[0].perf_total, 10.0)
+        self.assertEqual(detail.total_hbm_bytes, 1000)
+        self.assertEqual(detail.total_ddr_bytes, 30)
+        self.assertEqual(detail.total_ssd_bytes, 20)
+        self.assertEqual(detail.total_perf, 12.0)
+
+    def test_from_sharding_option_without_estimates(self) -> None:
+        # Shards without storage/perf project to zero bytes and None perf.
+        sharding_option = ShardingOption(
+            name="table_1",
+            tensor=torch.empty(
+                (100, 16), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.TABLE_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[Shard(size=[100, 16], offset=[0, 0])],
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertEqual(detail.total_hbm_bytes, 0)
+        self.assertEqual(detail.total_ddr_bytes, 0)
+        self.assertEqual(detail.total_ssd_bytes, 0)
+        self.assertIsNone(detail.total_perf)
+        self.assertIsNone(detail.shards[0].perf_total)
+
+    def test_negative_values_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ssd_bytes must be non-negative"):
+            ShardDetail(
+                rank=0,
+                size=(1, 1),
+                offset=(0, 0),
+                hbm_bytes=0,
+                ddr_bytes=0,
+                ssd_bytes=-1,
+            )
+        with self.assertRaisesRegex(ValueError, "perf_total must be non-negative"):
+            ShardDetail(
+                rank=0,
+                size=(1, 1),
+                offset=(0, 0),
+                hbm_bytes=0,
+                ddr_bytes=0,
+                ssd_bytes=0,
+                perf_total=-1.0,
+            )
+        with self.assertRaisesRegex(ValueError, "total_hbm_bytes must be non-negative"):
+            ShardingOptionDetail(
+                fqn="ebc.t0",
+                sharding_type="table_wise",
+                compute_kernel="fused",
+                total_hbm_bytes=-1,
+            )
+
+    def test_total_perf_none_when_any_shard_missing_perf(self) -> None:
+        # A partial perf sum would understate cost, so total_perf is None unless
+        # every shard has an estimate.
+        sharding_option = ShardingOption(
+            name="table_2",
+            tensor=torch.empty(
+                (200, 16), dtype=torch.float16, device=torch.device("meta")
+            ),
+            module=("ebc", MagicMock()),
+            input_lengths=MagicMock(),
+            batch_size=MagicMock(),
+            sharding_type=ShardingType.ROW_WISE.value,
+            partition_by=MagicMock(),
+            compute_kernel=EmbeddingComputeKernel.FUSED.value,
+            shards=[
+                Shard(
+                    size=[100, 16],
+                    offset=[0, 0],
+                    perf=Perf(
+                        fwd_compute=1.0, fwd_comms=1.0, bwd_compute=1.0, bwd_comms=1.0
+                    ),
+                ),
+                Shard(size=[100, 16], offset=[100, 0]),  # no perf estimate
+            ],
+        )
+        detail = ShardingOptionDetail.from_sharding_option(sharding_option)
+        self.assertIsNone(detail.total_perf)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2099,6 +2099,10 @@ class PlannerConfig:
     # Resolved PipelineType value for the storage estimator (e.g. "train_sparse_dist");
     # None = estimator default. Mirrors APF's pipeline-aware storage estimation.
     pipeline_type: Optional[str] = None
+    # Estimated dense (non-embedding) per-rank tensor bytes; threaded into
+    # HeuristicalStorageReservation so the reserved HBM matches the legacy
+    # path. None (the base provider default) leaves the reservation unchanged.
+    dense_tensor_estimate: Optional[int] = None
     # Hardware-based perf-estimator flags (apply when use_hardware_based_compute).
     use_batch_inputs_for_expected_cache_fetches: bool = False
     use_linear_regression_prefetch_estimate: bool = False
@@ -2316,6 +2320,7 @@ class ShardingPlanRequest:
                     self.planner_config.debug,
                     self.planner_config.timeout_seconds,
                     self.planner_config.pipeline_type,
+                    self.planner_config.dense_tensor_estimate,
                     self.planner_config.use_batch_inputs_for_expected_cache_fetches,
                     self.planner_config.use_linear_regression_prefetch_estimate,
                     self.planner_config.balance_modules,

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2596,6 +2596,40 @@ class ShardingPlanResult:
             raise ValueError("planner_failure_reason is required when success is False")
 
 
+@dataclass(frozen=True)
+class PlanReportMetadata:
+    """Observability provenance for plan reporting (Manifold/Scuba sinks).
+
+    Carries the framework/model-known facts the reporter needs to build the stats
+    sinks — data our layer cannot derive from the plan/topology/request. It is
+    observability-only and does NOT affect the plan, so it is deliberately kept
+    off ``PlannerConfig`` and excluded from ``request_hash``. Optional; absent ->
+    the reporter falls back to console stats only. (``feature_stats_summary`` and
+    similar summary objects are not projected here yet — a follow-up.)
+
+    One instance describes a single plan (one model), so model-specific fields
+    such as ``proposer_types``, ``embedding_hash`` and the size fields vary across
+    models by design — the caller populates them per request.
+    """
+
+    trainer: Optional[str] = None
+    pipeline: Optional[str] = None
+    total_model_param_size: Optional[int] = None
+    total_sparse_param_size: Optional[int] = None
+    embedding_hash: Optional[str] = None
+    # Tuple (not List) so this frozen dataclass stays hashable: @dataclass(
+    # frozen=True) auto-generates __hash__ over all fields, and a list field
+    # would raise TypeError when an instance carrying proposer types is hashed.
+    proposer_types: Optional[Tuple[str, ...]] = None
+    num_parallel_worlds: Optional[int] = None
+    log_plan: bool = True
+    # Optional override for the Manifold upload directory (relative to the
+    # sharding_analysis bucket, e.g. "tree/sharding_plan/my_dry_run"). None ->
+    # the reporter uses the default job-context path (or the local dry-run
+    # fallback offline). Lets a dry-run pin a known location for later diffing.
+    manifold_path: Optional[str] = None
+
+
 @dataclass
 class PlannerSessionContext:
     """Mutable context accumulating state during a planner session.
@@ -2650,6 +2684,9 @@ class PlannerSessionContext:
     # corresponds to. Links the request/session to the launching job for
     # cross-system correlation. Session-level; None until associated with a job.
     external_trace_id: Optional[str] = None
+    # Observability provenance for plan reporting (Manifold/Scuba); observability
+    # only, not plan-affecting (excluded from request_hash). None -> console-only.
+    report_metadata: Optional[PlanReportMetadata] = None
 
 
 # ---- Types Utils ---- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2687,6 +2687,9 @@ class PlannerSessionContext:
     # Observability provenance for plan reporting (Manifold/Scuba); observability
     # only, not plan-affecting (excluded from request_hash). None -> console-only.
     report_metadata: Optional[PlanReportMetadata] = None
+    # Stats sinks the planner logs to, built by the orchestrator's PlanReporter
+    # from report_metadata and forwarded to the planner. None -> planner default.
+    stats: Optional[List[Stats]] = None
 
 
 # ---- Types Utils ---- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -10,6 +10,7 @@
 import abc
 import hashlib
 import logging
+import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1848,6 +1849,403 @@ class CriticalPathEstimate:
 
     def total(self) -> float:
         return self.comms_estimate + self.comp_estimate
+
+
+class TrainingFramework(str, Enum):
+    """Training framework that consumes the sharding plan.
+
+    Selects framework-specific topology behavior (DDR division logic,
+    JustKnob-gated detection, framework-specific adjustments) in downstream
+    consumers. ``UNSET`` is the sentinel for "not set", which yields
+    framework-agnostic defaults.
+
+    Defined here (rather than imported) because this open-source module cannot
+    import the equivalent framework enum that lives in internal code; the string
+    values are the contract that bridges the two.
+
+    Subclasses ``str`` so members behave as their string value: they JSON
+    serialize to the bare string, compare equal to it, and ``UNSET`` ("") is
+    falsy — keeping downstream string-based consumers (fingerprints, configs)
+    working without special-casing the enum.
+    """
+
+    UNSET = ""
+    APF = "apf"
+    PYPER = "pyper"
+    MVAI = "mvai"
+
+
+class PlannerVariant(str, Enum):
+    """Planner backend that produces the plan.
+
+    Why an enum rather than a bare string: the frameworks (Pyper/MVAI/APF) pass
+    the backend as a free-form config value today, but the set of backends is
+    small, closed, and fully owned here in OSS. Normalizing that config string
+    into an enum at the request boundary gives (1) a single source of truth for
+    the valid backends, (2) typo-safety and autocomplete at call sites, and (3)
+    exhaustive, checkable dispatch in the executor (which switches on this to
+    pick the planner). Contrast launcher_hardware, kept a ``str`` because its
+    value set is large, still growing, and resolved fb-side — the same rule that
+    keeps TrainingFramework an enum but launcher_hardware a string.
+
+    Where the string -> enum conversion (and validation) happens: at the framework
+    request boundary, via the enum constructor — ``PlannerVariant(cfg_str)`` both
+    converts and raises ``ValueError`` on an unknown value in one call. The field
+    is typed as the enum and ``PlannerConfig`` does no coercion, so every reader
+    sees a ``PlannerVariant`` without a redundant normalization step.
+
+    Subclasses ``str`` so a member serializes/compares as its bare value, keeping
+    it stable in the request content hash and in string-based configs.
+
+    ``UNSET`` ("") is the "not specified" sentinel and the default: the executor
+    treats it as the OSS backend, so callers that do not care get sensible
+    behavior without naming a backend.
+    """
+
+    UNSET = ""
+    OSS = "oss"
+    LINEAR_PROGRAMMING = "linear_programming"
+    MANIFOLD = "manifold"
+
+
+class StorageReservationPolicy(str, Enum):
+    """Policy for reserving non-sharded (dense/overhead) memory before planning.
+
+    An enum for the same reasons as ``PlannerVariant``: a small, closed,
+    OSS-owned set that the frameworks pass as config strings, normalized here for
+    one source of truth, typo-safety, and an exhaustive switch in the
+    storage-reservation resolver (which maps each value to a StorageReservation
+    implementation). As with ``PlannerVariant``, the string -> enum conversion and
+    validation happen at the framework boundary via the enum constructor
+    (``StorageReservationPolicy(cfg_str)``); the field is typed as the enum and
+    ``PlannerConfig`` does no coercion.
+
+    Subclasses ``str`` for the same serialization reasons as ``PlannerVariant``.
+
+    ``UNSET`` ("") is the "not specified" sentinel and the default: the
+    storage-reservation resolver treats it as its default policy (heuristical).
+
+    Only policies with a backing StorageReservation are listed. HEURISTICAL,
+    FIXED_PERCENTAGE, and INFERENCE map to Heuristical/FixedPercentage/Inference
+    StorageReservation respectively; SKU_AWARE is planned (SKUAwareStorageReservation
+    is designed but not yet implemented). "memory_balanced" is intentionally absent
+    — it is a partitioner strategy (MemoryBalancedPartitioner), not a reservation.
+    """
+
+    UNSET = ""
+    HEURISTICAL = "heuristical"
+    FIXED_PERCENTAGE = "fixed_percentage"
+    INFERENCE = "inference"
+    # Planned: SKUAwareStorageReservation (design done, not yet implemented).
+    SKU_AWARE = "sku_aware"
+
+
+@dataclass(frozen=True)
+class LpPlannerConfig:
+    """OSS-safe scalar knobs for the LINEAR_PROGRAMMING planner variant.
+
+    Carried as plain data so it stays serializable/hashable (part of the request
+    content hash) — the fb LinearProgrammingPlanner accepts these scalars (e.g.
+    MVAI already passes ``objective``/``shard_solver_type`` as plain strings). Each
+    field is Optional; None means "use the LP planner's own default", so the fb
+    builder only forwards the ones that are set. The fb-typed forms
+    (OptimObjective/ShardSolverType/EMOConfig) are never referenced from OSS.
+    """
+
+    # Optimization objective, e.g. "max_total_perf" (LP OptimObjective by value)
+    objective: Optional[str] = None
+    # Shard solver, e.g. "greedy" (LP ShardSolverType by value)
+    shard_solver_type: Optional[str] = None
+    # Whether to tune column dimensions
+    tune_col_dims: Optional[bool] = None
+    # Hybrid solver percentage (0-100)
+    hybrid_percentage: Optional[int] = None
+    # Allowed solution-quality worsening percentage (>= 0.0)
+    allowed_worsening_percentage: Optional[float] = None
+    # Whether to apply per-stage timeouts
+    stagewise_timeout: Optional[bool] = None
+    # Whether plan caching is enabled
+    caching_enabled: Optional[bool] = None
+    # Number of local-search cycles
+    num_cycles: Optional[int] = None
+    # Whether to auto-derive column dimensions
+    auto_col_dims: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class PlannerConfig:
+    """Plan-affecting knobs the trainer expresses per request.
+
+    These are *data* (serializable, hashable) that select how the planner runs;
+    the concrete PlannerExecutor maps them to enumerator/estimator/proposer/
+    partitioner/planner instances. Object-valued, framework-specific behavior
+    (custom proposer instances, stats sinks) is injected into the API instance as
+    a per-framework profile, not carried here — so this stays part of the
+    request's content hash and cache key.
+    """
+
+    # Planner backend to run; UNSET (default) resolves to the OSS backend
+    planner_variant: PlannerVariant = PlannerVariant.UNSET
+    # How non-sharded memory is reserved; UNSET (default) resolves to heuristical
+    storage_reservation_policy: StorageReservationPolicy = (
+        StorageReservationPolicy.UNSET
+    )
+    # Fraction (0.0-1.0) to reserve for the chosen policy; None = policy default
+    storage_reservation_percentage: Optional[float] = None
+    # Proposer selector (e.g. "greedy", "grid_search", "dynamic_col_dim"); None =
+    # executor default. Free-form: the proposer set is extensible and custom
+    # proposer instances are injected via the API profile, so it isn't validated.
+    proposer_type: Optional[str] = None
+    # Partitioner selector (e.g. "greedy_perf", "memory_balanced"); None =
+    # executor default. Free-form for the same reason as proposer_type.
+    partitioner_type: Optional[str] = None
+    # Use hardware-capability-based compute estimates instead of the default model
+    use_hardware_based_compute: bool = False
+    # Use hardware-capability-based bandwidths instead of default topology values
+    use_hardware_based_bandwidth: bool = False
+    # Backward-pass compute multiplier for the perf estimate; None = planner default
+    bwd_compute_multiplier: Optional[float] = None
+    # Manifold path to a pre-computed sharding plan, consumed only by the MANIFOLD
+    # planner_variant (ManifoldPlanner loads the plan from here instead of solving).
+    # Required when planner_variant is MANIFOLD; ignored by other variants.
+    manifold_path: Optional[str] = None
+    # Enable planner debug mode (extra logging/validation). Forwarded to the planner.
+    debug: bool = False
+    # Solver timeout in seconds; None = planner default. Forwarded to the planner.
+    timeout_seconds: Optional[int] = None
+    # Resolved PipelineType value for the storage estimator (e.g. "train_sparse_dist");
+    # None = estimator default. Mirrors APF's pipeline-aware storage estimation.
+    pipeline_type: Optional[str] = None
+    # Hardware-based perf-estimator flags (apply when use_hardware_based_compute).
+    use_batch_inputs_for_expected_cache_fetches: bool = False
+    use_linear_regression_prefetch_estimate: bool = False
+    # Partitioner knobs: balance shards across modules; GreedyPerf sort key
+    # ("perf"/"storage"); MemoryBalanced search bounds (None = partitioner default).
+    balance_modules: bool = False
+    partitioner_sort_by: Optional[str] = None
+    memory_balanced_max_search_count: Optional[int] = None
+    memory_balanced_tolerance: Optional[float] = None
+    # Noop performance-model selector ("storage"/"table_size"); None = no perf model.
+    performance_model: Optional[str] = None
+    # LINEAR_PROGRAMMING scalar knobs; None = LP planner defaults. Consumed only by
+    # the LP variant's fb builder (ignored by other variants).
+    lp_config: Optional[LpPlannerConfig] = None
+
+    def __post_init__(self) -> None:
+        # planner_variant / storage_reservation_policy are typed as enums, so
+        # callers pass a member (framework builders convert a config string with
+        # PlannerVariant(cfg_str), which validates). No coercion is done here.
+        if (
+            self.storage_reservation_percentage is not None
+            and not 0.0 <= self.storage_reservation_percentage <= 1.0
+        ):
+            raise ValueError(
+                "storage_reservation_percentage must be between 0.0 and 1.0, got "
+                f"{self.storage_reservation_percentage}"
+            )
+        if self.bwd_compute_multiplier is not None and self.bwd_compute_multiplier < 0:
+            raise ValueError(
+                "bwd_compute_multiplier must be non-negative, got "
+                f"{self.bwd_compute_multiplier}"
+            )
+
+
+@dataclass(frozen=True)
+class ShardingPlanRequest:
+    """Request for sharding plan generation.
+
+    Encapsulates the model, sharders, cluster topology parameters, and
+    optional overrides needed to produce a sharding plan. Base type for
+    both runtime and dry-run planning flows.
+
+    Immutability note: ``frozen=True`` only prevents rebinding the fields
+    themselves; it does not deep-freeze their contents. The ``sharders``
+    list and the ``constraints`` dict remain mutable in place (e.g.
+    ``request.sharders.append(...)``). They are kept as ``List``/``Dict``
+    because downstream planner APIs consume those concrete types; callers
+    must treat them as read-only by convention rather than relying on an
+    enforced guarantee.
+    """
+
+    # User-provided nn.Module or a factory for lazy construction;
+    # consumers should use isinstance(model, nn.Module) to distinguish
+    model: Union[nn.Module, Callable[[], nn.Module]]
+    # Code-derived from model architecture + training config via get_default_sharders()
+    sharders: List[ModuleSharder[nn.Module]]
+    # Total number of devices in the cluster
+    world_size: int
+    # Devices per host — determines intra-host vs inter-host communication split
+    local_world_size: int
+    # Batch size affects per-device memory estimates from the perf model
+    batch_size: int
+
+    # Pod size for multi-pod topologies (None = single pod)
+    pod_size: Optional[int] = None
+    # Derived from planner.storage_reservation_policy config
+    storage_reservation: Optional[StorageReservation] = None
+    # Code-derived from embedding tables + fused params + UVM cache stats
+    constraints: Optional[Dict[str, ParameterConstraints]] = None
+    # Training framework that consumes the plan. TrainingFramework.UNSET (the
+    # default) means "not set" and yields framework-agnostic defaults. Typed as
+    # an enum so downstream gets a checked value; a plain string (e.g. from
+    # config) is coerced to the enum in __post_init__ and an unknown value
+    # raises ValueError.
+    training_framework: TrainingFramework = TrainingFramework.UNSET
+    # Override HBM capacity (GB); None = auto-detect from CUDA or hardware registry
+    hbm_gb: Optional[float] = None
+    # Override DDR capacity (GB); None = auto-detect
+    ddr_gb: Optional[float] = None
+    # Launcher hardware identifier for topology creation (e.g. "ZIONEX",
+    # "TC_ANY"); None = auto-detect from the launch environment. Kept free-form:
+    # the recognized values mirror the hardware-type identifiers resolved by
+    # downstream consumers, and that set grows as new accelerators are onboarded,
+    # so it is intentionally not validated here.
+    launcher_hardware: Optional[str] = None
+    # Runtime compute device for the plan's topology ("cuda"/"cpu"/"mtia"); None =
+    # let the provider default (production mirrors the framework's real device so
+    # the plan's shard placements match the model's device; dry-run models "cuda").
+    # Plan-affecting (a cpu vs cuda topology changes placement), so it is hashed.
+    compute_device: Optional[str] = None
+    # Plan-affecting knobs (planner backend, reservation policy, proposer/
+    # partitioner selection, hardware-based flags). Data-only so it participates
+    # in request_hash; object-valued behavior is injected into the API instance.
+    planner_config: PlannerConfig = field(default_factory=PlannerConfig)
+    # Unique per-instance id for this request, used to correlate it with the
+    # ShardingPlanResult(s) it produces (see ShardingPlanResult.request_id).
+    # Complements request_hash: request_hash is a *content* hash shared by
+    # identical requests (cache/dedup key), whereas request_id is unique per
+    # request object — use it to tell two otherwise-identical requests apart.
+    # Auto-generated; override to thread an externally-supplied id.
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def __post_init__(self) -> None:
+        self._normalize_training_framework()
+        self._validate()
+
+    def _normalize_training_framework(self) -> None:
+        # Accept either a TrainingFramework or its string value (e.g. read from
+        # config) and normalize to the enum, so downstream always reads a
+        # TrainingFramework. Unknown strings raise ValueError.
+        if isinstance(self.training_framework, TrainingFramework):
+            return
+        try:
+            object.__setattr__(
+                self,
+                "training_framework",
+                TrainingFramework(self.training_framework),
+            )
+        except ValueError as e:
+            valid = [f.value for f in TrainingFramework]
+            raise ValueError(
+                f"training_framework must be a TrainingFramework or one of "
+                f"{valid}, got {self.training_framework!r}"
+            ) from e
+
+    def _validate(self) -> None:
+        # Positive-required scalars.
+        for name in ("world_size", "local_world_size", "batch_size"):
+            value = getattr(self, name)
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.pod_size is not None and self.pod_size <= 0:
+            raise ValueError(f"pod_size must be positive, got {self.pod_size}")
+        # Non-negative-optional scalars.
+        for name in ("hbm_gb", "ddr_gb"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+        # Cross-field constraints.
+        if self.local_world_size > self.world_size:
+            raise ValueError(
+                f"local_world_size ({self.local_world_size}) must not exceed "
+                f"world_size ({self.world_size})"
+            )
+        if self.world_size % self.local_world_size != 0:
+            raise ValueError(
+                f"world_size ({self.world_size}) must be divisible by "
+                f"local_world_size ({self.local_world_size})"
+            )
+        if self.pod_size is not None and self.pod_size > self.world_size:
+            raise ValueError(
+                f"pod_size ({self.pod_size}) must not exceed "
+                f"world_size ({self.world_size})"
+            )
+
+    @property
+    def request_hash(self) -> str:
+        """Stable content hash identifying this request.
+
+        Deterministic over the planner-affecting parameters, so two requests
+        with the same parameters share a hash. Used to correlate the request
+        with its ShardingPlanResult(s) and PlannerSessionContext, and as a
+        cache key.
+
+        Excludes, by design: `model` and `sharders` (not stably hashable);
+        `storage_reservation` (an injected behavior object, not plan-data); and
+        `request_id` (unique per instance — hashing it would defeat the
+        identical-params-share-a-hash guarantee). Callers needing model-level
+        uniqueness should scope by the context's model — mirroring
+        DryRunRequest.fingerprint().
+        """
+        return format(
+            hash_sha256_to_int(
+                [
+                    self.world_size,
+                    self.local_world_size,
+                    self.batch_size,
+                    self.pod_size,
+                    self.hbm_gb,
+                    self.ddr_gb,
+                    self.training_framework.value,
+                    self.launcher_hardware,
+                    self.compute_device,
+                    # Hash constraints order-independently: a dict's repr follows
+                    # insertion order, so sort by key for a stable hash across
+                    # semantically-equal requests built in different orders. Sort
+                    # by key only (ParameterConstraints is not rich-comparable).
+                    (
+                        [(k, self.constraints[k]) for k in sorted(self.constraints)]
+                        if self.constraints is not None
+                        else None
+                    ),
+                    self.planner_config.planner_variant.value,
+                    self.planner_config.storage_reservation_policy.value,
+                    self.planner_config.storage_reservation_percentage,
+                    self.planner_config.proposer_type,
+                    self.planner_config.partitioner_type,
+                    self.planner_config.use_hardware_based_compute,
+                    self.planner_config.use_hardware_based_bandwidth,
+                    self.planner_config.bwd_compute_multiplier,
+                    self.planner_config.manifold_path,
+                    self.planner_config.debug,
+                    self.planner_config.timeout_seconds,
+                    self.planner_config.pipeline_type,
+                    self.planner_config.use_batch_inputs_for_expected_cache_fetches,
+                    self.planner_config.use_linear_regression_prefetch_estimate,
+                    self.planner_config.balance_modules,
+                    self.planner_config.partitioner_sort_by,
+                    self.planner_config.memory_balanced_max_search_count,
+                    self.planner_config.memory_balanced_tolerance,
+                    self.planner_config.performance_model,
+                    (
+                        (
+                            lp.objective,
+                            lp.shard_solver_type,
+                            lp.tune_col_dims,
+                            lp.hybrid_percentage,
+                            lp.allowed_worsening_percentage,
+                            lp.stagewise_timeout,
+                            lp.caching_enabled,
+                            lp.num_cycles,
+                            lp.auto_col_dims,
+                        )
+                        if (lp := self.planner_config.lp_config) is not None
+                        else None
+                    ),
+                ]
+            ),
+            "x",
+        )[:16]
 
 
 # ---- Types Utils ---- #

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -1941,6 +1941,38 @@ class StorageReservationPolicy(str, Enum):
 
 
 @dataclass(frozen=True)
+class TuneClfConfig:
+    """OSS-safe scalar projection of the fb TuneClfConfig (LP CLF search space).
+
+    Plain data so it stays serializable and hashable (part of ``request_hash``):
+    two EMO configs that differ only in CLF tuning must fingerprint differently,
+    or the plan cache would return one's plan for the other. None on a field keeps
+    the LP planner's own default for that knob.
+    """
+
+    increment_size: Optional[float] = None
+    max_clf: Optional[float] = None
+    min_clf: Optional[float] = None
+    min_prefetch_compute_decrease: Optional[float] = None
+    enable_clf_reduction: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class EmoConfig:
+    """OSS-safe scalar projection of the fb EMOConfig (embedding-managed offload).
+
+    Carries the EMO knobs the LP planner consumes as plain data. ``integration_type``
+    is the fb ``EMOIntegrationType`` by value; ``tune_clf_config`` projects the fb
+    CLF-tuning search-space knobs (so they participate in ``request_hash``). None on
+    a field keeps the LP planner's own default for that knob.
+    """
+
+    integration_type: Optional[str] = None
+    prefetch_compute_limit_per_rank: Optional[float] = None
+    tune_clf_config: Optional[TuneClfConfig] = None
+
+
+@dataclass(frozen=True)
 class LpPlannerConfig:
     """OSS-safe scalar knobs for the LINEAR_PROGRAMMING planner variant.
 
@@ -1970,6 +2002,57 @@ class LpPlannerConfig:
     num_cycles: Optional[int] = None
     # Whether to auto-derive column dimensions
     auto_col_dims: Optional[bool] = None
+    # Embedding-managed-offload config; None = LP planner default.
+    emo_config: Optional[EmoConfig] = None
+
+
+@dataclass(frozen=True)
+class ProposerGroup:
+    """One regex group's DynamicColDim args for the grouped-DCD proposer.
+
+    Mirrors a single entry of a framework's ``proposer_group_by_regex``: an fqn
+    regex plus the DynamicColDim knobs applied to the tables it matches. Frozen so
+    a tuple of these stays hashable inside ProposerConfig (part of request_hash).
+    """
+
+    # fqn regex selecting the tables this group's args apply to
+    regex: str
+    step_size: int = 10
+    target: str = "perf"
+    target_reshard_count: Optional[int] = None
+    min_col_dim: int = 20
+    max_inferior_proposals: int = 2
+    max_proposals: int = 10
+
+
+@dataclass(frozen=True)
+class ProposerConfig:
+    """OSS-safe scalar selector + args to reconstruct the planner's proposer(s).
+
+    ``kind`` selects the proposer ("default" keeps the planner's own set); the
+    Optional args mirror what the frameworks pass (DynamicColDim / embedding-offload
+    cache-scaling / scaleup). None keeps that arg's default. Grouped-DCD projects
+    its per-regex arg map into ``groups`` (one ProposerGroup per regex entry).
+    """
+
+    # default | greedy | grid_search | uniform | dynamic_col_dim |
+    # embedding_offload_cache_scaling | embedding_offload_scaleup |
+    # grouped_dynamic_col_dim
+    kind: str = "default"
+    # DynamicColDim / cache-scaling shared knobs
+    step_size: Optional[int] = None
+    target: Optional[str] = None
+    target_reshard_count: Optional[int] = None
+    min_col_dim: Optional[int] = None
+    max_inferior_proposals: Optional[int] = None
+    max_proposals: Optional[int] = None
+    # Embedding-offload cache-scaling knobs
+    allow_scale_down: Optional[bool] = None
+    demote_clf_threshold: Optional[float] = None
+    # Embedding-offload scaleup
+    use_depth: Optional[bool] = None
+    # Grouped-DCD per-regex args (kind="grouped_dynamic_col_dim"); empty otherwise
+    groups: Tuple[ProposerGroup, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2027,11 +2110,24 @@ class PlannerConfig:
     memory_balanced_tolerance: Optional[float] = None
     # Noop performance-model selector ("storage"/"table_size"); None = no perf model.
     performance_model: Optional[str] = None
+    # Proposer selection + scalar args; None = planner default proposer set. The
+    # structured form; mutually exclusive with proposer_type (see __post_init__).
+    proposer_config: Optional[ProposerConfig] = None
     # LINEAR_PROGRAMMING scalar knobs; None = LP planner defaults. Consumed only by
     # the LP variant's fb builder (ignored by other variants).
     lp_config: Optional[LpPlannerConfig] = None
 
     def __post_init__(self) -> None:
+        # proposer_type (OSS scalar selector) and proposer_config (structured form)
+        # are mutually exclusive: both set would hash distinctly for the same intent
+        # (spurious cache miss) and let the OSS vs fb builders pick differently.
+        if self.proposer_type is not None and self.proposer_config is not None:
+            raise ValueError(
+                "Set only one of proposer_type / proposer_config, not both: "
+                "proposer_config is the structured proposer spec (kind + args); "
+                "proposer_type is the simple OSS scalar-selector shortcut "
+                "(greedy/uniform/grid_search)."
+            )
         # planner_variant / storage_reservation_policy are typed as enums, so
         # callers pass a member (framework builders convert a config string with
         # PlannerVariant(cfg_str), which validates). No coercion is done here.
@@ -2229,6 +2325,36 @@ class ShardingPlanRequest:
                     self.planner_config.performance_model,
                     (
                         (
+                            pc.kind,
+                            pc.step_size,
+                            pc.target,
+                            pc.target_reshard_count,
+                            pc.min_col_dim,
+                            pc.max_inferior_proposals,
+                            pc.max_proposals,
+                            pc.allow_scale_down,
+                            pc.demote_clf_threshold,
+                            pc.use_depth,
+                            # Order-sensitive: grouped-DCD matches first regex win,
+                            # so group order is semantically meaningful (not sorted).
+                            tuple(
+                                (
+                                    g.regex,
+                                    g.step_size,
+                                    g.target,
+                                    g.target_reshard_count,
+                                    g.min_col_dim,
+                                    g.max_inferior_proposals,
+                                    g.max_proposals,
+                                )
+                                for g in pc.groups
+                            ),
+                        )
+                        if (pc := self.planner_config.proposer_config) is not None
+                        else None
+                    ),
+                    (
+                        (
                             lp.objective,
                             lp.shard_solver_type,
                             lp.tune_col_dims,
@@ -2238,6 +2364,26 @@ class ShardingPlanRequest:
                             lp.caching_enabled,
                             lp.num_cycles,
                             lp.auto_col_dims,
+                            (
+                                (
+                                    lp.emo_config.integration_type,
+                                    lp.emo_config.prefetch_compute_limit_per_rank,
+                                    (
+                                        (
+                                            tc.increment_size,
+                                            tc.max_clf,
+                                            tc.min_clf,
+                                            tc.min_prefetch_compute_decrease,
+                                            tc.enable_clf_reduction,
+                                        )
+                                        if (tc := lp.emo_config.tune_clf_config)
+                                        is not None
+                                        else None
+                                    ),
+                                )
+                                if lp.emo_config is not None
+                                else None
+                            ),
                         )
                         if (lp := self.planner_config.lp_config) is not None
                         else None

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2248,6 +2248,208 @@ class ShardingPlanRequest:
         )[:16]
 
 
+@dataclass(frozen=True)
+class ShardDetail:
+    """Per-shard placement and cost breakdown for one shard of a table.
+
+    Serializable projection of a planner Shard: keeps the size/offset/rank and
+    the storage/perf estimates that the deployment-facing ShardingPlan drops,
+    without holding the live tensor/module references.
+    """
+
+    # Rank this shard is placed on; None if unassigned
+    rank: Optional[int]
+    # Shard tensor dimensions
+    size: Tuple[int, ...]
+    # Shard offset within the full table
+    offset: Tuple[int, ...]
+    # Estimated HBM for this shard (bytes)
+    hbm_bytes: int
+    # Estimated DDR for this shard (bytes)
+    ddr_bytes: int
+    # Estimated SSD for this shard (bytes)
+    ssd_bytes: int
+    # Total perf score for this shard; None if the perf model did not run
+    perf_total: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("hbm_bytes", "ddr_bytes", "ssd_bytes"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+        if self.perf_total is not None and self.perf_total < 0:
+            raise ValueError(f"perf_total must be non-negative, got {self.perf_total}")
+
+
+@dataclass(frozen=True)
+class ShardingOptionDetail:
+    """Per-table row of the chosen sharding plan with full cost detail.
+
+    Serializable projection of the ShardingOption selected for one embedding
+    table. Unlike the deployment-facing ShardingPlan (which keeps only
+    sharding_type/compute_kernel/ranks/shard geometry), this retains the
+    per-shard storage/perf estimates for OOM debugging and plan explainability,
+    while staying free of the live tensor/module references that make a raw
+    ShardingOption unserializable.
+    """
+
+    # Fully qualified name of the embedding table (module fqn + table name)
+    fqn: str
+    # Sharding type selected (e.g. "table_wise", "row_wise")
+    sharding_type: str
+    # Compute kernel selected (e.g. "fused", "dense")
+    compute_kernel: str
+    # Per-shard placement and cost breakdown
+    shards: Tuple[ShardDetail, ...] = ()
+    # HBM summed across shards (bytes)
+    total_hbm_bytes: int = 0
+    # DDR summed across shards (bytes)
+    total_ddr_bytes: int = 0
+    # SSD summed across shards (bytes)
+    total_ssd_bytes: int = 0
+    # Perf summed across shards; None unless every shard has a perf estimate, so
+    # the total is never a misleading partial sum
+    total_perf: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        for name in ("total_hbm_bytes", "total_ddr_bytes", "total_ssd_bytes"):
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+    @classmethod
+    def from_sharding_option(
+        cls, sharding_option: "ShardingOption"
+    ) -> "ShardingOptionDetail":
+        """Build a serializable detail row from a selected ShardingOption."""
+        shards = tuple(
+            ShardDetail(
+                rank=shard.rank,
+                size=tuple(shard.size),
+                offset=tuple(shard.offset),
+                hbm_bytes=shard.storage.hbm if shard.storage is not None else 0,
+                ddr_bytes=shard.storage.ddr if shard.storage is not None else 0,
+                ssd_bytes=shard.storage.ssd if shard.storage is not None else 0,
+                perf_total=shard.perf.total if shard.perf is not None else None,
+            )
+            for shard in sharding_option.shards
+        )
+        # Only aggregate perf when every shard has an estimate; otherwise a
+        # partial sum would understate the true cost while looking complete.
+        if shards and all(s.perf_total is not None for s in shards):
+            total_perf: Optional[float] = sum(
+                s.perf_total for s in shards if s.perf_total is not None
+            )
+        else:
+            total_perf = None
+        return cls(
+            fqn=sharding_option.fqn,
+            sharding_type=sharding_option.sharding_type,
+            compute_kernel=sharding_option.compute_kernel,
+            shards=shards,
+            total_hbm_bytes=sum(s.hbm_bytes for s in shards),
+            total_ddr_bytes=sum(s.ddr_bytes for s in shards),
+            total_ssd_bytes=sum(s.ssd_bytes for s in shards),
+            total_perf=total_perf,
+        )
+
+
+@dataclass(frozen=True)
+class ShardingPlanResult:
+    """Immutable result of sharding plan generation for a single topology.
+
+    Captures the outcome of running the planner, including the sharding
+    plan (when available), failure reason on error, and memory estimates.
+    Base type for both runtime and dry-run result types.
+    """
+
+    # GPU-SKU identifier this result is for (e.g. "H100", "GB200"); also the key
+    # in the API's per-target result map. Distinct from Request.launcher_hardware
+    # (launcher-type vocabulary like "ZIONEX"/"TC_ANY"), which stays on the request.
+    sku: str
+    # Whether the planner found a valid sharding plan
+    success: bool
+    # The computed plan — how tables are distributed across devices. None on
+    # failure, and may also be None on a successful result that carries only
+    # metadata (e.g. cached-miss or estimate-only results).
+    sharding_plan: Optional[ShardingPlan]
+    # Why the plan failed — surfaces root cause (e.g. "OOM_HBM")
+    planner_failure_reason: Optional[str]
+    # Peak per-rank HBM of the sharded-embedding footprint (bytes): the max over
+    # ranks of the summed embedding-shard HBM placed on that rank. This is the
+    # embedding footprint only — it excludes the dense/optimizer/runtime overhead
+    # that StorageReservation carves out of the budget before planning (the
+    # reservation shrinks the HBM available for embeddings but is not added back
+    # into this figure).
+    estimated_max_hbm_bytes: int
+    # Peak per-rank DDR of the sharded-embedding footprint (bytes); same
+    # embedding-only semantics as estimated_max_hbm_bytes.
+    estimated_max_ddr_bytes: int
+
+    # Estimated throughput from perf model; None if perf model unavailable
+    estimated_qps: Optional[float] = None
+    # Latency of slowest path through sharded model (ms); None if unavailable
+    critical_path_ms: Optional[float] = None
+    # Non-fatal warnings even when plan succeeds
+    validation_warnings: Tuple[str, ...] = ()
+    # URL of the sharding plan persisted to Manifold (for sharing/debugging);
+    # None if the plan was not uploaded
+    sharding_plan_manifold_url: Optional[str] = None
+    # Correlates this result with the ShardingPlanRequest.request_hash that
+    # produced it (by content); "" if not set
+    request_hash: str = ""
+    # Correlates this result with the ShardingPlanRequest.request_id that
+    # produced it (by instance); "" if not set. Use this to tie a result to a
+    # specific request object; use request_hash to correlate by content.
+    request_id: str = ""
+    # Time spent in the planner's solver for this result (ms); None if unavailable
+    solve_time_ms: Optional[float] = None
+    # Per-table breakdown of the chosen sharding plan with per-shard storage/perf
+    # detail (the "sharding option table"); empty if the planner did not surface
+    # per-table detail. A serializable projection of the selected ShardingOptions
+    # (see ShardingOptionDetail.from_sharding_option) that explains the aggregate
+    # estimated_max_*_bytes at table/shard granularity.
+    sharding_options: Tuple[ShardingOptionDetail, ...] = ()
+    # Whether this result carries the authoritative plan breakdown/estimates.
+    # On the collective path only the planning rank (rank 0) populates the
+    # per-shard breakdown; other ranks return success=True with the broadcast
+    # plan but empty sharding_options and zero estimates. This flag makes that
+    # asymmetry explicit so an aggregator can filter to the trustworthy result
+    # instead of reading corrupt estimates off a non-planning rank. Defaults to
+    # True: the local path (pg=None) and dry-run always plan on the caller's rank.
+    is_planning_rank: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.sku:
+            raise ValueError("sku must not be empty")
+        if self.estimated_max_hbm_bytes < 0:
+            raise ValueError(
+                f"estimated_max_hbm_bytes must be non-negative, "
+                f"got {self.estimated_max_hbm_bytes}"
+            )
+        if self.estimated_max_ddr_bytes < 0:
+            raise ValueError(
+                f"estimated_max_ddr_bytes must be non-negative, "
+                f"got {self.estimated_max_ddr_bytes}"
+            )
+        if self.estimated_qps is not None and self.estimated_qps < 0:
+            raise ValueError(
+                f"estimated_qps must be non-negative, got {self.estimated_qps}"
+            )
+        if self.critical_path_ms is not None and self.critical_path_ms < 0:
+            raise ValueError(
+                f"critical_path_ms must be non-negative, got {self.critical_path_ms}"
+            )
+        if self.solve_time_ms is not None and self.solve_time_ms < 0:
+            raise ValueError(
+                f"solve_time_ms must be non-negative, got {self.solve_time_ms}"
+            )
+        if self.success and self.planner_failure_reason is not None:
+            raise ValueError("planner_failure_reason must be None when success is True")
+        if not self.success and self.planner_failure_reason is None:
+            raise ValueError("planner_failure_reason is required when success is False")
+
+
 # ---- Types Utils ---- #
 def hash_sha256_to_int(hashable_list: List[Any]) -> int:
     """

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2450,6 +2450,62 @@ class ShardingPlanResult:
             raise ValueError("planner_failure_reason is required when success is False")
 
 
+@dataclass
+class PlannerSessionContext:
+    """Mutable context accumulating state during a planner session.
+
+    Links the ShardingPlanRequest being planned and the per-SKU
+    ShardingPlanResult(s) it produces, plus session-only scratch state
+    (caches, timing, metadata). Fields that already live on the request or
+    its results are intentionally not duplicated here — read them through
+    ``request``/``results`` (e.g. ``request.request_id``, ``request.model``,
+    ``results[sku].validation_warnings``). Unlike the frozen request/result
+    types, this dataclass is mutable to allow incremental updates during
+    execution.
+    """
+
+    # The request this session is planning for (required). Populated once by the
+    # planner API when it constructs the context, before planning begins: it is
+    # the input being planned and the source of truth for model, sharders,
+    # request_id/request_hash, constraints, launcher_hardware, etc. — read those
+    # through `request` rather than duplicating them on the context.
+    request: ShardingPlanRequest
+    # Per-SKU results produced this session, keyed by SKU (required; the planner
+    # API passes an empty dict at session start). Populated incrementally: one
+    # entry is added as each ShardingPlanResult is produced while iterating the
+    # request's SKUs. Each result carries its sharding plan, memory estimates,
+    # validation_warnings, manifold url, and request_id/request_hash back-reference.
+    results: Dict[str, ShardingPlanResult]
+    # Unique session identifier; defaults to a UUID4
+    session_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # Topology cache keyed by (sku, world_size, local_world_size) — one per SKU
+    topology_cache: Dict[Tuple[str, int, int], Topology] = field(default_factory=dict)
+    # Wall-clock timing for each session phase (e.g. "topology_creation", "solve").
+    # Session-level aggregate, not per-SKU.
+    timing: Dict[str, float] = field(default_factory=dict)
+    # Storage reservation strategy used per SKU
+    storage_reservations_used: Dict[str, StorageReservation] = field(
+        default_factory=dict
+    )
+    # Hardware overrides applied per SKU
+    hw_overrides_applied: Dict[str, HardwareConfig] = field(default_factory=dict)
+    # Plans retrieved from cache, keyed by request fingerprint (per request+SKU)
+    cached_plans: Dict[str, ShardingPlan] = field(default_factory=dict)
+    # Caller-provided session metadata (e.g. oncall, use_case, experiment_id)
+    client_metadata: Dict[str, str] = field(default_factory=dict)
+    # Whether each SKU's result came from cache — per SKU (SKU -> hit)
+    cache_hit: Dict[str, bool] = field(default_factory=dict)
+    # Source of resolved hardware-capability data per SKU (SKU -> source label,
+    # e.g. "static_registry", "live_detection", "mast", "psutil", "serf"). Kept a
+    # free-form string so it isn't restricted to a fixed set of detection
+    # mechanisms.
+    hw_source: Dict[str, str] = field(default_factory=dict)
+    # External trace / job identifier (e.g. the MAST Job ID) this planning session
+    # corresponds to. Links the request/session to the launching job for
+    # cross-system correlation. Session-level; None until associated with a job.
+    external_trace_id: Optional[str] = None
+
+
 # ---- Types Utils ---- #
 def hash_sha256_to_int(hashable_list: List[Any]) -> int:
     """


### PR DESCRIPTION
Summary:

Why this diff:
A dry-run sweep plans several SKUs, but build_topology applied the launching job's single local_world_size/pod_size to every one of them. That mis-models SKUs whose host layout differs -- most sharply GB200, which packs 2 GPUs per host across a 36-host NVLink domain, not 8 GPUs on one host. Wrong intra/inter-host boundaries mean wrong comms costs and wrong/infeasible plans, the host-layout companion to the per-rank-HBM mis-scaling that drives most TC_ANY dry-run failures.

Use cases:
- Dry-run sweep across a fungible pool (from the *_ANY expansion): each expanded SKU now builds a topology with its own GPUs-per-host and NVLink-domain size, so the previewed plan matches the machine the job would actually run on.

How it is addressed / what is added:
- Adds `_SKU_HOST_LAYOUT` + `host_layout_for_sku(sku) -> (gpus_per_host, pod_size_hosts)` in HUM, the offline analogue of what MAST reports at runtime (host_count_per_domain -> resolve_pod_size). gpus_per_host is the per-host NVLink boundary (local_world_size); pod_size_hosts is set only for multi-host NVLink domains (GB200 NVL72 = 36 hosts, GB300 NVL72 = 18), None for single-host SKUs (matching resolve_pod_size returning None for them). Unknown SKU -> (None, None).
- `FbPlannerProvider.build_topology` uses the per-SKU layout for a DryRunRequest: local_world_size <- gpus_per_host, pod_size <- pod_size_hosts when set, keeping the request values otherwise. world_size (total GPUs) is held fixed; a non-divisible world_size is logged. Production is unchanged -- MAST/Serf resolve the real layout at runtime.
- Chose a small explicit SKU->layout map over extending HardwareCapability: only a few SKUs deviate from 8/host, pod_size applies to even fewer, and the map mirrors runtime (pod_size only for NVL domains) without dataclass churn.

Reviewed By: mserturk

Differential Revision: D110919393
