### PR TITLE
Add res_enabled_tables allowlist to scope RES streaming per-table (#4458)

### DIFF
--- a/torchrec/distributed/batched_embedding_kernel.py
+++ b/torchrec/distributed/batched_embedding_kernel.py
@@ -219,6 +219,7 @@ def _populate_res_params(config: GroupedEmbeddingConfig) -> Tuple[bool, RESParam
     ):
         return (False, res_params)
     res_params.table_names = [table.name for table in config.embedding_tables]
+    res_params.res_enabled_tables = res_enabled_tables or []
     if res_enabled_tables is not None and len(res_enabled_tables) != 0:
         if len(set(res_enabled_tables) & set(res_params.table_names)) == 0:
             logger.info(


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/6051


X-link: https://github.com/facebookresearch/FBGEMM/pull/2951

Adds a res_enabled_tables allowlist for per-table scoping of Raw Embedding Streaming (empty list = all tables). Previously RES only gated per-TBE - a TBE containing any enabled table streamed all of its tables; now only the listed tables stream. The subsequent HBM diffs relies on this to avoid streaming DEVICE tables that were not requested.

Reviewed By: chouxi

Differential Revision: D113301886


