### PR TITLE
Reset Default Batch Size to 32768

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_train_pipeline.py
+++ b/torchrec/distributed/benchmark/benchmark_train_pipeline.py
@@ -119,7 +119,7 @@ class RunOptions(BenchFuncConfig):
     """
 
     world_size: int = 2
-    batch_size: int = 1024 * 16
+    batch_size: int = 1024 * 32
     num_batches: int = 10
     num_benchmarks: int = 5
     num_profiles: int = 2

--- a/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
+++ b/torchrec/distributed/benchmark/yaml/sparse_data_dist_mpzch.yml
@@ -6,6 +6,7 @@ RunOptions:
   world_size: 2
   num_batches: 20
   num_benchmarks: 5
+  batch_size: 16384
   num_profiles: 1
   profile_dir: "."
   name: "sparse_data_dist_mpzch"
@@ -49,7 +50,7 @@ EmbeddingTablesConfig:
         data_type: FP16
         mc_config:
           mc_type: "mp-zch"
-          total_num_buckets: 5
+          total_num_buckets: 8
           max_probe: 128
           input_hash_size: 0
           eviction_policy_name: "SINGLE_TTL_EVICTION"


### PR DESCRIPTION
Summary: Update the default batch_size for pipeline benchmark

Reviewed By: Ali-Tehrani, amirafzali

Differential Revision: D113568471


