### PR TITLE
Wire SKU_AWARE storage reservation into FbPlannerProvider (#4468)

### DIFF
--- a/torchrec/distributed/planner/dry_run/cli.py
+++ b/torchrec/distributed/planner/dry_run/cli.py
@@ -74,7 +74,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--storage-reservation-policy",
-        choices=["heuristical", "fixed_percentage", "inference"],
+        choices=["heuristical", "fixed_percentage", "inference", "sku_aware"],
         default=None,
     )
     parser.add_argument("--storage-reservation-percentage", type=float, default=None)

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2163,6 +2163,13 @@ class PlannerConfig:
     # LINEAR_PROGRAMMING scalar knobs; None = LP planner defaults. Consumed only by
     # the LP variant's fb builder (ignored by other variants).
     lp_config: Optional[LpPlannerConfig] = None
+    # Explicit per-model non-sharded footprint in bytes for the SKU_AWARE policy;
+    # when set it replaces the home-anchored margin + computed dense with this
+    # measured static base. None (default) keeps the migration proxy. Consumed only
+    # by the SKU_AWARE reservation (mirrors the legacy APF planner-config field);
+    # ignored by every other policy. (Appended last to preserve positional
+    # construction of the pre-existing fields.)
+    model_base_bytes: Optional[int] = None
 
     def __post_init__(self) -> None:
         # proposer_type (OSS scalar selector) and proposer_config (structured form)


### PR DESCRIPTION
Summary:

Fills the `SKU_AWARE` slot in the unified planner API so a `PlannerConfig`
with `storage_reservation_policy == SKU_AWARE` resolves a real
`SKUAwareStorageReservation` instead of raising `NotImplementedError`.

The OSS `DefaultPlannerProvider.build_storage_reservation` handles
`UNSET`/`HEURISTICAL`/`FIXED_PERCENTAGE`/`INFERENCE` but cannot build
`SKU_AWARE`: its home-anchored margin and per-SKU runtime overhead come from
the HUM hardware registry, which is fb-only. This override resolves that one
policy via the same factory the legacy APF path uses
(`build_sku_aware_reservation` in `hardware_utilities/storage_reservation_utils.py`),
and delegates every other policy -- and any caller-supplied reservation -- to
the base via `super()`.

`is_dry_run` is threaded from whether the request is a `DryRunRequest`, and an
unset `storage_reservation_percentage` falls back to
`_DEFAULT_RESERVATION_PERCENTAGE` (0.15), matching the base.

`model_base_bytes` is threaded from the unified `PlannerConfig` (new optional
field, appended last) into the factory, mirroring the legacy APF path
(`parallel.py` passes `planner_config.model_base_bytes`, landed in D110113933) --
so the unified path is at capability parity with legacy, not silently dropping a
model owner's explicit footprint. When set it replaces the static base with the
measured per-model footprint; when `None` (today's default, since no live
producer populates it yet) the factory falls back to the home-anchored margin +
computed dense, which with `overhead` defaulting to 0 is byte-identical to
Heuristical on the home SKU. The remaining follow-up is the *measured-value
producer* (KR 2.9), which no path has yet.

Also exposes `sku_aware` as a `--storage-reservation-policy` choice in the
offline dry-run CLI (`torchrec/distributed/planner/dry_run/cli.py`) so the
policy is selectable end-to-end for offline validation.

Differential Revision: D113594909


