### PR TITLE
Create A2A Primitive Benchmark

### DIFF
--- a/torchrec/distributed/benchmark/base.py
+++ b/torchrec/distributed/benchmark/base.py
@@ -19,7 +19,7 @@ import resource
 import sys
 import time
 import timeit
-from dataclasses import dataclass, fields, is_dataclass, MISSING
+from dataclasses import dataclass, field, fields, is_dataclass, MISSING
 from enum import Enum
 from typing import (
     Any,
@@ -36,7 +36,7 @@ from typing import (
 
 import torch
 import yaml
-from torch import multiprocessing as mp
+from torch import distributed as dist, multiprocessing as mp
 from torch.autograd.profiler import record_function
 from torchrec.distributed.benchmark.utils import (
     create_snapshot_file_name,
@@ -155,6 +155,11 @@ class BenchmarkResult:
     gpu_mem_stats: List[GPUMemoryStats]  # GPU memory stats per rank
     cpu_mem_stats: List[CPUMemoryStats]  # CPU memory stats per rank
     qps: torch.Tensor  # per-iteration queries per second
+    # Per-iteration wall-clock time in milliseconds (from ``time.perf_counter``).
+    # This measures the elapsed CPU-side time of the iteration; for async GPU work
+    # (e.g. a collective enqueued and not awaited on the host) it reflects launch
+    # overhead, not device execution -- use ``gpu_elapsed_time`` for GPU latency.
+    wall_elapsed_time: torch.Tensor = field(default_factory=lambda: torch.zeros(1))
     rank: int = -1
 
     def __str__(self) -> str:
@@ -165,6 +170,10 @@ class BenchmarkResult:
         cpu_runtime = (
             "CPU Runtime (P10/P50/P90)",
             f"{self.runtime_percentile(10, device='cpu'):.2f} / {self.runtime_percentile(50, device='cpu'):.2f} / {self.runtime_percentile(90, device='cpu'):.2f} ms",
+        )
+        wall_runtime = (
+            "Wall Runtime (P10/P50/P90)",
+            f"{self.runtime_percentile(10, device='wall'):.2f} / {self.runtime_percentile(50, device='wall'):.2f} / {self.runtime_percentile(90, device='wall'):.2f} ms",
         )
         cpu_util = (
             "CPU Utilization (P10/P50/P90)",
@@ -210,6 +219,7 @@ class BenchmarkResult:
         for h, c in [
             gpu_runtime,
             cpu_runtime,
+            wall_runtime,
             cpu_util,
             norm_cpu_util,
             mem_alloc,
@@ -238,6 +248,7 @@ class BenchmarkResult:
             "  Runtime:",
             f"    GPU  (P10/P50/P90):     {self.runtime_percentile(10, device='gpu'):.2f} / {self.runtime_percentile(50, device='gpu'):.2f} / {self.runtime_percentile(90, device='gpu'):.2f} ms",
             f"    CPU  (P10/P50/P90):     {self.runtime_percentile(10, device='cpu'):.2f} / {self.runtime_percentile(50, device='cpu'):.2f} / {self.runtime_percentile(90, device='cpu'):.2f} ms",
+            f"    Wall (P10/P50/P90):     {self.runtime_percentile(10, device='wall'):.2f} / {self.runtime_percentile(50, device='wall'):.2f} / {self.runtime_percentile(90, device='wall'):.2f} ms",
             f"    CPU Utilization (P10/P50/P90):  {self.cpu_utilization_percentile(10):.2%} / {self.cpu_utilization_percentile(50):.2%} / {self.cpu_utilization_percentile(90):.2%}",
             f"    Normalized CPU Util (P10/P50/P90):  {self.normalized_cpu_utilization_percentile(10):.2%} / {self.normalized_cpu_utilization_percentile(50):.2%} / {self.normalized_cpu_utilization_percentile(90):.2%}",
         ]
@@ -276,6 +287,9 @@ class BenchmarkResult:
         for p in (10, 50, 90):
             d[f"gpu_runtime_p{p}_ms"] = float(self.runtime_percentile(p, device="gpu"))
             d[f"cpu_runtime_p{p}_ms"] = float(self.runtime_percentile(p, device="cpu"))
+            d[f"wall_runtime_p{p}_ms"] = float(
+                self.runtime_percentile(p, device="wall")
+            )
             d[f"cpu_utilization_p{p}"] = float(self.cpu_utilization_percentile(p))
             d[f"normalized_cpu_utilization_p{p}"] = float(
                 self.normalized_cpu_utilization_percentile(p)
@@ -314,9 +328,15 @@ class BenchmarkResult:
         Args:
             percentile: Percentile to compute.
             interpolation: See ``torch.quantile``.
-            device: 'gpu' for CUDA event timings, 'cpu' for active CPU timings.
+            device: 'gpu' for CUDA event timings, 'cpu' for active CPU timings,
+                'wall' for wall-clock (perf_counter) timings.
         """
-        timings = self.gpu_elapsed_time if device == "gpu" else self.cpu_elapsed_time
+        if device == "gpu":
+            timings = self.gpu_elapsed_time
+        elif device == "wall":
+            timings = self.wall_elapsed_time
+        else:
+            timings = self.cpu_elapsed_time
         return torch.quantile(
             timings,
             percentile / 100.0,
@@ -545,6 +565,7 @@ def multi_process_benchmark(
         ],
         cpu_mem_stats=[CPUMemoryStats(rank, 0) for rank in range(world_size)],
         qps=benchmark_res_per_rank[0].qps,
+        wall_elapsed_time=benchmark_res_per_rank[0].wall_elapsed_time,
         rank=0,
     )
 
@@ -856,6 +877,7 @@ class PerfWrapper:
         rank: int,
         reset_accumulated_memory_stats: bool = True,
         sample_count: int = 0,
+        pg: Optional[dist.ProcessGroup] = None,
     ) -> None:
         self._start_events: List[torch.cuda.Event] = [
             torch.cuda.Event(enable_timing=True) for _ in range(num_benchmarks)
@@ -875,6 +897,10 @@ class PerfWrapper:
         # local device ordinal so multi-host jobs (global rank > per-host GPUs) work.
         self._rank: int = rank
         self._device: int = _bench_cuda_device(rank)
+        # When set, every rank rendezvouses here before each measured iteration so
+        # cross-rank arrival skew is absorbed outside the timing window (see
+        # ``measure``). ``None`` in single-process mode disables the barrier.
+        self._pg: Optional[dist.ProcessGroup] = pg
         self._reset_accumulated_memory_stats = reset_accumulated_memory_stats
 
         # Scratch state for in-flight measurement
@@ -916,7 +942,25 @@ class PerfWrapper:
         self._cur += 1
 
     def measure(self, fn: Callable[[], None]) -> None:
-        """Run ``fn`` bracketed by start/end measurement."""
+        """Run ``fn`` bracketed by start/end measurement.
+
+        When a process group is set, all ranks rendezvous at a ``dist.barrier``
+        *before* ``_start`` opens the timers, so cross-rank arrival skew is
+        absorbed in this untimed region. Otherwise the earliest rank opens its
+        window and then blocks *inside* ``fn``'s collective waiting for the
+        slowest (straggler) rank, charging that wait to its own comm time. The
+        barrier only helps here, ahead of the timers -- inside the timed window it
+        would merely relabel the wait, not exclude it.
+        """
+        if self._pg is not None:
+            dist.barrier(group=self._pg)
+            # A NCCL barrier is asynchronous on the host, so block until it has
+            # actually completed; otherwise the wall-clock timer in ``_start``
+            # would open before the ranks are aligned and the skew would leak back
+            # into the wall measurement (GPU-event timing is already safe because
+            # the barrier's stream op precedes the start event).
+            if torch.cuda.is_available():
+                torch.cuda.synchronize(self._device)
         self._start()
         fn()
         self._end()
@@ -939,6 +983,11 @@ class PerfWrapper:
     def cpu_elapsed_time(self) -> torch.Tensor:
         """Per-iteration active CPU time in milliseconds."""
         return self._trim_outliers([t / 1e6 for t in self._cpu_times_active_ns])
+
+    @property
+    def wall_elapsed_time(self) -> torch.Tensor:
+        """Per-iteration wall-clock time in milliseconds (from ``time.perf_counter``)."""
+        return self._trim_outliers([t / 1e6 for t in self._wall_times_ns])
 
     @property
     def cpu_utilization(self) -> torch.Tensor:
@@ -1026,6 +1075,7 @@ class PerfWrapper:
             gpu_mem_stats=[self.gpu_mem_stats_p90],
             cpu_mem_stats=[CPUMemoryStats(rank, self.peak_rss_mbs)],
             qps=self.qps,
+            wall_elapsed_time=self.wall_elapsed_time,
             rank=rank,
         )
 
@@ -1036,15 +1086,17 @@ def _run_cuda_benchmark(
     rank: int,
     reset_accumulated_memory_stats: bool = True,
     sample_count: int = 0,
+    pg: Optional[dist.ProcessGroup] = None,
 ) -> PerfWrapper:
     """Run benchmark iterations on CUDA, collecting GPU/CPU timing and memory stats.
 
     Returns a ``PerfWrapper`` containing raw per-iteration measurements.
     Call ``to_benchmark_result(name, rank, world_size)`` on the result to
-    obtain a ``BenchmarkResult``.
+    obtain a ``BenchmarkResult``. When ``pg`` is set, ranks barrier before each
+    measured iteration so arrival skew stays out of the timing (see ``measure``).
     """
     perf = PerfWrapper(
-        num_benchmarks, rank, reset_accumulated_memory_stats, sample_count
+        num_benchmarks, rank, reset_accumulated_memory_stats, sample_count, pg
     )
     logger.info(f"Running cuda benchmark {num_benchmarks} times on rank {rank}")
 
@@ -1172,6 +1224,7 @@ def _run_benchmark_core(
     profile_all_threads: bool = False,
     sample_count: int = 0,
     test_name: str = "",
+    pg: Optional[dist.ProcessGroup] = None,
 ) -> BenchmarkResult:
     """Internal helper that contains the core benchmarking logic shared by
     ``benchmark`` and ``benchmark_func``.  All heavy–lifting (timing, memory
@@ -1213,6 +1266,7 @@ def _run_benchmark_core(
             rank,
             reset_accumulated_memory_stats,
             sample_count,
+            pg,
         )
         result = perf.to_benchmark_result(name, rank, world_size)
     else:  # CPU benchmarking
@@ -1234,6 +1288,7 @@ def _run_benchmark_core(
             gpu_mem_stats=[],
             cpu_mem_stats=[CPUMemoryStats.for_process(rank)],
             qps=cpu_qps,
+            wall_elapsed_time=cpu_elapsed_time.clone(),
             rank=rank,
         )
 
@@ -1404,6 +1459,7 @@ def benchmark_func(
     profile_all_threads: bool = False,
     sample_count: int = 0,
     test_name: str = "",
+    pg: Optional[dist.ProcessGroup] = None,
 ) -> BenchmarkResult:
     """
     Args:
@@ -1429,6 +1485,10 @@ def benchmark_func(
         all_rank_traces: Whether to export traces from all ranks.
         memory_snapshot: Whether to capture memory snapshot during the profiling
             usage: https://docs.pytorch.org/memory_viz
+        pg: Optional process group. When provided, all ranks barrier before each
+            measured iteration so cross-rank arrival skew is absorbed outside the
+            timing window -- important for collective (e.g. all-to-all) benchmarks
+            where the straggler would otherwise inflate the measured comm time.
     """
     if benchmark_func_kwargs is None:
         benchmark_func_kwargs = {}
@@ -1475,4 +1535,5 @@ def benchmark_func(
         profile_all_threads=profile_all_threads,
         sample_count=sample_count,
         test_name=test_name,
+        pg=pg,
     )

--- a/torchrec/distributed/benchmark/benchmark_primitive.py
+++ b/torchrec/distributed/benchmark/benchmark_primitive.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 """
-Benchmark for primitive ops (placeholder).
+Benchmark for primitive ops.
 
 ``benchmark_runner`` is the per-rank entry point. It is invoked once per rank by the process
 runner (``process_runner.run_single_process_func`` /
@@ -17,16 +17,363 @@ handshake and injects a live ``SingleProcessContext`` (``ctx``) plus this rank's
 ``rank`` and ``world_size``. The runner must therefore use ``ctx.device`` /
 ``ctx.pg`` directly rather than creating its own context.
 
+Multiple primitive benchmarks live in this file. ``benchmark_runner`` selects which one
+to run via the ``primitive`` flag (see ``_BENCHMARKS``); each benchmark measures latency
+only -- outputs are not checked for correctness. The first is ``kjt_a2a``, the All-to-All
+performance of ``KJTAllToAll`` (the ``KeyedJaggedTensor`` A2A collective from
+``dist_data.py``). The second is ``kt_a2a``, the All-to-All performance of
+``PooledEmbeddingsAllToAll`` -- the dense pooled-embedding (``KeyedTensor``) collective
+``output_dist`` uses to redistribute real embedding outputs. Unlike ``kjt_a2a`` it
+exchanges float tensors rather than sparse indices.
+
 A follow-up launcher binary will call ``runner`` explicitly with options to run on
 MAST or locally.
 """
 
 import logging
-from typing import Any
+import socket
+from typing import Any, Callable, Dict, List, Optional
 
+import torch
+from torchrec.distributed.benchmark.base import benchmark_func, BenchmarkResult
+from torchrec.distributed.dist_data import KJTAllToAll, PooledEmbeddingsAllToAll
 from torchrec.distributed.test_utils.process_runner import SingleProcessContext
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
 logger: logging.Logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def _build_splits(num_features: int, world_size: int) -> List[int]:
+    """Distribute ``num_features`` keys across ``world_size`` ranks as evenly as possible.
+
+    The remainder is spread over the first ranks, so the result sums to ``num_features``
+    and has exactly ``world_size`` entries (the contract ``KJTAllToAll`` enforces).
+    """
+    base, rem = divmod(num_features, world_size)
+    return [base + (1 if r < rem else 0) for r in range(world_size)]
+
+
+def _make_input_kjt(
+    num_features: int,
+    num_values: int,
+    batch_size: int,
+    values_dtype: torch.dtype,
+    device: torch.device,
+) -> KeyedJaggedTensor:
+    """Build a ``KeyedJaggedTensor`` whose ``values`` tensor is exactly ``num_values`` long.
+
+    ``num_values`` is spread uniformly across the ``num_features * batch_size`` length
+    slots (the leftover from integer division is added to the first slots) so the per-slot
+    jagged lengths sum to ``num_values``. Content is random -- only the A2A transport size
+    matters for this benchmark, not the values themselves.
+    """
+    keys: List[str] = [f"f_{i}" for i in range(num_features)]
+
+    num_slots = num_features * batch_size
+    per_slot, rem = divmod(num_values, num_slots)
+    lengths = torch.full((num_slots,), per_slot, dtype=torch.int32, device=device)
+    if rem > 0:
+        lengths[:rem] += 1
+
+    # Vocab bound is arbitrary -- A2A moves the raw bytes regardless of index values.
+    values = torch.randint(
+        0, 1_000_000, (num_values,), dtype=values_dtype, device=device
+    )
+
+    return KeyedJaggedTensor(keys=keys, values=values, lengths=lengths)
+
+
+def _run_a2a(
+    _batch_inputs: List[Any],
+    *,
+    a2a: KJTAllToAll,
+    kjt: KeyedJaggedTensor,
+) -> None:
+    """One measured iteration: full two-stage KJT A2A, then touch the output.
+
+    Rank alignment against the straggler effect is handled by ``PerfWrapper`` (it
+    barriers before each iteration, outside the timing window); this function only
+    runs the collective. ``KJTAllToAll`` returns a two-stage awaitable -- the first
+    ``wait()`` exchanges splits, the second exchanges the tensors. ``out.values()``
+    only returns the values tensor handle: no data read, no host sync (and ``wait()``
+    on CUDA does not block the host either -- the collective runs async on the stream).
+    The input KJT is reused across iterations: ``_wait_impl`` does not free input storage
+    (only the explicit ``clear_inputs()`` does), which we never call.
+
+    So we ``torch.cuda.synchronize()`` at the end to actually block the host on the
+    collective inside the measured region; that is what makes the wall-clock timer reflect
+    end-to-end collective latency (GPU-event timing is unaffected either way).
+    """
+    out = a2a(kjt).wait().wait()
+    values = out.values()
+    if values.is_cuda:
+        torch.cuda.synchronize(values.device)
+
+
+def _benchmark_kjt_a2a(
+    ctx: SingleProcessContext,
+    rank: int,
+    world_size: int,
+    **kwargs: Any,
+) -> BenchmarkResult:
+    """``KJTAllToAll`` (A2A) benchmark.
+
+    Builds an input ``KeyedJaggedTensor`` of a configurable size, then measures the
+    latency of running it through ``KJTAllToAll`` over ``ctx.pg``. Correctness of the
+    redistributed output is intentionally not verified.
+
+    Args:
+        ctx: live single-process context (device + process group) injected by the
+            process runner; use ``ctx.device`` / ``ctx.pg`` directly.
+        rank: this process' global rank.
+        world_size: total number of ranks.
+        **kwargs: benchmark options:
+            num_features (int): total number of KJT keys across all ranks (split across
+                ranks via ``KJTAllToAll`` splits). Default 256.
+            num_values (int): total length of the ``values`` tensor -- the headline size
+                knob (with the default, ``50M * 8B (int64) ~= 400 MB`` of transport per
+                rank). Default 50_000_000.
+            batch_size (int): stride; the lengths tensor has ``num_features * batch_size``
+                entries. Default 32 * 1024.
+            values_dtype (torch.dtype): dtype of the ``values`` tensor. Default int64.
+            num_benchmarks (int): number of measured iterations. Default 20.
+            num_profiles (int): number of profiled iterations (requires profile_dir).
+                Default 0.
+            profile_dir (str): directory for chrome traces; empty disables profiling.
+            name (str): human-readable benchmark name. Default "kjt_a2a".
+
+    Returns:
+        This rank's ``BenchmarkResult``.
+    """
+    num_features: int = int(kwargs.get("num_features", 256))
+    num_values: int = int(kwargs.get("num_values", 50_000_000))
+    batch_size: int = int(kwargs.get("batch_size", 32 * 1024))
+    values_dtype: torch.dtype = kwargs.get("values_dtype", torch.int64)
+    num_benchmarks: int = int(kwargs.get("num_benchmarks", 20))
+    num_profiles: int = int(kwargs.get("num_profiles", 0))
+    profile_dir: str = str(kwargs.get("profile_dir", ""))
+    name: str = str(kwargs.get("name", "kjt_a2a"))
+
+    pg: Optional[torch.distributed.ProcessGroup] = ctx.pg
+    assert pg is not None, "ctx.pg must be initialized by the process runner"
+
+    splits = _build_splits(num_features, world_size)
+    assert sum(splits) == num_features
+    assert len(splits) == world_size
+    if num_features < world_size:
+        logger.warning(
+            "num_features (%d) < world_size (%d): some ranks receive no features.",
+            num_features,
+            world_size,
+        )
+
+    kjt = _make_input_kjt(
+        num_features=num_features,
+        num_values=num_values,
+        batch_size=batch_size,
+        values_dtype=values_dtype,
+        device=ctx.device,
+    )
+    a2a = KJTAllToAll(pg=pg, splits=splits)
+
+    logger.info(
+        "rank=%d local_rank=%d host=%s running KJT A2A benchmark: num_features=%d "
+        "num_values=%d batch_size=%d splits=%s device=%s",
+        rank,
+        ctx.local_rank,
+        socket.gethostname(),
+        num_features,
+        num_values,
+        batch_size,
+        splits,
+        ctx.device,
+    )
+
+    result = benchmark_func(
+        name=name,
+        rank=rank,
+        world_size=world_size,
+        func_to_benchmark=_run_a2a,
+        bench_inputs=[],
+        prof_inputs=[],
+        benchmark_func_kwargs={"a2a": a2a, "kjt": kjt},
+        num_profiles=num_profiles,
+        num_benchmarks=num_benchmarks,
+        profile_dir=profile_dir,
+        device_type=ctx.device.type,
+        pg=pg,
+    )
+
+    if rank == 0:
+        logger.info("KJT A2A benchmark result:\n%s", result)
+
+    return result
+
+
+def _make_pooled_embeddings(
+    batch_size: int,
+    dim: int,
+    values_dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build this rank's dense pooled-embedding input for ``PooledEmbeddingsAllToAll``.
+
+    Returns a ``[batch_size, dim]`` tensor holding the *global* batch (every rank's rows)
+    but only this rank's local embedding width. The A2A scatters the batch dimension and
+    gathers the width, so each rank ends up with
+    ``[batch_size // world_size, dim * world_size]``. Content is random -- only the A2A
+    transport size matters for this benchmark, not the values themselves.
+    """
+    return torch.rand((batch_size, dim), dtype=values_dtype, device=device)
+
+
+def _run_pooled_a2a(
+    _batch_inputs: List[Any],
+    *,
+    a2a: PooledEmbeddingsAllToAll,
+    local_embs: torch.Tensor,
+) -> None:
+    """One measured iteration: full pooled-embedding A2A, then touch the output.
+
+    Rank alignment against the straggler effect is handled by ``PerfWrapper`` (it
+    barriers before each iteration, outside the timing window); this function only
+    runs the collective. ``PooledEmbeddingsAllToAll`` returns a single-stage awaitable
+    (unlike the two-stage ``KJTAllToAll``) -- one ``wait()`` exchanges the dense tensors
+    and yields the redistributed output. ``numel()`` only reads the output's shape
+    metadata: no data read, no kernel, and -- like ``wait()`` on CUDA -- no host sync
+    (the collective runs async on the stream). The input tensor is reused across
+    iterations.
+
+    So we ``torch.cuda.synchronize()`` at the end to actually block the host on the
+    collective inside the measured region; that is what makes the wall-clock timer reflect
+    end-to-end collective latency (GPU-event timing is unaffected either way).
+    """
+    out = a2a(local_embs).wait()
+    out.numel()
+    if local_embs.is_cuda:
+        torch.cuda.synchronize(local_embs.device)
+
+
+def _benchmark_kt_a2a(
+    ctx: SingleProcessContext,
+    rank: int,
+    world_size: int,
+    **kwargs: Any,
+) -> BenchmarkResult:
+    """``PooledEmbeddingsAllToAll`` (dense pooled-embedding / ``KeyedTensor`` A2A) benchmark.
+
+    Builds a dense pooled-embedding input tensor of a configurable size, then measures the
+    latency of redistributing it through ``PooledEmbeddingsAllToAll`` over ``ctx.pg`` --
+    the collective ``output_dist`` uses to exchange real embedding outputs (float tensors)
+    rather than sparse indices. Correctness of the redistributed output is intentionally
+    not verified.
+
+    The embedding width is assumed balanced across ranks (``dim_sum_per_rank`` is
+    ``[dim] * world_size``), matching balanced table-wise sharding.
+
+    Args:
+        ctx: live single-process context (device + process group) injected by the
+            process runner; use ``ctx.device`` / ``ctx.pg`` directly.
+        rank: this process' global rank.
+        world_size: total number of ranks.
+        **kwargs: benchmark options:
+            batch_size (int): global batch size (number of rows in the input) -- must be
+                divisible by ``world_size`` (``PooledEmbeddingsAllToAll`` scatters the
+                batch evenly). Default 32 * 1024.
+            dim (int): per-rank embedding width; ``dim_sum_per_rank`` is
+                ``[dim] * world_size``. The headline transport size is
+                ``batch_size * dim`` (with the defaults, ``32768 * 3072 * 4B ~= 400 MB``
+                of float32 per rank, comparable to ``kjt_a2a``). Default 3072.
+            values_dtype (torch.dtype): dtype of the embedding tensor; must be a floating
+                dtype. Default float32.
+            num_benchmarks (int): number of measured iterations. Default 20.
+            num_profiles (int): number of profiled iterations (requires profile_dir).
+                Default 0.
+            profile_dir (str): directory for chrome traces; empty disables profiling.
+            name (str): human-readable benchmark name. Default "kt_a2a".
+
+    Returns:
+        This rank's ``BenchmarkResult``.
+    """
+    batch_size: int = int(kwargs.get("batch_size", 32 * 1024))
+    dim: int = int(kwargs.get("dim", 3072))
+    values_dtype: torch.dtype = kwargs.get("values_dtype", torch.float32)
+    num_benchmarks: int = int(kwargs.get("num_benchmarks", 20))
+    num_profiles: int = int(kwargs.get("num_profiles", 0))
+    profile_dir: str = str(kwargs.get("profile_dir", ""))
+    name: str = str(kwargs.get("name", "kt_a2a"))
+
+    pg: Optional[torch.distributed.ProcessGroup] = ctx.pg
+    assert pg is not None, "ctx.pg must be initialized by the process runner"
+    assert batch_size % world_size == 0, (
+        f"batch_size ({batch_size}) must be divisible by world_size ({world_size}): "
+        "PooledEmbeddingsAllToAll scatters the global batch evenly across ranks."
+    )
+
+    dim_sum_per_rank = [dim] * world_size
+
+    local_embs = _make_pooled_embeddings(
+        batch_size=batch_size,
+        dim=dim,
+        values_dtype=values_dtype,
+        device=ctx.device,
+    )
+    a2a = PooledEmbeddingsAllToAll(
+        pg=pg,
+        dim_sum_per_rank=dim_sum_per_rank,
+        device=ctx.device,
+    )
+
+    logger.info(
+        "rank=%d local_rank=%d host=%s running KT A2A benchmark: batch_size=%d "
+        "dim=%d dim_sum_per_rank=%s device=%s",
+        rank,
+        ctx.local_rank,
+        socket.gethostname(),
+        batch_size,
+        dim,
+        dim_sum_per_rank,
+        ctx.device,
+    )
+
+    result = benchmark_func(
+        name=name,
+        rank=rank,
+        world_size=world_size,
+        func_to_benchmark=_run_pooled_a2a,
+        bench_inputs=[],
+        prof_inputs=[],
+        benchmark_func_kwargs={"a2a": a2a, "local_embs": local_embs},
+        num_profiles=num_profiles,
+        num_benchmarks=num_benchmarks,
+        profile_dir=profile_dir,
+        device_type=ctx.device.type,
+        pg=pg,
+    )
+
+    if rank == 0:
+        logger.info("KT A2A benchmark result:\n%s", result)
+
+    return result
+
+
+# Registry of available primitive benchmarks, keyed by the ``primitive`` flag.
+# Add new primitive benchmarks here -- each is called as
+# ``fn(ctx, rank, world_size, **kwargs)`` and returns a per-rank ``BenchmarkResult``.
+_BENCHMARKS: Dict[str, Callable[..., BenchmarkResult]] = {
+    "kjt_a2a": _benchmark_kjt_a2a,
+    "kt_a2a": _benchmark_kt_a2a,
+}
+
+
+def available_primitives() -> List[str]:
+    """Return the sorted names of registered primitive benchmarks.
+
+    These are the valid values for the ``name`` flag consumed by
+    :func:`benchmark_runner` (and surfaced as the launcher's ``--name`` choices).
+    """
+    return sorted(_BENCHMARKS)
 
 
 def benchmark_runner(
@@ -34,15 +381,36 @@ def benchmark_runner(
     rank: int,
     world_size: int,
     **kwargs: Any,
-) -> None:
-    """Per-rank primitive benchmark entry point (placeholder -- does nothing yet).
+) -> BenchmarkResult:
+    """Per-rank primitive benchmark entry point.
+
+    Selects which primitive benchmark to run via the ``name`` flag and dispatches to
+    it. The injected ``ctx`` (device + process group), ``rank`` and ``world_size`` plus
+    the remaining ``kwargs`` are forwarded to the selected benchmark.
 
     Args:
         ctx: live single-process context (device + process group) injected by the
             process runner; use ``ctx.device`` / ``ctx.pg`` directly.
         rank: this process' global rank.
         world_size: total number of ranks.
-        **kwargs: forwarded benchmark options (none consumed yet).
+        **kwargs: ``name`` (str) selects the benchmark (default ``"kjt_a2a"``); the
+            rest are forwarded to the selected benchmark (see its docstring).
+
+    Returns:
+        This rank's ``BenchmarkResult``.
     """
-    # TODO: implement the primitive benchmark body.
-    pass
+    name: str = str(kwargs.pop("name", "kjt_a2a"))
+    if name not in _BENCHMARKS:
+        raise ValueError(
+            f"unknown primitive benchmark {name!r}; "
+            f"available: {sorted(_BENCHMARKS)}"
+        )
+
+    logger.info(
+        "rank=%d local_rank=%d host=%s selected primitive benchmark %r",
+        rank,
+        ctx.local_rank,
+        socket.gethostname(),
+        name,
+    )
+    return _BENCHMARKS[name](ctx, rank, world_size, **kwargs)

--- a/torchrec/distributed/test_utils/benchmark_utils/benchmark_launcher.py
+++ b/torchrec/distributed/test_utils/benchmark_utils/benchmark_launcher.py
@@ -27,10 +27,15 @@ Both paths create + handshake the process group and inject a live
 into the selected benchmark's ``benchmark_runner``.
 
 Examples:
-    # local: spawn 2 ranks on this host and run the primitive benchmark
+    # local: spawn 2 ranks on this host and run the KJT (sparse index) A2A benchmark
     buck2 run @fbcode//mode/opt \\
         fbcode//torchrec/distributed/test_utils/benchmark_utils:benchmark_launcher -- \\
-        --mode=local --benchmark=primitive --world-size=2
+        --mode=local --benchmark=primitive --name=kjt_a2a --world-size=2
+
+    # local: run the KT (dense pooled-embedding / output_dist) A2A benchmark
+    buck2 run @fbcode//mode/opt \\
+        fbcode//torchrec/distributed/test_utils/benchmark_utils:benchmark_launcher -- \\
+        --mode=local --benchmark=primitive --name=kt_a2a --world-size=2
 
     # remote: invoked per-rank by torchrun/MAST (rendezvous env preset)
     buck2 run @fbcode//mode/opt \\
@@ -40,7 +45,7 @@ Examples:
 
 import argparse
 import logging
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
 from torchrec.distributed.benchmark import benchmark_module, benchmark_primitive
@@ -53,14 +58,64 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # Registry of available benchmarks: name -> per-rank runner. Each runner has the
 # signature ``benchmark_runner(ctx, rank, world_size, **kwargs)`` and is invoked
-# once per rank with the live context injected by the process runner.
-_BENCHMARKS: Dict[str, Callable[..., None]] = {
+# once per rank with the live context injected by the process runner. Runners may
+# return a per-rank result (e.g. ``BenchmarkResult``) or ``None``; the launcher
+# ignores the value, so the registry is typed ``Callable[..., Any]``.
+_BENCHMARKS: Dict[str, Callable[..., Any]] = {
     "primitive": benchmark_primitive.benchmark_runner,
     "module": benchmark_module.benchmark_runner,
 }
 
+# torchrun/torchelastic inject args like ``--local-rank`` into the worker argv;
+# LOCAL_RANK is read from the environment instead, so these must not be forwarded
+# as benchmark kwargs.
+_TORCHRUN_INJECTED_KEYS: frozenset[str] = frozenset({"local_rank"})
 
-def _parse_args() -> argparse.Namespace:
+
+def _coerce(value: str) -> Any:
+    """Best-effort cast a CLI string to ``int``, then ``float``, else leave as ``str``."""
+    for cast in (int, float):
+        try:
+            return cast(value)
+        except ValueError:
+            continue
+    return value
+
+
+def _parse_forwarded_kwargs(unknown: List[str]) -> Dict[str, Any]:
+    """Parse leftover ``--key=value`` / ``--key value`` args into benchmark kwargs.
+
+    Unrecognized args are benchmark-specific options (e.g. ``--batch_size``,
+    ``--dim``) forwarded verbatim to the selected ``benchmark_runner``. Keys are
+    normalized (leading ``--`` stripped, ``-`` -> ``_``) and values are coerced to
+    ``int``/``float`` when possible. torchrun-injected keys (see
+    ``_TORCHRUN_INJECTED_KEYS``) are dropped.
+    """
+    kwargs: Dict[str, Any] = {}
+    i = 0
+    while i < len(unknown):
+        tok = unknown[i]
+        if not tok.startswith("--"):
+            i += 1
+            continue
+        body = tok[2:]
+        if "=" in body:
+            key, value = body.split("=", 1)
+            i += 1
+        elif i + 1 < len(unknown) and not unknown[i + 1].startswith("--"):
+            key, value = body, unknown[i + 1]
+            i += 2
+        else:
+            key, value = body, "true"
+            i += 1
+        key = key.replace("-", "_")
+        if key in _TORCHRUN_INJECTED_KEYS:
+            continue
+        kwargs[key] = _coerce(value)
+    return kwargs
+
+
+def _parse_args() -> Tuple[argparse.Namespace, Dict[str, Any]]:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--mode",
@@ -77,6 +132,13 @@ def _parse_args() -> argparse.Namespace:
         help="which benchmark runner to launch.",
     )
     parser.add_argument(
+        "--name",
+        choices=benchmark_primitive.available_primitives(),
+        default="kjt_a2a",
+        help="which primitive op to benchmark when --benchmark=primitive (ignored by "
+        "other benchmarks). Default: kjt_a2a.",
+    )
+    parser.add_argument(
         "--world-size",
         type=int,
         default=2,
@@ -89,22 +151,22 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="process-group backend (defaults to nccl on GPU, gloo otherwise).",
     )
-    # torchrun / fb.dist.ddp inject extra args (e.g. --local-rank) into the
-    # worker argv; LOCAL_RANK is read from the environment instead, so ignore
-    # unrecognized args rather than failing with argparse's exit code 2.
+    # Use parse_known_args so argparse does not fail (exit code 2) on the leftover
+    # args: these are either torchrun/fb.dist.ddp injections (e.g. --local-rank,
+    # dropped) or benchmark-specific options (e.g. --batch_size, --dim) that we
+    # forward to the selected benchmark_runner.
     args, unknown = parser.parse_known_args()
-    if unknown:
-        logger.info(
-            "ignoring unrecognized args (injected by torchrun/MAST): %s", unknown
-        )
-    return args
+    extra_kwargs = _parse_forwarded_kwargs(unknown)
+    if extra_kwargs:
+        logger.info("forwarding benchmark kwargs: %s", extra_kwargs)
+    return args, extra_kwargs
 
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
-    args = _parse_args()
+    args, extra_kwargs = _parse_args()
 
-    runner: Callable[..., None] = _BENCHMARKS[args.benchmark]
+    runner: Callable[..., Any] = _BENCHMARKS[args.benchmark]
 
     if args.mode == "local":
         # Validate we have enough GPUs for the requested world_size before
@@ -128,6 +190,8 @@ def main() -> None:
             runner,
             world_size=args.world_size,
             backend=args.backend,
+            name=args.name,
+            **extra_kwargs,
         )
     else:  # remote
         logger.info(
@@ -136,6 +200,8 @@ def main() -> None:
         run_single_process_func(
             runner,
             backend=args.backend,
+            name=args.name,
+            **extra_kwargs,
         )
 
 


### PR DESCRIPTION
Summary:
# Create A2A Primitive Benchmarks

## Goals
Build a small set of **A2A (all-to-all) primitive microbenchmarks** that closely mirror the communication patterns used in TorchRec distributed modules, and extend the benchmark reporting to include **wall-clock time**.

## Tasks

1. **Input distribution (sparse KJT)**
   - Create an A2A benchmark that uses **`KJTAllToAll`** to simulate the all-to-all performed in `input_dist(...)` for **sparse `KeyedJaggedTensor` (KJT)** inputs.
   - Ensure the benchmark can vary key knobs such as:
     - world size / ranks
     - batch size
     - number of features / keys
     - pooling / jaggedness characteristics (e.g., lengths distribution)

2. **Output distribution (dense KT)**
   - Create an A2A benchmark that uses **`PooledEmbeddingsAllToAll`** to simulate the all-to-all performed in `output_dist(...)` for **dense `KeyedTensor` (KT)** outputs.
   - Support configurable parameters such as:
     - embedding dimension
     - number of pooled features
     - batch size
     - communication volume per rank

3. **Benchmark reporting improvements**
   - Update `base.py` to report **wall time** in addition to any existing timing metrics.
   - Use wall time as the primary end-to-end benchmark metric (i.e., includes Python overhead and synchronization as appropriate), and ensure results are consistently reported across benchmarks.


## Data Volume
Both benchmark uses data volume of ~1.2GB HBM per rank.

Reviewed By: TroyGarden

Differential Revision: D109717841


