### PR TITLE
Optimizer scratch-buffer stashing in MemoryStashingManager (#4470)

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -9,7 +9,17 @@
 
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    Tuple,
+    Union,
+)
 
 import torch
 from torch import nn
@@ -30,6 +40,11 @@ logger: logging.Logger = logging.getLogger(__name__)
 # keep the copy engine yielding often enough for the main stream's small copies
 # to interleave, at a negligible bandwidth cost (see chunked copy design).
 _STASH_CHUNK_SIZE_BYTES: int = 32 * 1024**2
+
+
+@runtime_checkable
+class _ScratchBufferOptimizer(Protocol):
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]: ...
 
 
 def _tensor_size_text(tensor: Union[List[torch.Tensor], torch.Tensor]) -> str:
@@ -152,6 +167,7 @@ class MemoryStashingManager:
     _device_to_host_stream: Optional[torch.cuda.Stream] = None
     _embedding_weight_restore_callbacks: List[Callable[..., None]] = []
     _optimizer_state_restore_callbacks: List[Callable[..., None]] = []
+    _optimizer_scratch_buffer_restore_callbacks: List[Callable[..., None]] = []
     _emo_cache_restore_callbacks: List[Callable[..., None]] = []
     _stash_executor: Optional[ThreadPoolExecutor] = None
     _delay_stash: bool = False
@@ -286,6 +302,7 @@ class MemoryStashingManager:
         cls._device_to_host_stream = None
         cls._embedding_weight_restore_callbacks.clear()
         cls._optimizer_state_restore_callbacks.clear()
+        cls._optimizer_scratch_buffer_restore_callbacks.clear()
         cls._emo_cache_restore_callbacks.clear()
         cls._delay_stash = False
         cls._stash_chunk_size_bytes = _STASH_CHUNK_SIZE_BYTES
@@ -330,9 +347,15 @@ class MemoryStashingManager:
         # Ensure the async D2H that fills cpu_buffer has completed before the
         # stager reads it (host-side wait; near-zero cost when already done).
         d2h_event.synchronize()
-        view = torch.empty(0, dtype=cpu_buffer.dtype, device="cpu")
-        view.set_(cpu_buffer.untyped_storage(), cpu_offset, obj.shape, obj.stride())
-        return view
+        # ``cpu_buffer`` holds the stashed tensor's LOGICAL values in CONTIGUOUS
+        # layout: ``chunked_copy_`` fills it via ``copy_`` (falling back to a
+        # single ``copy_`` for non-contiguous sources), which materializes the
+        # source in logical/row-major order. Reconstruct the returned view
+        # CONTIGUOUSLY over that data. Using ``obj.stride()`` here would reinterpret
+        # the contiguous buffer with the source's original (possibly transposed /
+        # non-contiguous) stride and hand the checkpoint stager transposed/garbage
+        # values -> silently corrupt optimizer state on resume.
+        return cpu_buffer.reshape(-1).narrow(0, cpu_offset, obj.numel()).view(obj.shape)
 
     @classmethod
     def restore_embedding_weights(
@@ -353,14 +376,23 @@ class MemoryStashingManager:
         cls,
         _grad: Optional[torch.Tensor] = None,
         sync_event: Optional[torch.cuda.Event] = None,
+        restore_scratch_buffer: bool = True,
     ) -> None:
-        """Pop and call all optimizer state restore callbacks in reverse order."""
+        """Restore copied optimizer state and, optionally, disposable scratch buffer."""
         cls._log_ems_once(
             "ems_restore_optimizer_state_callbacks",
-            {"num_callbacks": str(len(cls._optimizer_state_restore_callbacks))},
+            {
+                "num_callbacks": str(len(cls._optimizer_state_restore_callbacks)),
+                "num_scratch_buffer_callbacks": str(
+                    len(cls._optimizer_scratch_buffer_restore_callbacks)
+                ),
+            },
         )
         while cls._optimizer_state_restore_callbacks:
             cls._optimizer_state_restore_callbacks.pop()(None, sync_event)
