### PR TITLE
Add `model_id` to `ShardingPlanRequest` for per-model rollout bucketing

### DIFF
--- a/torchrec/distributed/planner/tests/test_types.py
+++ b/torchrec/distributed/planner/tests/test_types.py
@@ -2103,6 +2103,21 @@ class ShardingPlanRequestTest(unittest.TestCase):
         self.assertNotEqual(first.request_id, second.request_id)
         self.assertEqual(first.request_hash, second.request_hash)
 
+    def test_model_id_defaults_to_none(self) -> None:
+        self.assertIsNone(self._create_request().model_id)
+
+    def test_model_id_pass_through(self) -> None:
+        request = self._create_request(model_id="mtml_ctr_ig_stories_model")
+        self.assertEqual(request.model_id, "mtml_ctr_ig_stories_model")
+
+    def test_model_id_excluded_from_request_hash(self) -> None:
+        # model_id is a rollout-bucketing hint (JK hashval), not a plan-affecting
+        # parameter -- two otherwise-identical requests with different model_id
+        # must share a request_hash so the cache/dedup key is stable.
+        base = self._create_request().request_hash
+        self.assertEqual(base, self._create_request(model_id="model_a").request_hash)
+        self.assertEqual(base, self._create_request(model_id="model_b").request_hash)
+
 
 class PlannerConfigTest(unittest.TestCase):
     def test_defaults(self) -> None:

--- a/torchrec/distributed/planner/types.py
+++ b/torchrec/distributed/planner/types.py
@@ -2234,6 +2234,16 @@ class ShardingPlanRequest:
     # request object — use it to tell two otherwise-identical requests apart.
     # Auto-generated; override to thread an externally-supplied id.
     request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    # Stable per-model identifier used as the hashval for JK Consistent Pass
+    # Rate bucketing when the planner rolls a change out (e.g. "10% of models
+    # get SKUAware"). Must be stable across job retries for the same model so
+    # the same model consistently lands in the same bucket -- prefer the model
+    # TYPE name (e.g. "mtml_ctr_ig_stories_model") over per-job identifiers.
+    # None falls back to `training_framework.name` at the rollout call site,
+    # which is an all-or-nothing gate (every job in the framework hashes to
+    # one bucket); populate this to get true per-model ramp granularity. Not
+    # plan-affecting, so excluded from request_hash.
+    model_id: Optional[str] = None
     # Observability opt-in: when True the executor captures the full enumerated
     # search space onto ctx.search_space (per SKU) and the reproduction upload
     # persists it to Manifold (URL surfaced on the planner_runs Scuba row). Off by


### PR DESCRIPTION
Summary:
Adds a new optional field to the OSS `ShardingPlanRequest` dataclass:

    model_id: Optional[str] = None

This is a stable per-model identifier used as the `hashval` for the JK
Consistent Pass Rate check when the planner rolls a change out at a
fractional stage (e.g. "10% of models get SKUAware"). It replaces the
current fallback of `training_framework.name`, which hashes every job in
a framework to the same bucket -- yielding all-or-nothing gating instead
of true per-model ramp granularity.

Callers should populate this with the model TYPE name (stable across job
retries), NOT a per-job identifier (which would rehash every submission
and undo the "N% of models" semantic). Adapter changes to populate the
field land in follow-up diffs (APF / MVAI).

Not plan-affecting: excluded from `request_hash` by design, so two
otherwise-identical requests with different `model_id` values still
share a content hash (cache/dedup key stays stable).

Differential Revision: D114432426


