### PR TITLE
Pass the training device to get_device_module() in TorchRec train pipeline (#4477)

### DIFF
--- a/torchrec/distributed/train_pipeline/train_pipelines.py
+++ b/torchrec/distributed/train_pipeline/train_pipelines.py
@@ -1843,7 +1843,9 @@ class TrainPipelineSemiSync(TrainPipelineSparseDist[In, Out]):
             del context
 
         if len(self.batches) >= 1 and not is_semi_sync:
-            torch.get_device_module().synchronize()  # needed to avoid race condition
+            torch.get_device_module(
+                self._device
+            ).synchronize()  # needed to avoid race condition
             # pyrefly: ignore [bad-argument-type]
             self.start_embedding_lookup(self.batches[0], self.contexts[0])
 


### PR DESCRIPTION
Summary:

`torch.get_device_module()` called with no argument resolves the default device module, and that default is moving to build-time detection (it returns the compiled-in accelerator even when no accelerator device is available at runtime), please see: https://github.com/pytorch/pytorch/pull/190751. Pass the pipeline's `self._device` so the `synchronize()` call targets the module for the actual training device and does not trigger accelerator initialization on hosts without a usable device.

Differential Revision: D114277607


