### PR TITLE
Add preserving stride per key per rank to KJT.from_jt

### DIFF
--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -2271,7 +2271,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         return self
 
     @staticmethod
-    def from_jt_dict(jt_dict: Dict[str, JaggedTensor]) -> "KeyedJaggedTensor":
+    def from_jt_dict(
+        jt_dict: Dict[str, JaggedTensor], force_variable_stride: bool = False
+    ) -> "KeyedJaggedTensor":
         """
         Constructs a KeyedJaggedTensor from a dictionary of JaggedTensors.
         Automatically calls `kjt.sync()` on newly created KJT.
@@ -2313,6 +2315,9 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
 
         Args:
             jt_dict (Dict[str, JaggedTensor]): dictionary of JaggedTensors.
+            force_variable_stride: bool: If true, always builds the KJT with an
+                explicit per-key stride instead of collapsing to a single uniform
+                stride when all per-key strides are equal. Defaults to False.
 
         Returns:
             KeyedJaggedTensor: constructed KeyedJaggedTensor.
@@ -2337,7 +2342,13 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
         kjt_stride, kjt_stride_per_key_per_rank = (
             (stride_per_key[0], None)
             if all(s == stride_per_key[0] for s in stride_per_key)
-            else (None, torch.IntTensor(stride_per_key, device="cpu").reshape(-1, 1))
+            and not force_variable_stride
+            else (
+                None,
+                torch.tensor(stride_per_key, dtype=torch.int32, device="cpu").reshape(
+                    -1, 1
+                ),
+            )
         )
         kjt = KeyedJaggedTensor(
             keys=kjt_keys,

--- a/torchrec/sparse/tests/test_jagged_tensor.py
+++ b/torchrec/sparse/tests/test_jagged_tensor.py
@@ -886,7 +886,7 @@ class TestJaggedTensor(unittest.TestCase):
             atol=0,
         )
 
-    def test_from_jt_dict_vb(self) -> None:
+    def test_from_jt_dict_vbe(self) -> None:
         values = torch.Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
         weights = torch.Tensor([1.0, 0.5, 1.5, 1.0, 0.5, 1.0, 1.0, 1.5])
         keys = ["index_0", "index_1"]
@@ -928,6 +928,49 @@ class TestJaggedTensor(unittest.TestCase):
         torch.testing.assert_close(
             j1.values(),
             torch.Tensor([3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+            rtol=0,
+            atol=0,
+        )
+
+        # Test the case when stride per key per rank is the same
+        values = torch.Tensor(
+            [
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                5.0,
+            ]
+        )
+        weights = torch.Tensor(
+            [
+                1.0,
+                0.5,
+                1.5,
+                1.0,
+                0.5,
+            ]
+        )
+        keys = ["index_0", "index_1"]
+        offsets = torch.IntTensor([0, 2, 3, 4, 5])
+        stride_per_key_per_rank = [[2], [2]]
+        jag_tensor = KeyedJaggedTensor(
+            values=values,
+            keys=keys,
+            offsets=offsets,
+            weights=weights,
+            stride_per_key_per_rank=stride_per_key_per_rank,
+        )
+        jag_tensor_dict = jag_tensor.to_dict()
+        kjt = KeyedJaggedTensor.from_jt_dict(jag_tensor_dict)
+        self.assertIsNone(kjt._stride_per_key_per_rank)
+        kjt = KeyedJaggedTensor.from_jt_dict(
+            jag_tensor_dict, force_variable_stride=True
+        )
+        self.assertIsNotNone(kjt._stride_per_key_per_rank)
+        torch.testing.assert_close(
+            kjt._stride_per_key_per_rank,
+            torch.IntTensor([[2], [2]]),
             rtol=0,
             atol=0,
         )


### PR DESCRIPTION
Summary:
Context
---------

The job f1115250146 fails with a  `shape '[128, 0]' is invalid for input of size 1` during KJT.dist_init. This occurs only with VBE, due to mismatch between the size of stride_per_key_per_rank and the number of keys/ranks. This is evident in the [logs](https://fburl.com/mlhub/jkc3zzje), where the stride per key per rank collapses for some ranks and not others, so when All2All happens, there becomes a mismatch.

Implementation
-----------------

- added a boolean variable `force_variable_stride` that forces the stride per key per rank to always be set based on the lengths. This needs to be turned on.
- changed FI to force the stride per key per rank.

NOTE: this implementation forces Feature Importance to always have VBE on.

Differential Revision: D113285377


