### PR TITLE
(4/N)[MPZCH] Fresh-wins read path for the Main/Fresh region split

### DIFF
--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -563,6 +563,62 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         region_offset = main_size if is_fresh else 0
         return torch.full_like(local_sizes, region_size), offsets + region_offset
 
+    def _region_read(
+        self,
+        values: torch.Tensor,
+        local_sizes: torch.Tensor,
+        offsets: torch.Tensor,
+        is_fresh: bool,
+    ) -> torch.Tensor:
+        # Read-only probe confined to one (Main or Fresh) region window via
+        # local_sizes/offsets; write-side kernel args are unused, passed as
+        # neutral values.
+        region_sizes, region_offsets = self._region_window(
+            local_sizes, offsets, is_fresh=is_fresh
+        )
+        remapped_ids, _ = self._zero_collision_hash(
+            input=values,
+            identities=self._hash_zch_identities,
+            max_probe=self._max_probe,
+            circular_probe=True,
+            exp_hours=-1,  # deprecated, always -1
+            readonly=True,
+            local_sizes=region_sizes,
+            offsets=region_offsets,
+            metadata=None,
+            output_on_uvm=False,
+            disable_fallback=self._disable_fallback,
+            _modulo_identity_DPRECATED=False,  # deprecated, always False
+            input_metadata=None,
+            eviction_threshold=-1,
+            eviction_policy=0,
+            opt_in_prob=-1,
+            num_reserved_slots=-1,
+            opt_in_rands=None,
+            runtime_meta=None,
+        )
+        return remapped_ids
+
+    def _fresh_wins_read(
+        self,
+        values: torch.Tensor,
+        local_sizes: Optional[torch.Tensor],
+        offsets: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        # With Fresh empty every id misses, so this reduces to a Main-only read.
+        assert local_sizes is not None and offsets is not None
+        fresh_ids = self._region_read(values, local_sizes, offsets, is_fresh=True)
+        fresh_miss = fresh_ids == -1
+        main_ids = self._region_read(
+            values[fresh_miss],
+            local_sizes[fresh_miss],
+            offsets[fresh_miss],
+            is_fresh=False,
+        )
+        remapped_ids = fresh_ids.clone()
+        remapped_ids[fresh_miss] = main_ids
+        return remapped_ids
+
     # TODO: This is hacky as we are using parameters to go through publishing.
     # Can remove once working out buffer solution.
     def named_buffers(
@@ -744,36 +800,41 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     )
 
                 num_reserved_slots: int = self.get_reserved_slots_per_bucket()
-                remapped_ids, evictions = self._zero_collision_hash(
-                    input=values,
-                    identities=self._hash_zch_identities,
-                    max_probe=self._max_probe,
-                    circular_probe=True,
-                    exp_hours=-1,  # deprecated, always -1
-                    readonly=overwrite_readonly,
-                    local_sizes=local_sizes,
-                    offsets=offsets,
-                    metadata=overwrite_metadata,
-                    # Use self._is_inference to turn on writing to pinned
-                    # CPU memory directly. But may not have perf benefit.
-                    output_on_uvm=False,  # self._is_inference,
-                    disable_fallback=self._disable_fallback,
-                    _modulo_identity_DPRECATED=False,  # deprecated, always False
-                    input_metadata=input_metadata,
-                    eviction_threshold=eviction_threshold,
-                    eviction_policy=self.eviction_flag,
-                    opt_in_prob=self._opt_in_prob,
-                    num_reserved_slots=num_reserved_slots,
-                    opt_in_rands=opt_in_rands,
-                    # When we use _hash_zch_runtime_meta to save custom metadata, don't pass _hash_zch_runtime_meta to the kernel.
-                    # runtime_meta is managed externally via update_runtime_meta()
-                    # and should not be incremented by the kernel.
-                    runtime_meta=(
-                        None
-                        if self._write_runtime_meta_dim > 0
-                        else self._hash_zch_runtime_meta
-                    ),
-                )
+                if overwrite_readonly and self._percent_fresh_region > 0:
+                    # No eviction on the read path, so evictions is None.
+                    remapped_ids = self._fresh_wins_read(values, local_sizes, offsets)
+                    evictions = None
+                else:
+                    remapped_ids, evictions = self._zero_collision_hash(
+                        input=values,
+                        identities=self._hash_zch_identities,
+                        max_probe=self._max_probe,
+                        circular_probe=True,
+                        exp_hours=-1,  # deprecated, always -1
+                        readonly=overwrite_readonly,
+                        local_sizes=local_sizes,
+                        offsets=offsets,
+                        metadata=overwrite_metadata,
+                        # Use self._is_inference to turn on writing to pinned
+                        # CPU memory directly. But may not have perf benefit.
+                        output_on_uvm=False,  # self._is_inference,
+                        disable_fallback=self._disable_fallback,
+                        _modulo_identity_DPRECATED=False,  # deprecated, always False
+                        input_metadata=input_metadata,
+                        eviction_threshold=eviction_threshold,
+                        eviction_policy=self.eviction_flag,
+                        opt_in_prob=self._opt_in_prob,
+                        num_reserved_slots=num_reserved_slots,
+                        opt_in_rands=opt_in_rands,
+                        # When we use _hash_zch_runtime_meta to save custom metadata, don't pass _hash_zch_runtime_meta to the kernel.
+                        # runtime_meta is managed externally via update_runtime_meta()
+                        # and should not be incremented by the kernel.
+                        runtime_meta=(
+                            None
+                            if self._write_runtime_meta_dim > 0
+                            else self._hash_zch_runtime_meta
+                        ),
+                    )
                 # Zero out runtime_meta at evicted slots so it follows
                 # the same eviction behavior as the identity tensor.
                 if (

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -521,6 +521,12 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         assert (
             0 <= self._percent_fresh_region < 100
         ), f"percent_fresh_region must be in [0, 100), got {self._percent_fresh_region}"
+        assert (
+            self._disable_fallback
+        ), "percent_fresh_region requires disable_fallback=True; otherwise a full Main region falls back into the Fresh tail"
+        assert (
+            self._opt_in_prob == -1
+        ), "percent_fresh_region is incompatible with opt-in; opt_in_prob must be -1"
         unique = torch.unique(size_per_rank[self._start_bucket : self._end_bucket])
         assert (
             unique.numel() == 1

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -256,6 +256,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         write_runtime_meta_dim: int = 0,
         persist_hash_zch_bucket: bool = True,
         percent_fresh_region: float = 0,
+        write_to_fresh_region: bool = False,
     ) -> None:
         if output_segments is None:
             assert (
@@ -407,6 +408,11 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                 size_per_rank
             )
 
+        self._write_to_fresh_region: bool = write_to_fresh_region
+        assert not (
+            self._write_to_fresh_region and self._percent_fresh_region == 0
+        ), "write_to_fresh_region=True requires a Fresh region (percent_fresh_region != 0)"
+
         logger.info(
             f"HashZchManagedCollisionModule: {self._name=}, {self.device=}, "
             f"{self._zch_size=}, {self._input_hash_size=}, {self._max_probe=}, "
@@ -419,7 +425,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
             f"{self._no_bag=}, {self._write_runtime_meta_dim=}, "
             f"{self._persist_hash_zch_bucket=}, {self._percent_fresh_region=}, "
-            f"{self._main_size=}, {self._fresh_size=}"
+            f"{self._main_size=}, {self._fresh_size=}, {self._write_to_fresh_region=}"
         )
 
     def _create_zch_buffer(
@@ -541,6 +547,21 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"yields ({main_size}, {fresh_size}); both regions must be non-empty"
         )
         return main_size, fresh_size
+
+    def _region_window(
+        self,
+        local_sizes: Optional[torch.Tensor],
+        offsets: Optional[torch.Tensor],
+        is_fresh: bool,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Restrict placement to the target Main or Fresh region within each bucket.
+        main_size = self._main_size
+        fresh_size = self._fresh_size
+        assert main_size is not None and fresh_size is not None
+        assert local_sizes is not None and offsets is not None
+        region_size = fresh_size if is_fresh else main_size
+        region_offset = main_size if is_fresh else 0
+        return torch.full_like(local_sizes, region_size), offsets + region_offset
 
     # TODO: This is hacky as we are using parameters to go through publishing.
     # Can remove once working out buffer solution.
@@ -716,6 +737,12 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
                     output_offset=self._output_global_offset_tensor,
                 )
 
+                # Region-aware insert
+                if self._percent_fresh_region > 0 and not overwrite_readonly:
+                    local_sizes, offsets = self._region_window(
+                        local_sizes, offsets, is_fresh=self._write_to_fresh_region
+                    )
+
                 num_reserved_slots: int = self.get_reserved_slots_per_bucket()
                 remapped_ids, evictions = self._zero_collision_hash(
                     input=values,
@@ -881,6 +908,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             write_runtime_meta_dim=self._write_runtime_meta_dim,
             persist_hash_zch_bucket=self._persist_hash_zch_bucket,
             percent_fresh_region=self._percent_fresh_region,
+            write_to_fresh_region=self._write_to_fresh_region,
         )
 
     def lookup_runtime_meta(

--- a/torchrec/modules/hash_mc_modules.py
+++ b/torchrec/modules/hash_mc_modules.py
@@ -255,6 +255,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         no_bag: bool = False,
         write_runtime_meta_dim: int = 0,
         persist_hash_zch_bucket: bool = True,
+        percent_fresh_region: float = 0,
     ) -> None:
         if output_segments is None:
             assert (
@@ -398,6 +399,14 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
         self._enable_per_feature_lookups: bool = enable_per_feature_lookups
         self._no_bag = no_bag
 
+        self._percent_fresh_region: float = percent_fresh_region
+        self._main_size: Optional[int] = None
+        self._fresh_size: Optional[int] = None
+        if self._percent_fresh_region != 0:
+            self._main_size, self._fresh_size = self._compute_region_split(
+                size_per_rank
+            )
+
         logger.info(
             f"HashZchManagedCollisionModule: {self._name=}, {self.device=}, "
             f"{self._zch_size=}, {self._input_hash_size=}, {self._max_probe=}, "
@@ -409,7 +418,8 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             f"{self._opt_in_prob=}, {self._percent_reserved_slots=}, {self._disable_fallback=}, "
             f"{self._track_id_freq=}, {self._read_only_suffix=}, {self._enable_per_feature_lookups=}, "
             f"{self._no_bag=}, {self._write_runtime_meta_dim=}, "
-            f"{self._persist_hash_zch_bucket=}"
+            f"{self._persist_hash_zch_bucket=}, {self._percent_fresh_region=}, "
+            f"{self._main_size=}, {self._fresh_size=}"
         )
 
     def _create_zch_buffer(
@@ -506,6 +516,25 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
     def is_sharded(self) -> bool:
         # For sharded hash mc module, the buckets are split across multiple ranks.
         return (self._end_bucket - self._start_bucket) < self._buckets
+
+    def _compute_region_split(self, size_per_rank: torch.Tensor) -> Tuple[int, int]:
+        assert (
+            0 <= self._percent_fresh_region < 100
+        ), f"percent_fresh_region must be in [0, 100), got {self._percent_fresh_region}"
+        unique = torch.unique(size_per_rank[self._start_bucket : self._end_bucket])
+        assert (
+            unique.numel() == 1
+        ), "cannot split non-uniform buckets into main/fresh regions"
+        bucket_size = int(unique.item())
+        fresh_size = math.floor(bucket_size * self._percent_fresh_region / 100)
+        main_size = bucket_size - fresh_size
+        assert not (
+            self._percent_fresh_region > 0 and (fresh_size <= 0 or main_size <= 0)
+        ), (
+            f"percent_fresh_region={self._percent_fresh_region} with bucket_size={bucket_size} "
+            f"yields ({main_size}, {fresh_size}); both regions must be non-empty"
+        )
+        return main_size, fresh_size
 
     # TODO: This is hacky as we are using parameters to go through publishing.
     # Can remove once working out buffer solution.
@@ -845,6 +874,7 @@ class HashZchManagedCollisionModule(ManagedCollisionModule):
             no_bag=self._no_bag,
             write_runtime_meta_dim=self._write_runtime_meta_dim,
             persist_hash_zch_bucket=self._persist_hash_zch_bucket,
+            percent_fresh_region=self._percent_fresh_region,
         )
 
     def lookup_runtime_meta(

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2276,3 +2276,67 @@ class TestPersistHashZchBucket(unittest.TestCase):
         count = make_hash_zch_buckets_non_persistent(parent)
         self.assertGreaterEqual(count, 1)
         self.assertNotIn("child._hash_zch_bucket", parent.state_dict())
+
+
+class TestFreshRegionSplit(unittest.TestCase):
+    def _build(
+        self,
+        zch_size: int,
+        total_num_buckets: int,
+        percent_fresh_region: float,
+        output_segments: Optional[list[int]] = None,
+    ) -> HashZchManagedCollisionModule:
+        return HashZchManagedCollisionModule(
+            zch_size=zch_size,
+            device=torch.device("cpu"),
+            total_num_buckets=total_num_buckets,
+            percent_fresh_region=percent_fresh_region,
+            output_segments=output_segments,
+        )
+
+    def test_no_fresh_region_by_default(self) -> None:
+        m = self._build(1000, 2, 0)
+        self.assertIsNone(m._main_size)
+        self.assertIsNone(m._fresh_size)
+
+    def test_no_fresh_region_skips_validation(self) -> None:
+        # percent=0 skips the split, so an otherwise-rejected config (non-uniform
+        # buckets) still constructs — backward compatible for existing callers.
+        m = self._build(100, 3, 0, output_segments=[0, 34, 67, 100])
+        self.assertIsNone(m._main_size)
+        self.assertIsNone(m._fresh_size)
+
+    def test_region_sizes(self) -> None:
+        m = self._build(1000, 2, 20.0)  # bucket_size 500, 20% fresh
+        self.assertEqual(m._main_size, 400)
+        self.assertEqual(m._fresh_size, 100)
+
+    def test_split_floors_not_rounds(self) -> None:
+        m = self._build(10, 1, 39.0)  # bucket_size 10 -> 3.9 -> 3
+        self.assertEqual(m._main_size, 7)
+        self.assertEqual(m._fresh_size, 3)
+
+    def test_fractional_percent(self) -> None:
+        m = self._build(1000, 2, 12.5)  # bucket_size 500 -> 62.5 -> 62
+        self.assertEqual(m._main_size, 438)
+        self.assertEqual(m._fresh_size, 62)
+
+    def test_sharded_module_keeps_split(self) -> None:
+        shard = self._build(1000, 2, 20.0).rebuild_with_output_id_range((500, 1000))
+        self.assertEqual(shard._main_size, 400)
+        self.assertEqual(shard._fresh_size, 100)
+
+    def test_percent_out_of_range_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, -1.0)
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 100.0)
+
+    def test_percent_too_small_raises(self) -> None:
+        # 10% of a 4-slot bucket floors to 0 fresh slots.
+        with self.assertRaises(AssertionError):
+            self._build(4, 1, 10.0)
+
+    def test_non_uniform_buckets_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(100, 3, 20.0, output_segments=[0, 34, 67, 100])

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2287,15 +2287,18 @@ class TestFreshRegionSplit(unittest.TestCase):
         output_segments: Optional[list[int]] = None,
         disable_fallback: bool = True,
         opt_in_prob: int = -1,
+        write_to_fresh_region: bool = False,
+        device: str = "cpu",
     ) -> HashZchManagedCollisionModule:
         return HashZchManagedCollisionModule(
             zch_size=zch_size,
-            device=torch.device("cpu"),
+            device=torch.device(device),
             total_num_buckets=total_num_buckets,
             percent_fresh_region=percent_fresh_region,
             output_segments=output_segments,
             disable_fallback=disable_fallback,
             opt_in_prob=opt_in_prob,
+            write_to_fresh_region=write_to_fresh_region,
         )
 
     def test_no_fresh_region_by_default(self) -> None:
@@ -2352,3 +2355,152 @@ class TestFreshRegionSplit(unittest.TestCase):
     def test_rejects_opt_in(self) -> None:
         with self.assertRaises(AssertionError):
             self._build(1000, 2, 20.0, opt_in_prob=0)
+
+    def test_write_to_fresh_region_requires_percent_fresh_region(self) -> None:
+        # Can't target the Fresh region when there is no split.
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 0, write_to_fresh_region=True)
+
+    # bucket_size 500, main 400, fresh 100; sample per-id mapper output:
+    # two ids in buckets 0 and 1 -> local_sizes [500, 500], offsets [0, 500].
+    def test_region_window_main(self) -> None:
+        # Main: modulo -> main_size (400); base unchanged.
+        m = self._build(1000, 2, 20.0)
+        local_sizes, offsets = torch.tensor([500, 500]), torch.tensor([0, 500])
+        region_sizes, region_offsets = m._region_window(
+            local_sizes, offsets, is_fresh=False
+        )
+        self.assertTrue(torch.equal(region_sizes, torch.tensor([400, 400])))
+        self.assertTrue(torch.equal(region_offsets, torch.tensor([0, 500])))
+
+    def test_region_window_fresh(self) -> None:
+        # Fresh: modulo -> fresh_size (100); base += main_size (400).
+        m = self._build(1000, 2, 20.0)
+        local_sizes, offsets = torch.tensor([500, 500]), torch.tensor([0, 500])
+        region_sizes, region_offsets = m._region_window(
+            local_sizes, offsets, is_fresh=True
+        )
+        self.assertTrue(torch.equal(region_sizes, torch.tensor([100, 100])))
+        self.assertTrue(torch.equal(region_offsets, torch.tensor([400, 900])))
+
+    def test_region_window_asserts_without_region(self) -> None:
+        # Precondition: caller must gate on a configured region; without one the
+        # helper asserts rather than silently no-op'ing.
+        m = self._build(1000, 2, 0)  # no split configured
+        local_sizes, offsets = torch.tensor([500, 500]), torch.tensor([0, 500])
+        with self.assertRaises(AssertionError):
+            m._region_window(local_sizes, offsets, is_fresh=False)
+
+    def test_rebuild_preserves_write_to_fresh_region(self) -> None:
+        shard = self._build(
+            1000, 2, 20.0, write_to_fresh_region=True
+        ).rebuild_with_output_id_range((0, 500))
+        self.assertTrue(shard._write_to_fresh_region)
+
+    def _assert_remap_insert_region(self, write_to_fresh_region: bool) -> None:
+        # End-to-end insert through remap (input_mapper -> _region_window -> kernel):
+        # every assigned slot must land in the target region's within-bucket window.
+        zch_size, total_num_buckets, percent = 100, 2, 20.0
+        bucket_size = zch_size // total_num_buckets  # 50
+        main_size = 40  # bucket_size * (1 - percent/100)
+        # ids alternate buckets (x % num_buckets), so 8 ids -> 4 per bucket,
+        # comfortably under the tighter Fresh capacity (10/bucket) -> no misses.
+        num_ids = 8
+        m = self._build(
+            zch_size,
+            total_num_buckets,
+            percent,
+            write_to_fresh_region=write_to_fresh_region,
+            device="cuda",
+        )
+        values = torch.arange(0, num_ids, dtype=torch.int64, device="cuda")
+        out = m(
+            {
+                "f": JaggedTensor(
+                    values=values,
+                    lengths=torch.tensor([num_ids], dtype=torch.int64, device="cuda"),
+                )
+            }
+        )["f"].values()
+        self.assertFalse(bool(torch.any(out < 0)), f"unexpected insert misses: {out=}")
+        in_bucket = out % bucket_size
+        if write_to_fresh_region:
+            self.assertTrue(bool(torch.all(in_bucket >= main_size)), f"{in_bucket=}")
+        else:
+            self.assertTrue(bool(torch.all(in_bucket < main_size)), f"{in_bucket=}")
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_remap_insert_targets_main_region(self) -> None:
+        self._assert_remap_insert_region(write_to_fresh_region=False)
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_remap_insert_targets_fresh_region(self) -> None:
+        self._assert_remap_insert_region(write_to_fresh_region=True)
+
+    def _assert_full_region_does_not_spill(self, write_to_fresh_region: bool) -> None:
+        # Saturate the target region in EVERY bucket, then overflow each by one id.
+        # Circular probing must wrap WITHIN each bucket's region (filling all its
+        # slots); the overflow ids must NOT spill into the other region. With
+        # disable_fallback a miss is dropped from the output (not returned as -1),
+        # so a confined carve yields exactly region_size outputs per bucket, all
+        # inside the region; a leak would place an overflow in the neighbor region.
+        zch_size, total_num_buckets, percent = 20, 2, 20.0
+        bucket_size = zch_size // total_num_buckets  # 10
+        main_size, fresh_size = 8, 2
+        region_size = fresh_size if write_to_fresh_region else main_size
+        in_bucket_lo = main_size if write_to_fresh_region else 0
+        in_bucket_hi = bucket_size if write_to_fresh_region else main_size
+        m = self._build(
+            zch_size,
+            total_num_buckets,
+            percent,
+            write_to_fresh_region=write_to_fresh_region,
+            device="cuda",
+        )
+        # ids alternate buckets (x % num_buckets), so arange(0, 2*(region_size+1))
+        # puts region_size+1 ids in each bucket: region_size fill it, one overflows.
+        num_ids = total_num_buckets * (region_size + 1)
+        values = torch.arange(0, num_ids, dtype=torch.int64, device="cuda")
+        out = m(
+            {
+                "f": JaggedTensor(
+                    values=values,
+                    lengths=torch.tensor([num_ids], dtype=torch.int64, device="cuda"),
+                )
+            }
+        )["f"].values()
+        # Exactly region_size placed per bucket (overflows dropped, not spilled),
+        # all distinct and inside the region -> each bucket's region fully covered.
+        in_bucket = out % bucket_size
+        self.assertEqual(int(out.numel()), total_num_buckets * region_size, f"{out=}")
+        self.assertEqual(
+            int(torch.unique(out).numel()), total_num_buckets * region_size, f"{out=}"
+        )
+        self.assertTrue(
+            bool(torch.all((in_bucket >= in_bucket_lo) & (in_bucket < in_bucket_hi))),
+            f"{out=}",
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_full_main_region_does_not_spill_into_fresh(self) -> None:
+        self._assert_full_region_does_not_spill(write_to_fresh_region=False)
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_full_fresh_region_does_not_spill_into_main(self) -> None:
+        self._assert_full_region_does_not_spill(write_to_fresh_region=True)

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2504,3 +2504,153 @@ class TestFreshRegionSplit(unittest.TestCase):
     )
     def test_full_fresh_region_does_not_spill_into_main(self) -> None:
         self._assert_full_region_does_not_spill(write_to_fresh_region=True)
