### PR TITLE
Align TBE fake batch shape with its operator contract (#4481)

### DIFF
--- a/torchrec/ir/tests/test_serializer.py
+++ b/torchrec/ir/tests/test_serializer.py
@@ -15,11 +15,13 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from torch import nn
+from torch.fx.experimental.symbolic_shapes import statically_known_true
 from torch.fx.passes.utils.fuser_utils import fuse_by_partitions
 from torchrec.ir.serializer import JsonSerializer
 from torchrec.ir.utils import (
     decapsulate_ir_modules,
     encapsulate_ir_modules,
+    ir_tbe_lookup_impl,
     mark_dynamic_kjt,
     qualname,
 )
@@ -95,6 +97,36 @@ class CompoundModuleSerializer(JsonSerializer):
         #  got `Union[Module, Tensor]`.
         # pyrefly: ignore[bad-argument-type]
         return CompoundModule(ebc, comp, mlist)
+
+
+class _IRTBELookupModule(nn.Module):
+    def forward(self, offsets: torch.Tensor) -> torch.Tensor:
+        # offset_count = num_features * batch_size + 1; num_features is 2 here.
+        batch_size = (offsets.size(0) - 1) // 2
+        return ir_tbe_lookup_impl([offsets, None, None], batch_size, [3])[0]
+
+
+class IRTBELookupTest(unittest.TestCase):
+    def test_fake_preserves_input_backed_batch_expression(self) -> None:
+        offsets = torch.arange(7, dtype=torch.int32)
+        exported_program = torch.export.export(
+            _IRTBELookupModule(),
+            (offsets,),
+            dynamic_shapes=({0: torch.export.Dim("offset_count", min=5, max=13)},),
+            strict=False,
+        )
+
+        offsets_node = next(
+            node for node in exported_program.graph.nodes if node.op == "placeholder"
+        )
+        lookup_node = next(
+            node
+            for node in exported_program.graph.nodes
+            if node.op == "call_function" and "ir_tbe_lookup" in str(node.target)
+        )
+        offset_count = offsets_node.meta["val"].shape[0]
+        output_batch = lookup_node.meta["val"][0].shape[0]
+        self.assertTrue(statically_known_true(output_batch == (offset_count - 1) // 2))
 
 
 class TestJsonSerializer(unittest.TestCase):

--- a/torchrec/ir/utils.py
+++ b/torchrec/ir/utils.py
@@ -128,9 +128,8 @@ def ir_tbe_lookup_fake(
     tensors: List[Optional[torch.Tensor]], batch_size: int, dims: List[int]
 ) -> List[torch.Tensor]:
     device = get_device(tensors)
-    dynamic_batch_size = torch.library.get_ctx().new_dynamic_size()
-    logger.info(f"ir_tbe_lookup_fake -> ({dynamic_batch_size}, {dims}) {device}")
-    return [torch.empty(dynamic_batch_size, dim, device=device) for dim in dims]
+    logger.info(f"ir_tbe_lookup_fake -> ({batch_size}, {dims}) {device}")
+    return [torch.empty(batch_size, dim, device=device) for dim in dims]
 
 
 def encapsulate_ir_modules(


### PR DESCRIPTION
Summary:

`ir_tbe_lookup_impl` returns output tensors using the supplied `batch_size`, but its fake registration discarded that value and invented an unbacked dimension. This change makes the fake use the supplied `batch_size`, matching the real implementation and the sibling `ir_emb_lookup` and `ir_kt_regroup` fakes.

This is a shape-contract consistency cleanup, not a claim of new runtime batch polymorphism. For static exports, it makes the lookup interior batch dimension input-derived instead of unbacked. Dynamic exports may prove the same relation through downstream constraints. `ir_dynamic_batch_emb_lookup` remains the dedicated operator for cases that intentionally require an unbacked batch dimension.

The BUCK target-label updates are AUTODEPS2-required normalization for the two touched Python targets; no dependency behavior change is intended.

Differential Revision: D114760345