+        if restore_scratch_buffer:
+            while cls._optimizer_scratch_buffer_restore_callbacks:
+                cls._optimizer_scratch_buffer_restore_callbacks.pop()(None, sync_event)
 
     @classmethod
     def restore_optimizer_state_next(
@@ -384,6 +416,18 @@ class MemoryStashingManager:
             )
             cls._optimizer_state_restore_callbacks.pop(0)(None, sync_event)
 
+    @staticmethod
+    def _consume_restore_callback(
+        callback: Callable[..., None],
+        callbacks: List[Callable[..., None]],
+        sync_event: Optional[torch.cuda.Event],
+    ) -> None:
+        try:
+            callbacks.remove(callback)
+        except ValueError:
+            return
+        callback(None, sync_event)
+
     @classmethod
     def _stash_tensors(
         cls,
@@ -393,7 +437,7 @@ class MemoryStashingManager:
         delay: bool = False,
     ) -> Tuple[
         Callable[[Optional[torch.Tensor]], None],
-        Callable[[Optional[torch.Tensor]], None],
+        Callable[..., None],
         Callable[[Optional[torch.Tensor]], None],
     ]:
         """
@@ -931,6 +975,77 @@ class MemoryStashingManager:
         return await_restore, restore
 
     @classmethod
+    def _release_optimizer_scratch_buffers(
+        cls,
+        optimizer: torch.optim.Optimizer,
+        sync_event: Optional[torch.cuda.Event],
+    ) -> Optional[Callable[..., None]]:
+        if not isinstance(optimizer, _ScratchBufferOptimizer):
+            return None
+        if sync_event is not None:
+            sync_event.synchronize()
+
+        scratch_buffer_storages: list[tuple[torch.UntypedStorage, int]] = []
+        seen_storage_ids: set[int] = set()
+        for scratch_buffer in optimizer.scratch_buffers():
+            storage = scratch_buffer.untyped_storage()
+            storage_id = storage._cdata
+            storage_size = storage.size()
+            if storage_size == 0 or storage_id in seen_storage_ids:
+                continue
+            seen_storage_ids.add(storage_id)
+            scratch_buffer_storages.append((storage, storage_size))
+
+        released_scratch_buffer_bytes = sum(
+            storage_size for _, storage_size in scratch_buffer_storages
+        )
+        if released_scratch_buffer_bytes == 0:
+            return None
+        for storage, _ in scratch_buffer_storages:
+            storage.resize_(0)
+
+        cls._log_ems_once(
+            "ems_stash_optimizer_scratch_buffer_released",
+            {
+                "optimizer": type(optimizer).__name__,
+                "size_bytes": str(released_scratch_buffer_bytes),
+            },
+        )
+
+        def restore_scratch_buffer(
+            _grad: Optional[torch.Tensor] = None,
+            _sync_event: Optional[torch.cuda.Event] = None,
+        ) -> None:
+            restored_scratch_buffer_bytes = 0
+            for storage, storage_size in scratch_buffer_storages:
+                if storage.size() == 0:
+                    storage.resize_(storage_size)
+                    restored_scratch_buffer_bytes += storage_size
+            cls._log_ems_once(
+                "ems_restore_optimizer_scratch_buffer",
+                {
+                    "optimizer": type(optimizer).__name__,
+                    "size_bytes": str(restored_scratch_buffer_bytes),
+                },
+            )
+
+        cls._optimizer_scratch_buffer_restore_callbacks.append(restore_scratch_buffer)
+        return restore_scratch_buffer
+
+    @staticmethod
+    def _collect_optimizer_state_tensors(
+        optimizer: torch.optim.Optimizer,
+    ) -> List[torch.Tensor]:
+        """Collect all stashable CUDA tensors from ``optimizer.state``."""
+        tensors: List[torch.Tensor] = []
+        for _param, state_dict in optimizer.state.items():
+            if not isinstance(state_dict, dict):
+                continue
+            for _state_key, state_value in state_dict.items():
+                tensors.extend(_collect_cuda_tensors_from_value(state_value))
+        return tensors
+
+    @classmethod
     def stash_optimizer_state(
         cls,
         optimizer: torch.optim.Optimizer,
@@ -991,12 +1106,7 @@ class MemoryStashingManager:
             - Supports nested structures like Shampoo's ShampooKroneckerFactors
         """
         # Collect all CUDA tensors from optimizer state