+
+    # ----- Fresh-wins read path -----
+    def test_fresh_wins_read_prefers_fresh_over_main(self) -> None:
+        # _region_read maps each id to a SLOT, or -1 on a miss.
+        # Mock it so the 1st call is the Fresh probe and the 2nd is the Main probe.
+        m = self._build(20, 2, 20.0)
+        ids = torch.tensor([10001, 10002, 10003, 10004], dtype=torch.int64)
+        # Placeholders: the mock ignores sizes/offsets, only their length matters.
+        sizes = torch.full((4,), 10, dtype=torch.int64)
+        offsets = torch.zeros(4, dtype=torch.int64)
+        with patch.object(
+            m,
+            "_region_read",
+            side_effect=[
+                # Fresh: 10001->slot 8, 10003->slot 9; 10002 and 10004 miss.
+                torch.tensor([8, -1, 9, -1], dtype=torch.int64),
+                # Main (only the two misses): 10002->slot 2, 10004->slot 4.
+                torch.tensor([2, 4], dtype=torch.int64),
+            ],
+        ) as region_read:
+            out = m._fresh_wins_read(ids, sizes, offsets)
+        # Fresh wins where it hit (slots 1, 2); Main fills the misses (slots 3, 4).
+        self.assertTrue(
+            torch.equal(out, torch.tensor([8, 2, 9, 4], dtype=torch.int64)), f"{out=}"
+        )
+        # Main was probed with only the two ids that missed Fresh.
+        _, main_call = region_read.call_args_list
+        self.assertTrue(
+            torch.equal(
+                main_call.args[0], torch.tensor([10002, 10004], dtype=torch.int64)
+            ),
+            f"{main_call=}",
+        )
+
+    def _assert_remap_dispatch(
+        self, feature_name: str, expect_fresh_wins: bool
+    ) -> None:
+        # Read-only region enabled requests routes remap() to _fresh_wins_read;
+        # any other feature uses the insert kernel. Both are
+        # mocked so the test asserts which branch ran, not its result.
+        m = self._build(20, 2, 20.0)
+        values = torch.tensor([1, 2], dtype=torch.int64)
+        lengths = torch.tensor([1, 1], dtype=torch.int64)
+        remapped = torch.tensor([0, 1], dtype=torch.int64)
+        with patch.object(m, "_fresh_wins_read", return_value=remapped) as fresh_wins:
+            with patch.object(
+                m, "_zero_collision_hash", return_value=(remapped, None)
+            ) as kernel:
+                m.remap({feature_name: JaggedTensor(values=values, lengths=lengths)})
+        if expect_fresh_wins:
+            fresh_wins.assert_called_once()
+            kernel.assert_not_called()
+        else:
+            fresh_wins.assert_not_called()
+            kernel.assert_called_once()
+
+    def test_remap_read_dispatches_to_fresh_wins(self) -> None:
+        self._assert_remap_dispatch("f_readonly", expect_fresh_wins=True)
+
+    def test_remap_write_does_not_use_fresh_wins(self) -> None:
+        self._assert_remap_dispatch("f", expect_fresh_wins=False)
+
+    def _assert_readonly_region(
+        self,
+        values: torch.Tensor,
+        write_main: bool,
+        write_fresh: bool,
+        expect_fresh: bool,
+    ) -> None:
+        # E2E via the real kernel: populate the region(s), then assert each id
+        # resolves into its expected window (Fresh slots >= main_size, else Main).
+        zch_size, total_num_buckets, percent = 100, 2, 20.0
+        bucket_size = zch_size // total_num_buckets
+        main_size = 40
+        m = self._build(zch_size, total_num_buckets, percent, device="cuda")
+        if write_main:
+            m._write_to_fresh_region = False
+            m.remap(
+                {
+                    "f": JaggedTensor(
+                        values=values,
+                        lengths=torch.tensor(
+                            [values.numel()], dtype=torch.int64, device=values.device
+                        ),
+                    )
+                }
+            )
+        if write_fresh:
+            m._write_to_fresh_region = True
+            m.remap(
+                {
+                    "f": JaggedTensor(
+                        values=values,
+                        lengths=torch.tensor(
+                            [values.numel()], dtype=torch.int64, device=values.device
+                        ),
+                    )
+                }
+            )
+        out = m.remap(
+            {
+                "f_readonly": JaggedTensor(
+                    values=values,
+                    lengths=torch.tensor(
+                        [values.numel()], dtype=torch.int64, device=values.device
+                    ),
+                )
+            }
+        )["f_readonly"].values()
+        self.assertEqual(int(out.numel()), int(values.numel()), f"{out=}")
+        slot_in_bucket = out % bucket_size
+        if expect_fresh:
+            self.assertTrue(
+                bool(torch.all(slot_in_bucket >= main_size)),
+                f"expected Fresh slots: {out=}",
+            )
+        else:
+            self.assertTrue(
+                bool(torch.all(slot_in_bucket < main_size)),
+                f"expected Main slots: {out=}",
+            )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_fresh_wins_read_returns_fresh_slot(self) -> None:
+        # An id written to BOTH regions resolves to its Fresh slot.
+        self._assert_readonly_region(
+            torch.tensor([0, 1], dtype=torch.int64, device="cuda"),
+            write_main=True,
+            write_fresh=True,
+            expect_fresh=True,
+        )
+
+    # pyre-ignore[56]
+    @unittest.skipIf(
+        torch.cuda.device_count() < 1,
+        "This test requires at least one GPU",
+    )
+    def test_fresh_wins_read_falls_back_to_main_on_fresh_miss(self) -> None:
+        # An id present only in Main is resolved from Main; with Fresh empty this
+        # is also the Phase-1 "every read is Main-only" (zero serving change) path.
+        self._assert_readonly_region(
+            torch.tensor([0, 1], dtype=torch.int64, device="cuda"),
+            write_main=True,
+            write_fresh=False,
+            expect_fresh=False,
+        )

