### PR TITLE
Add `skip_batch_waiting` option to skip `_wait_for_batch()` in customized-order sparse-dist train pipeline (#4460)

### DIFF
--- a/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/tests/test_train_pipelines.py
@@ -1076,6 +1076,20 @@ class TrainPipelineSparseDist2DShardingTest(unittest.TestCase):
         dmp.assert_called_once()
         dmp.sync.assert_called_once()
 
+    def test_skip_batch_waiting_flag_stored(self) -> None:
+        dmp = MagicMock(spec=DMPCollection)
+        optimizer = MagicMock(spec=torch.optim.Optimizer)
+        device = torch.device("cpu")
+
+        self.assertFalse(
+            TrainPipelineSparseDist(dmp, optimizer, device=device)._skip_batch_waiting
+        )
+        self.assertTrue(
+            TrainPipelineSparseDist(
+                dmp, optimizer, device=device, skip_batch_waiting=True
+            )._skip_batch_waiting
+        )
+
     def test_sync_disabled_if_dmp_collection_is_not_used(self) -> None:
         dmp = MagicMock(spec=DistributedModelParallel)
         dmp.training = True

--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -583,6 +583,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         enable_inplace_copy_batch: bool = False,
         free_features_storage_early: bool = False,
         clear_data_dist_inputs: bool = False,
+        skip_batch_waiting: bool = False,
     ) -> None:
         self._model = model
         self._optimizer = optimizer
@@ -595,6 +596,7 @@ class TrainPipelineSparseDist(TrainPipeline[In, Out]):
         self._batch_count = 0
         self._inplace_copy_batch_size_logged = False
         self._clear_data_dist_inputs = clear_data_dist_inputs
+        self._skip_batch_waiting = skip_batch_waiting
 
         logger.info(
             f"enqueue_batch_after_forward: {self._enqueue_batch_after_forward} "


### PR DESCRIPTION
Summary:

example cuda event record observed with signifcant increasing of input batch tensors takes up to 200+ms, e.g. in IG CTR v0

{F1992558184}



as a solution, this diff adds a `skip_batch_waiting` boolean training config (default `False`) that lets the customized-order sparse-dist train pipeline skip the `_wait_for_batch()` cross-stream sync at the start of each `progress()` step.

`_wait_for_batch()` makes the compute stream wait on the data-dist (or prefetch) stream so `batches[0]` is guaranteed ready on device before the forward pass reads it. In steady state this wait is expected to already be satisfied, since the `input_dist()` of `batches[0]` was issued in the previous iteration, so skipping it removes a redundant stream sync and its bubble. The flag defaults to `False` to preserve current behavior; enable it only where `batches[0]` readiness is otherwise guaranteed, since removing the barrier turns any unmet assumption into a silent cross-stream data race.

Plumbing:
- `apf/rec/config_def.py`: new `skip_batch_waiting: bool = False` field on `RecTrainingConfig`.
- `torchrec/distributed/train_pipeline/train_pipelines.py`: `TrainPipelineSparseDist.__init__` accepts and stores `self._skip_batch_waiting`.
- `aps_models/ads/common/train_pipeline.py`: threads the flag through `TrainPipelineCustomizedOrderSparseDist` and `MBTrainPipelineCustomizedOrderSparseDist`, and gates the `_wait_for_batch()` call in `TrainPipelineCustomizedOrderSparseDist.progress()`. This is the only pipeline family whose `progress()` currently honors the flag.
- `apf/rec/distributed/train_pipeline.py`: reads the config, and rejects the unsupported combination by raising `APFException` (`APFErrorCategory.CONFIG`) when `skip_batch_waiting` is set without `enable_inplace_copy_batch`, then forwards it when building the sparse-dist pipeline.
- BUCK: migrate the torch dependency from `//caffe2:_torch` to `fbsource//third-party/pypi/torch:torch` in the two affected targets.

Reviewed By: TroyGarden

Differential Revision: D112454086