-        tensors: List[torch.Tensor] = []
-        for _param, state_dict in optimizer.state.items():
-            if not isinstance(state_dict, dict):
-                continue
-            for _state_key, state_value in state_dict.items():
-                tensors.extend(_collect_cuda_tensors_from_value(state_value))
+        tensors: List[torch.Tensor] = cls._collect_optimizer_state_tensors(optimizer)
 
         cls._log_ems_once(
             "ems_stash_optimizer_state_collected",
@@ -1006,11 +1116,33 @@ class MemoryStashingManager:
             },
         )
 
+        scratch_buffer_restore: Callable[..., None] | None = None
+
         if num_slices <= 1:
-            await_restore, restore, _execute_stash = cls._stash_tensors(
+            await_restore, tensor_restore, _execute_stash = cls._stash_tensors(
                 tensors, label="optimizer state", sync_event=sync_event
             )
-            cls._optimizer_state_restore_callbacks.append(restore)
+            cls._optimizer_state_restore_callbacks.append(tensor_restore)
+            scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
+                optimizer, sync_event
+            )
+
+            def restore(
+                _grad: Optional[torch.Tensor] = None,
+                restore_sync_event: Optional[torch.cuda.Event] = None,
+            ) -> None:
+                cls._consume_restore_callback(
+                    tensor_restore,
+                    cls._optimizer_state_restore_callbacks,
+                    restore_sync_event,
+                )
+                if scratch_buffer_restore is not None:
+                    cls._consume_restore_callback(
+                        scratch_buffer_restore,
+                        cls._optimizer_scratch_buffer_restore_callbacks,
+                        restore_sync_event,
+                    )
+
             return await_restore, restore
 
         # Gradual (throttled) restore: partition the dense optimizer state into
@@ -1038,6 +1170,10 @@ class MemoryStashingManager:
             # maps slice k to the k-th hook to fire.
             cls._optimizer_state_restore_callbacks.append(restore_k)
 
+        scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
+            optimizer, sync_event
+        )
+
         def aggregate_await(_grad: Optional[torch.Tensor] = None) -> None:
             """Gate the current stream on EVERY slice's restore completion."""
             for slice_await in slice_awaits:
@@ -1045,11 +1181,21 @@ class MemoryStashingManager:
 
         def restore_all(
             _grad: Optional[torch.Tensor] = None,
-            sync_event: Optional[torch.cuda.Event] = None,
+            restore_sync_event: Optional[torch.cuda.Event] = None,
         ) -> None:
-            """Restore all slices (used when no per-hook driver is present)."""
+            """Restore all slices, followed by disposable optimizer scratch buffer."""
             for slice_restore in slice_restores:
-                slice_restore(None, sync_event)
+                cls._consume_restore_callback(
+                    slice_restore,
+                    cls._optimizer_state_restore_callbacks,
+                    restore_sync_event,
+                )
+            if scratch_buffer_restore is not None:
+                cls._consume_restore_callback(
+                    scratch_buffer_restore,
+                    cls._optimizer_scratch_buffer_restore_callbacks,
+                    restore_sync_event,
+                )
 
         return aggregate_await, restore_all
 

--- a/torchrec/distributed/tests/test_memory_stashing.py
+++ b/torchrec/distributed/tests/test_memory_stashing.py
@@ -20,7 +20,7 @@ import torch
 from hypothesis import given, settings
 from torch import distributed as dist, nn
 from torch.distributed._shard.sharded_tensor import init_from_local_shards, Shard