--- a/torchrec/modules/tests/test_hash_mc_modules.py
+++ b/torchrec/modules/tests/test_hash_mc_modules.py
@@ -2285,6 +2285,8 @@ class TestFreshRegionSplit(unittest.TestCase):
         total_num_buckets: int,
         percent_fresh_region: float,
         output_segments: Optional[list[int]] = None,
+        disable_fallback: bool = True,
+        opt_in_prob: int = -1,
     ) -> HashZchManagedCollisionModule:
         return HashZchManagedCollisionModule(
             zch_size=zch_size,
@@ -2292,6 +2294,8 @@ class TestFreshRegionSplit(unittest.TestCase):
             total_num_buckets=total_num_buckets,
             percent_fresh_region=percent_fresh_region,
             output_segments=output_segments,
+            disable_fallback=disable_fallback,
+            opt_in_prob=opt_in_prob,
         )
 
     def test_no_fresh_region_by_default(self) -> None:
@@ -2340,3 +2344,11 @@ class TestFreshRegionSplit(unittest.TestCase):
     def test_non_uniform_buckets_raises(self) -> None:
         with self.assertRaises(AssertionError):
             self._build(100, 3, 20.0, output_segments=[0, 34, 67, 100])
+
+    def test_requires_disable_fallback(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 20.0, disable_fallback=False)
+
+    def test_rejects_opt_in(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._build(1000, 2, 20.0, opt_in_prob=0)


### PR DESCRIPTION
Summary:
Make the eval/serving read path region-aware for MPZCH tables that carve a Fresh region (`percent_fresh_region > 0`). Today the region window is applied only on the insert path (gated on `not overwrite_readonly`), so a read-only `remap()` probes the whole bucket with no Main-vs-Fresh priority. This diff adds a "fresh-wins" read: resolve each id against the Fresh region first, then probe Main ONLY for the ids that miss Fresh, so a fresh-hit is never looked up in Main.

Implemented as two helpers on `HashZchManagedCollisionModule`:
- `_region_read`: a single read-only probe confined to one region via the existing `_region_window` (the write-side kernel args are unused on a read and passed as neutral values).
- `_fresh_wins_read`: probes Fresh for all ids, then probes Main for `values[fresh_miss]` only, and scatters the Main results back so Fresh wins where both hit.

`remap()` dispatches inline on a region-aware read (`overwrite_readonly and percent_fresh_region > 0`) to `_fresh_wins_read` (no eviction on the read path, so `evictions` is `None`); otherwise it takes the original single `zero_collision_hash` call, unchanged.

Behavior is unchanged for non-region models (`percent_fresh_region == 0`) and for the write path. While the Fresh region is empty (Phase 1) every id misses Fresh, so the read reduces to a Main-only read identical to prior behavior — zero serving risk — while making the module region-aware and ready for the streaming phase.

Stacked on D112042625 (`write_to_fresh_region`).

Differential Revision: D112223250


