### PR TITLE
Fix pyrefly type errors at torch.distributed collective call sites

### DIFF
--- a/examples/bert4rec/bert4rec_main.py
+++ b/examples/bert4rec/bert4rec_main.py
@@ -14,7 +14,7 @@
 import argparse
 import os
 import sys
-from typing import Any, cast, Dict, List, Union
+from typing import Any, cast, Dict, List, Optional, Union
 
 import numpy as np
 import torch
@@ -277,7 +277,7 @@ def _train_one_epoch(
     loss_logs = []
     train_iterator = iter(train_loader)
     ce = nn.CrossEntropyLoss(ignore_index=0)
-    outputs = [None for _ in range(dist.get_world_size())]
+    outputs: List[Optional[float]] = [None for _ in range(dist.get_world_size())]
     for _ in tqdm(iter(int, 1), desc=f"Epoch {epoch+1}"):
         try:
             batch = next(train_iterator)
@@ -335,7 +335,9 @@ def _validate(
     model.eval()
     if torch.cuda.is_available():
         torch.cuda.set_device(dist.get_rank())
-    outputs = [None for _ in range(dist.get_world_size())]
+    outputs: List[Optional[Dict[str, float]]] = [
+        None for _ in range(dist.get_world_size())
+    ]
     keys = ["Recall@1", "Recall@5", "Recall@10", "NDCG@5", "NDCG@10"]
     metrics_log: Dict[str, List[float]] = {key: [] for key in keys}
 

--- a/torchrec/distributed/collective_utils.py
+++ b/torchrec/distributed/collective_utils.py
@@ -59,6 +59,7 @@ def invoke_on_rank_and_broadcast_result(
 
         id = invoke_on_rank_and_broadcast_result(pg, 0, allocate_id)
     """
+    object_list: List[Optional[T]]
     if pg.rank() == rank:
         res = func(*args, **kwargs)
         object_list = [res]

--- a/torchrec/distributed/sharded_relay_utils.py
+++ b/torchrec/distributed/sharded_relay_utils.py
@@ -493,7 +493,7 @@ def allreduce_tensors_with_sharded_relay(
     state: ShardedRelayState,
     tensors_dict: dict[torch.dtype, list[torch.Tensor]],
     annotation: str,
-    op: dist.ReduceOp = dist.ReduceOp.AVG,
+    op: dist.ReduceOp | dist.ReduceOp.RedOpType = dist.ReduceOp.AVG,
 ) -> None:
     """
     Perform allreduce using the fused sharded relay algorithm.

--- a/torchrec/distributed/tests/test_mc_embedding.py
+++ b/torchrec/distributed/tests/test_mc_embedding.py
@@ -526,7 +526,7 @@ def _test_sharding_and_resharding(  # noqa C901
             if isinstance(tensor, ShardedTensor):
                 tensor = tensor.local_shards()[0].tensor
             cpu_state_dict[key] = tensor.to("cpu")
-        gather_list = [None, None] if ctx.rank == 0 else None
+        gather_list: Optional[List[Any]] = [None, None] if ctx.rank == 0 else None
         torch.distributed.gather_object(cpu_state_dict, gather_list)
 
     if rank == 0:

--- a/torchrec/inference/state_dict_transform.py
+++ b/torchrec/inference/state_dict_transform.py
@@ -7,7 +7,7 @@
 
 # pyre-strict
 
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 from torch import distributed as dist
@@ -51,7 +51,7 @@ def state_dict_all_gather_keys(
         pg (ProcessGroup): Process Group used for comms
     """
     names = list(state_dict.keys())
-    all_names = [None] * dist.get_world_size(pg)
+    all_names: List[Optional[List[str]]] = [None] * dist.get_world_size(pg)
     dist.all_gather_object(all_names, names, pg)
     deduped_names = set()
     for local_names in all_names:

--- a/torchrec/metrics/metric_module.py
+++ b/torchrec/metrics/metric_module.py
@@ -248,6 +248,7 @@ class RecMetricModule(nn.Module):
     oom_count: int
     compute_count: int
     last_compute_time: float
+    _compute_interval_steps: torch.Tensor
 
     # TODO(chienchin): Reorganize the argument to directly accept a MetricsConfig.
     def __init__(
@@ -378,7 +379,6 @@ class RecMetricModule(nn.Module):
                     # is set to infinite, adding 1.0 to the `min_compute_interval`
                     # increase the chance that the final compute interval is
                     # indeed larger than `min_compute_interval`.
-                    # pyrefly: ignore[unsupported-operation]
                     self._compute_interval_steps[0] = int(
                         (self.min_compute_interval + 1.0) / per_step_time
                     )
@@ -388,19 +388,16 @@ class RecMetricModule(nn.Module):
                     # can increase the chance that the final compute interval
                     # is indeed smaller than `max_compute_interval`
                     offset = 0.0 if self.max_compute_interval <= 1.0 else 1.0
-                    # pyrefly: ignore[unsupported-operation]
                     self._compute_interval_steps[0] = int(
                         (self.max_compute_interval - offset) / per_step_time
                     )
                 else:
-                    # pyrefly: ignore[unsupported-operation]
                     self._compute_interval_steps[0] = int(
                         (self.max_compute_interval + self.min_compute_interval)
                         / 2
                         / per_step_time
                     )
                 dist.all_reduce(self._compute_interval_steps, op=dist.ReduceOp.MAX)
-            # pyrefly: ignore[not-callable]
             self.compute_interval_steps = int(self._compute_interval_steps.item())
             self.min_compute_interval = -1.0
             self.max_compute_interval = -1.0
@@ -469,7 +466,7 @@ class RecMetricModule(nn.Module):
         self,
         metric: RecMetric,
         world_size: int,
-        process_group: Union[dist.ProcessGroup, DeviceMesh],
+        process_group: dist.ProcessGroup,
     ) -> Dict[str, Dict[str, Union[torch.Tensor, List[torch.Tensor]]]]:
         """
         Gather metric states from all ranks and apply reduction.
@@ -768,7 +765,7 @@ def generate_metric_module(
 def _all_gather_tensor(
     tensor: torch.Tensor,
     world_size: int,
-    pg: Union[dist.ProcessGroup, DeviceMesh],
+    pg: dist.ProcessGroup,
 ) -> List[torch.Tensor]:
     """All-gather a single tensor and return the gathered list."""
     out = [torch.empty_like(tensor) for _ in range(world_size)]  # pragma: no cover


### PR DESCRIPTION
Summary:
Recent tightening of the `torch.distributed` type stubs made the collective
helpers (`gather_object`, `all_gather_object`, `broadcast_object_list`,
`all_gather`, `all_reduce`) stricter, surfacing pyrefly errors across several
TorchRec `-type-checking` targets. This fixes them without adding any
`pyre-ignore` / `pyrefly: ignore` suppressions:

- `collective_utils.py`: annotate `object_list` as `List[Optional[T]]` so
  `broadcast_object_list` sees one homogeneous element type instead of
  `list[T] | list[None]`.
- `distributed/tests/test_mc_embedding.py` and
  `fb/distributed/tests/test_mc_embedding.py`: annotate the `gather_object`
  output placeholder list as `Optional[List[Any]]`.
- `bert4rec_main.py`: annotate the `all_gather_object` output lists as
  `List[Optional[float]]` / `List[Optional[Dict[str, float]]]` so the gathered
  `obj` type is no longer inferred as `None`.
- `state_dict_transform.py`: annotate the `all_gather_object` output list as
  `List[Optional[List[str]]]`.
- `test_embeddingtower.py`: `assert sharded_pred is not None` after the training
  loop so `all_gather` / `empty_like` see a `Tensor` (this replaces an existing
  `bad-argument-type` suppression).
- `sharded_relay_utils.py`: broaden `allreduce_tensors_with_sharded_relay`'s
  `op` parameter to `dist.ReduceOp | dist.ReduceOp.RedOpType`, matching the union
  torch accepts and the type of `AllreduceCoalescedOptions.reduceOp`.
- `metric_module.py`: declare the `_compute_interval_steps` buffer's type at
  class level (`_compute_interval_steps: torch.Tensor`) so it is no longer
  inferred as `Module | Tensor`; this fixes the `all_reduce` call and lets
  several nearby `unsupported-operation` / `not-callable` suppressions be
  removed. Also narrow the process-group params of `_get_metric_states` and
  `_all_gather_tensor` to `dist.ProcessGroup` (callers already resolve
  `DeviceMesh` via `get_group`).

Differential Revision: D113765682