-from torch.distributed._tensor import DeviceMesh, DTensor, Replicate
+from torch.distributed._tensor import DeviceMesh, distribute_tensor, DTensor, Replicate
 from torchrec.distributed.embedding_types import (
     EmbeddingComputeKernel,
     GroupedEmbeddingConfig,
@@ -512,6 +512,19 @@ class TestStashEmbeddingWeights(unittest.TestCase):
         self.assertFalse(MemoryStashingManager.is_enabled())
 
 
+class ScratchBufferOptimizer(torch.optim.SGD):
+    def __init__(
+        self,
+        params: Any,
+        scratch_buffer: torch.Tensor,
+    ) -> None:
+        super().__init__(params, lr=0.01)
+        self._scratch_buffer = scratch_buffer
+
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        return (self._scratch_buffer,)
+
+
 class TestStashOptimizerState(unittest.TestCase):
     """Tests for MemoryStashingManager.stash_optimizer_state method."""
 
@@ -525,6 +538,87 @@ class TestStashOptimizerState(unittest.TestCase):
 
     def tearDown(self) -> None:
         MemoryStashingManager.reset()
+
+    def test_scratch_buffer_only_uses_optimizer_state_stash_restore_api(self) -> None:
+        model = nn.Linear(10, 10).to(self.device)
+        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
+        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
+        scratch_buffer_size = scratch_buffer.untyped_storage().size()
+
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(optimizer)
+
+        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
+            1,
+        )
+
+        MemoryStashingManager.restore_optimizer_state()
+        await_restore(None)
+
+        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
+            0,
+        )
+
+    def test_returned_restore_consumes_registered_callbacks(self) -> None:
+        model = nn.Linear(10, 10).to(self.device)
+        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
+        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
+        scratch_buffer_size = scratch_buffer.untyped_storage().size()
+
+        await_restore, restore = MemoryStashingManager.stash_optimizer_state(optimizer)
+        restore(None)
+        await_restore(None)
+
+        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
+        self.assertEqual(MemoryStashingManager._optimizer_state_restore_callbacks, [])
+        self.assertEqual(
+            MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks,
+            [],
+        )
+
+        MemoryStashingManager.restore_optimizer_state()
+        self.assertEqual(scratch_buffer.untyped_storage().size(), scratch_buffer_size)
+
+    def test_scratch_buffer_restore_can_be_deferred_until_pre_step_guard(self) -> None:
+        model = nn.Linear(10, 10).to(self.device)
+        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
+        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
+
+        MemoryStashingManager.stash_optimizer_state(optimizer)
+        MemoryStashingManager.restore_optimizer_state(restore_scratch_buffer=False)
+
+        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
+        self.assertEqual(
+            len(MemoryStashingManager._optimizer_scratch_buffer_restore_callbacks),
+            1,
+        )
+
+        MemoryStashingManager.restore_optimizer_state()
+
+        self.assertGreater(scratch_buffer.untyped_storage().size(), 0)
+
+    def test_scratch_buffer_restore_waits_until_all_slices_are_restored(self) -> None:
+        model = nn.Linear(512, 512).to(self.device)
+        scratch_buffer = torch.zeros(1024, dtype=torch.int8, device=self.device)
+        optimizer = ScratchBufferOptimizer(model.parameters(), scratch_buffer)
+        x = torch.randn(32, 512, device=self.device)
+        model(x).sum().backward()
+        optimizer.step()
+
+        await_restore, _restore = MemoryStashingManager.stash_optimizer_state(
+            optimizer, num_slices=2
+        )
+        MemoryStashingManager.restore_optimizer_state_next()
+
+        self.assertEqual(scratch_buffer.untyped_storage().size(), 0)
+
+        MemoryStashingManager.restore_optimizer_state()
+        await_restore(None)
+
+        self.assertGreater(scratch_buffer.untyped_storage().size(), 0)
 
     def test_basic_adam_optimizer_stash_and_restore(self) -> None:
         """Test basic stash and restore with Adam optimizer."""
