### PR TITLE
Run test_deferrable_metrics on GPU RE to unskip CUDA tests

### DIFF
--- a/torchrec/metrics/tests/test_deferrable_metrics.py
+++ b/torchrec/metrics/tests/test_deferrable_metrics.py
@@ -375,7 +375,18 @@ class TransferTensorsToCpuTest(unittest.TestCase):
         dtoh_stream = _get_metric_dtoh_stream(device)
         self.assertNotEqual(default_stream, dtoh_stream)
 
-        # Block the dedicated stream with a long synthetic op BEFORE calling
+        # Warm up the device and pinned-host caching allocators before arming
+        # the blocker. The first pinned allocation inside transfer_tensors_to_cpu
+        # issues a synchronizing cudaHostAlloc; if it ran between the stall and
+        # the copy it would drain the stall off dtoh_stream (opt builds hit this;
+        # dev happened to run with a warm allocator), leaving the copy on an idle
+        # stream so the event was already complete. Pre-warming keeps that sync
+        # out of the measured window.
+        warmup: dict[str, Any] = {"x": torch.randn(128, device=device)}
+        transfer_tensors_to_cpu(warmup)
+        torch.cuda.synchronize()
+
+        # Block the dedicated stream with a synthetic op BEFORE calling
         # transfer_tensors_to_cpu. The returned event must be ordered behind
         # this blocker because it was recorded on the same (dedicated) stream.
         # If a future change regressed to recording on the default stream,


### PR DESCRIPTION
Summary:
The `test_deferrable_metrics` target was a plain CPU `python_unittest` with no GPU, but seven of its tests are gated by `unittest.skipIf(not torch.cuda.is_available(), ...)`. On CPU-only CI hosts these tests were consistently skipped, so TestInfra raised a SKIPPING issue for `test_mixed_cpu_and_cuda_tensors`.

Fix: route the target to `gpu-remote-execution` via `re_test_utils.remote_execution` (matching sibling targets `test_gpu`/`test_recmetric` in the same BUCK file), with `use_case = "tpx-no-network"`, `PYTORCH_DISABLE_JUSTKNOBS=1`, and test-execution caching. The CUDA-gated tests genuinely need a real `cuda` device, so running on a GPU host — rather than removing the guards — is the correct resolution. This unskips all seven CUDA tests, resolving the SKIPPING issue at the target level.

No production code changed; the `transfer_tensors_to_cpu` implementation already correctly guards CPU tensors.

Reviewed By: jeffkbkim

Differential Revision: D114002504


