### PR TITLE
Revert D113962249: Gate optimizer scratch-buffer freeing behind a flag

### DIFF
--- a/torchrec/distributed/memory_stashing.py
+++ b/torchrec/distributed/memory_stashing.py
@@ -1079,7 +1079,6 @@ class MemoryStashingManager:
         optimizer: torch.optim.Optimizer,
         sync_event: Optional[torch.cuda.Event] = None,
         num_slices: int = 1,
-        free_scratch_buffers: bool = True,
     ) -> Tuple[
         Callable[[Optional[torch.Tensor]], None],
         Callable[[Optional[torch.Tensor]], None],
@@ -1109,12 +1108,6 @@ class MemoryStashingManager:
                 callback (slice 0 first), to be driven per-hook via
                 ``restore_optimizer_state_next``; the returned ``await_restore``
                 then gates on ALL slices' restore completion.
-            free_scratch_buffers: When True (default), also free the optimizer's
-                disposable communication scratch buffers (e.g. DistributedShampoo's
-                ``_global_dist_buffer`` -- the all-gather buffer for per-rank search
-                directions) via ``resize_(0)``, re-allocating them before the step.
-                Pure scratch: freed/re-alloc'd, NOT copied to host, distinct from
-                the persistent-state stash. When False, they are left resident.
 
         Returns:
             A tuple of two callback functions:
@@ -1158,10 +1151,8 @@ class MemoryStashingManager:
                 tensors, label="optimizer state", sync_event=sync_event
             )
             cls._optimizer_state_restore_callbacks.append(tensor_restore)
-            scratch_buffer_restore = (
-                cls._release_optimizer_scratch_buffers(optimizer, sync_event)
-                if free_scratch_buffers
-                else None
+            scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
+                optimizer, sync_event
             )
 
             def restore(
@@ -1207,10 +1198,8 @@ class MemoryStashingManager:
             # maps slice k to the k-th hook to fire.
             cls._optimizer_state_restore_callbacks.append(restore_k)
 
-        scratch_buffer_restore = (
-            cls._release_optimizer_scratch_buffers(optimizer, sync_event)
-            if free_scratch_buffers
-            else None
+        scratch_buffer_restore = cls._release_optimizer_scratch_buffers(
+            optimizer, sync_event
         )
 
         def aggregate_await(_grad: Optional[torch.Tensor] = None) -> None:


### PR DESCRIPTION
Summary:
D113962249 added `OptimizerMemoryStashingConfig.free_scratch_buffers` to gate
freeing/re-allocating DistributedShampoo's `_global_dist_buffer` (the all-gather
scratch buffer for per-rank search directions) during the optimizer-state stash
window.

That gate only needed to exist because the buffer's lifecycle was routed through
torchrec's `MemoryStashingManager` and the APS MB train pipeline.
`_global_dist_buffer` is pure scratch that DistributedShampoo allocates, fills,
and consumes entirely within `update_params()` -- it never leaves the optimizer
and is not part of `state_dict`. Splitting its free/re-alloc across three
codebases forced a cross-repo `scratch_buffers()` protocol, optimizer-wrapper
fan-out, an extra restore-callback list in the stashing manager, a
`restore_scratch_buffer=False` special case on the checkpoint path, and this APF
config flag -- all to coordinate something that never crosses a module boundary.
It also coupled this feature's rollout to the persistent-state stashing rollout,
and only worked for pipelines that happen to use `MemoryStashingManager`.

Reverting the full stack (this diff, then D113962248, then D113962247). The
feature is being re-implemented entirely inside
`hpc/optimizers/distributed_shampoo/dev/`, driven by a new
`DDPDistributedConfig.free_dist_buffer_between_steps` flag, with the free /
re-alloc confined to the distributor that owns the buffer.

Bottom of a 3-diff revert stack.

Original commit changeset: 3d74a0bcb80d
Original Phabricator Diff: D113962249

Differential Revision: D114959515