@@ -1481,6 +1575,146 @@ class TestRestoreStashedSyncTensors(unittest.TestCase):
         )
         # Must not raise (e.g. from h2d_stream() asserting an unset stream).
         self._call_helper(ctx)
+
+
+class TestCheckpointWhileStashed(unittest.TestCase):
+    """Repro for the checkpoint-while-stashed corruption path.
+
+    When a DCP checkpoint is captured between steps (dense optimizer state stashed
+    to CPU, GPU storage ``resize_(0)``'d), the stager must read the correct
+    pre-stash values via ``staged_cpu_view_for``. If the redirect misses, DCP
+    reads a freed CUDA storage -> corrupt optimizer state is persisted -> the
+    model diverges (NE spike) when the job resumes from that checkpoint.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        if not dist.is_available():
+            self.skipTest("torch.distributed not available")
+        self.device = torch.device("cuda:0")
+        self._created_pg = False
+        if not dist.is_initialized():
+            dist.init_process_group(
+                backend="cpu:gloo,cuda:nccl",
+                rank=0,
+                world_size=1,
+                init_method=f"file:///tmp/trec_memstash_ckpt_pg_{os.getpid()}",
+            )
+            self._created_pg = True
+        MemoryStashingManager.set_streams(torch.cuda.Stream(device=self.device))
+
+    def tearDown(self) -> None:
+        MemoryStashingManager.reset()
+        if self._created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+    def test_dcp_redirect_plain_tensor(self) -> None:
+        """Baseline: a stashed plain CUDA tensor is readable via the redirect.
+
+        Faithfully models DCP: the stager holds a SEPARATE view that keeps
+        referencing the GPU storage, so when the stash swaps ``tensor.data`` to
+        CPU and ``resize_(0)``'s the GPU storage, the captured view points at the
+        freed storage the redirect is keyed on.
+        """
+        tensor = torch.randn(1024, 512, device=self.device)  # 2 MiB
+        original = tensor.detach().clone()
+        captured = tensor.detach().view_as(tensor)  # separate view, shares GPU storage
+
+        MemoryStashingManager._stash_tensors([tensor])
+        self.assertEqual(captured.untyped_storage().size(), 0)  # GPU storage freed
+
+        cpu_src = MemoryStashingManager.staged_cpu_view_for(captured)
+        self.assertIsNotNone(cpu_src)
+        assert cpu_src is not None
+        torch.testing.assert_close(cpu_src, original.cpu())
+
+    def test_dcp_redirect_dtensor_state(self) -> None:
+        """Shampoo-style DTensor optimizer state must round-trip through a
+        checkpoint captured while the state is stashed."""
+        mesh = DeviceMesh("cuda", [0])
+        local = torch.randn(1024, 512, device=self.device)
+        original = local.detach().clone()
+        dtensor = distribute_tensor(local, mesh, [Replicate()])
+
+        # The DCP planner reads a DTensor state value via its local shard.
+        collected = _collect_cuda_tensors_from_value(dtensor)
+        self.assertEqual(len(collected), 1)
+        captured_local = dtensor.to_local()
+
+        MemoryStashingManager._stash_tensors(collected)
+
+        cpu_src = MemoryStashingManager.staged_cpu_view_for(captured_local)
+        self.assertIsNotNone(
+            cpu_src,
+            "DCP redirect missed the stashed DTensor local shard; the checkpoint "
+            "would read freed CUDA memory -> corrupt optimizer state on resume.",
+        )
+        assert cpu_src is not None
+        torch.testing.assert_close(cpu_src, original.cpu())
+
+    def test_dcp_redirect_noncontiguous_tensor(self) -> None:
+        """A non-contiguous stashed tensor must round-trip through the redirect.
+
+        ``chunked_copy_`` fills the pinned buffer, but ``staged_cpu_view_for``
+        reconstructs the view with the ORIGINAL (non-contiguous) stride over that
+        buffer. If the buffer is laid out contiguously while the view is rebuilt
+        with the transposed stride, the checkpoint reads transposed/garbage values.
+        """
+        base = torch.randn(512, 1024, device=self.device)  # 2 MiB
+        noncontig = base.t()  # transposed view: non-contiguous, shares storage
+        self.assertFalse(noncontig.is_contiguous())
+        original = noncontig.detach().clone()  # logical values, contiguous copy
+        captured = noncontig.detach()  # separate view sharing the GPU storage
+
+        MemoryStashingManager._stash_tensors([noncontig])
+
+        cpu_src = MemoryStashingManager.staged_cpu_view_for(captured)
+        self.assertIsNotNone(cpu_src)
+        assert cpu_src is not None
+        torch.testing.assert_close(cpu_src, original.cpu())
+
+    def test_stash_restore_noncontiguous_tensor(self) -> None:
+        """Full stash->restore round-trip must preserve a non-contiguous tensor's
+        logical values."""
+        base = torch.randn(512, 1024, device=self.device)  # 2 MiB
+        noncontig = base.t()
+        self.assertFalse(noncontig.is_contiguous())
+        original = noncontig.detach().clone()
+
+        await_restore, restore, _ = MemoryStashingManager._stash_tensors([noncontig])
+        restore(None)
+        await_restore(None)
+
+        self.assertTrue(noncontig.is_cuda)
+        torch.testing.assert_close(noncontig, original, rtol=1e-05, atol=1e-08)
+
+    def test_dcp_redirect_shampoo_like_noncontiguous_state(self) -> None:
+        """End-to-end via the real collect path: a Shampoo-style non-contiguous
+        state tensor (a strided view, as produced by DistributedShampoo's
+        ``torch.split(...).view(...)`` blocked buffers) stored in ``optimizer.state``,
+        collected by ``_collect_cuda_tensors_from_value`` and stashed, must survive
+        a checkpoint read via the DCP redirect.
+        """
+        backing = torch.randn(512, 1024, device=self.device)
+        state_tensor = backing.t()  # non-contiguous 1024x512 view, 2 MiB > 1 MiB
+        self.assertFalse(state_tensor.is_contiguous())
+        state_value = {"exp_avg": state_tensor, "step": torch.tensor(1)}
+
+        collected = _collect_cuda_tensors_from_value(state_value)
+        self.assertEqual(len(collected), 1)
+        original = collected[0].detach().clone()
+        captured = collected[0].detach()  # separate view for the DCP stager
+
+        MemoryStashingManager._stash_tensors(collected)
+
+        cpu_src = MemoryStashingManager.staged_cpu_view_for(captured)
+        self.assertIsNotNone(
+            cpu_src,
+            "DCP redirect missed the stashed non-contiguous Shampoo-like state.",
+        )
+        assert cpu_src is not None
+        torch.testing.assert_close(cpu_src, original.cpu())
 
 
 if __name__ == "__main__":

--- a/torchrec/optim/keyed.py
+++ b/torchrec/optim/keyed.py
@@ -414,6 +414,14 @@ class CombinedOptimizer(KeyedOptimizer):
         for _, opt in self._optims:
             opt.save_param_groups(save)
 
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            scratch_buffer
+            for _, opt in self._optims
+            if hasattr(opt, "scratch_buffers")
+            for scratch_buffer in opt.scratch_buffers()
+        )
+
     def set_optimizer_step(self, step: int) -> None:
         for _, opt in self._optims:
             if hasattr(opt, "set_optimizer_step"):
@@ -450,6 +458,11 @@ class KeyedOptimizerWrapper(KeyedOptimizer):
     # pyrefly: ignore[bad-override]
     def step(self, closure: Any = None) -> None:
         self._optimizer.step(closure=closure)
+
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        if hasattr(self._optimizer, "scratch_buffers"):
+            return self._optimizer.scratch_buffers()
+        return ()
 
     def set_optimizer_step(self, step: int) -> None:
         if hasattr(self._optimizer, "set_optimizer_step"):
@@ -504,6 +517,11 @@ class OptimizerWrapper(KeyedOptimizer):
 
     def save_param_groups(self, save: bool) -> None:
         self._optimizer.save_param_groups(save)
+
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        if hasattr(self._optimizer, "scratch_buffers"):
+            return self._optimizer.scratch_buffers()
+        return ()
 
     def set_optimizer_step(self, step: int) -> None:
         if hasattr(self._optimizer, "set_optimizer_step"):

--- a/torchrec/optim/semi_sync.py
+++ b/torchrec/optim/semi_sync.py
@@ -290,6 +290,14 @@ class SemisyncOptimizer(KeyedOptimizer):
         ret.append(f"{SEMI_SYNC_GLOBAL_OPTIM_KEY}: {self._global_optimizer.__repr__()}")
         return ", ".join(ret)
 
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            scratch_buffer
+            for optimizer in (self._optimizer, self._global_optimizer)
+            if hasattr(optimizer, "scratch_buffers")
+            for scratch_buffer in optimizer.scratch_buffers()
+        )
+
     def set_optimizer_step(self, step: int) -> None:
         for opt in [self._optimizer, self._global_optimizer]:
             if hasattr(opt, "set_optimizer_step"):

--- a/torchrec/optim/tests/test_keyed.py
+++ b/torchrec/optim/tests/test_keyed.py
@@ -39,6 +39,15 @@ class DummyOptimizerModule:
         self.tensor.detach().copy_(state_dict["tensor"])
 
 
+class ScratchBufferSGD(torch.optim.SGD):
+    def __init__(self, params: Any, scratch_buffer: torch.Tensor) -> None:
+        super().__init__(params, lr=0.1)
+        self._scratch_buffer = scratch_buffer
+
+    def scratch_buffers(self) -> tuple[torch.Tensor, ...]:
+        return (self._scratch_buffer,)
+
+
 class TestKeyedOptimizer(unittest.TestCase):
     def _assert_state_dict_equals(
         self, dict1: Dict[str, Any], dict2: Dict[str, Any]
@@ -216,6 +225,21 @@ class TestKeyedOptimizer(unittest.TestCase):
         self.assertTrue("state" in opt.state_dict())
         self.assertFalse(opt.state_dict()["state"])
 
+    def test_keyed_optimizer_wrapper_scratch_buffers(self) -> None:
+        param = torch.nn.Parameter(torch.ones(1))
+        scratch_buffer = torch.empty(7)
+        capable = KeyedOptimizerWrapper(
+            {"param": param},
+            lambda params: ScratchBufferSGD(params, scratch_buffer),
+        )
+        incapable = KeyedOptimizerWrapper(
+            {"param": param},
+            lambda params: torch.optim.SGD(params, lr=0.1, foreach=True),
+        )
+
+        self.assertEqual(capable.scratch_buffers(), (scratch_buffer,))
+        self.assertEqual(incapable.scratch_buffers(), ())
+
     def test_pickle(self) -> None:
         dense = torch.nn.Parameter(torch.ones((2, 3), dtype=torch.float))
         sparse = torch.nn.Parameter(torch.ones((1, 4), dtype=torch.float))
@@ -238,6 +262,36 @@ class TestKeyedOptimizer(unittest.TestCase):
 
 
 class TestCombinedOptimizer(unittest.TestCase):
+    def test_scratch_buffers_fan_out_through_nested_children(self) -> None:
+        first_scratch_buffer = torch.empty(3)
+        second_scratch_buffer = torch.empty(5)
+        first_param = torch.nn.Parameter(torch.ones(1))
+        second_param = torch.nn.Parameter(torch.ones(1))
+        first = KeyedOptimizerWrapper(
+            {"first": first_param},
+            lambda params: ScratchBufferSGD(params, first_scratch_buffer),
+        )
+        second = KeyedOptimizerWrapper(
+            {"second": second_param},
+            lambda params: ScratchBufferSGD(params, second_scratch_buffer),
+        )
+        incapable = KeyedOptimizer(
+            {"plain": torch.nn.Parameter(torch.ones(1))},
+            {},
+            [],
+        )
+        optimizer = CombinedOptimizer(
+            [
+                ("nested", CombinedOptimizer([("first", first), ("plain", incapable)])),
+                ("second", second),
+            ]
+        )
+
+        self.assertEqual(
+            optimizer.scratch_buffers(),
+            (first_scratch_buffer, second_scratch_buffer),
+        )
+
     def test_pickle(self) -> None:
         # Set up example KeyedOptimizer 1.
         param_1_t = torch.tensor([1.0, 2.0])
@@ -315,6 +369,20 @@ class TestCombinedOptimizer(unittest.TestCase):
 
 
 class TestOptimizerWrapper(unittest.TestCase):
+    def test_scratch_buffers_forwarding(self) -> None:
+        scratch_buffer = torch.empty(11)
+        param = torch.nn.Parameter(torch.ones(1))
+        capable = OptimizerWrapper(
+            KeyedOptimizerWrapper(
+                {"param": param},
+                lambda params: ScratchBufferSGD(params, scratch_buffer),
+            )
+        )
+        incapable = OptimizerWrapper(KeyedOptimizer({"param": param}, {}, []))
+
+        self.assertEqual(capable.scratch_buffers(), (scratch_buffer,))
+        self.assertEqual(incapable.scratch_buffers(), ())
+
     def test_load_state_dict(self) -> None:
         param_1_t = torch.tensor([1.0, 2.0])
         param_1 = Variable(param_1_t)

--- a/torchrec/optim/tests/test_semi_sync.py
+++ b/torchrec/optim/tests/test_semi_sync.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import unittest
+from typing import Any, cast
 from unittest.mock import Mock
 
 import torch
@@ -57,6 +58,21 @@ class TestSemisyncOptimizer(unittest.TestCase):
             global_params=self.global_params,
             optimizer=self.mock_local_optimizer,
             global_optimizer=self.mock_global_optimizer,
+        )
+
+    def test_scratch_buffers_fan_out_to_children(self) -> None:
+        local_scratch_buffer = torch.empty(3)
+        global_scratch_buffer = torch.empty(5)
+        cast(Any, self.mock_local_optimizer).scratch_buffers = Mock(
+            return_value=(local_scratch_buffer,)
+        )
+        cast(Any, self.mock_global_optimizer).scratch_buffers = Mock(
+            return_value=(global_scratch_buffer,)
+        )
+
+        self.assertEqual(
+            self.optimizer.scratch_buffers(),
+            (local_scratch_buffer, global_scratch_buffer),
         )
 
     def test_initialization_with_mocks(self) -> None:


### PR DESCRIPTION
Summary:

torchrec half of "Stash DistributedShampoo scratch buffers", split from the
DistributedShampoo + APS changes for reviewability.

Adds the ability to free an optimizer's disposable communication scratch buffers
during optimizer-state stashing:
- MemoryStashingManager: the _ScratchBufferOptimizer protocol, scratch_buffers()
  discovery, and _release_optimizer_scratch_buffers (resize_(0) after stashing
  persistent state, restore before optimizer.step()).
- KeyedOptimizer wrappers + SemiSyncOptimizer: propagate scratch_buffers().

The concrete scratch_buffers() implementation (DistributedShampoo's
_global_dist_buffer) and the APS MB train-pipeline wiring live in the dependent
non-torchrec diff.

Reviewed By: aporialiao, Fiery

Differential Revision: D113962248


