### PR TITLE
eval-only DATA_PARALLEL embeddings skip the DDP gradient reducer

### DIFF
--- a/torchrec/distributed/embedding.py
+++ b/torchrec/distributed/embedding.py
@@ -34,7 +34,10 @@ from torch.distributed._tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
-from torchrec.distributed.embedding_lookup import PartiallyMaterializedTensor
+from torchrec.distributed.embedding_lookup import (
+    GroupedEmbeddingsLookup,
+    PartiallyMaterializedTensor,
+)
 from torchrec.distributed.embedding_sharding import (
     EmbeddingSharding,
     EmbeddingShardingInfo,
@@ -103,6 +106,7 @@ from torchrec.modules.embedding_configs import (
 from torchrec.modules.embedding_modules import (
     EmbeddingCollection,
     EmbeddingCollectionInterface,
+    should_skip_data_parallel_grad_sync,
 )
 from torchrec.modules.utils import construct_jagged_tensors, SequenceVBEContext
 from torchrec.optim.fused import EmptyFusedOptimizer, FusedOptimizerModule
@@ -463,6 +467,10 @@ class ShardedEmbeddingCollection(
         self._enable_feature_score_weight_accumulation: bool = False
 
         self._module_fqn = module_fqn
+        # Opt-out of the DATA_PARALLEL DDP gradient reducer (see embedding_modules).
+        self._skip_data_parallel_grad_sync: bool = should_skip_data_parallel_grad_sync(
+            module
+        )
         self._embedding_configs: List[EmbeddingConfig] = module.embedding_configs()
         self._table_names: List[str] = [
             config.name for config in self._embedding_configs
@@ -603,6 +611,9 @@ class ShardedEmbeddingCollection(
         """
         Initialize data parallel for the embedding collection.
         """
+        # Opt-out: skip the DDP wrap; the raw DP lookup forwards on its own.
+        if self._skip_data_parallel_grad_sync:
+            return
         for index, (sharding, lookup) in enumerate(
             zip(
                 self._sharding_type_to_sharding.values(),
@@ -939,8 +950,9 @@ class ShardedEmbeddingCollection(
             self._sharding_type_to_sharding.keys(), self._lookups
         ):
             if sharding_type == ShardingType.DATA_PARALLEL.value:
-                # unwrap DDP
-                lookup = lookup.module
+                # mark_data_parallel_skip_grad_sync modules are never wrapped.
+                while isinstance(lookup, DistributedDataParallel):
+                    lookup = lookup.module
             else:
                 # save local_shards for transforming MP params to shardedTensor
                 for key, v in lookup.state_dict().items():
@@ -972,12 +984,9 @@ class ShardedEmbeddingCollection(
                         self._model_parallel_name_to_local_shards[table_name].extend(
                             v.local_shards()
                         )
-            for (
-                table_name,
-                tbe_slice,
-                #  `named_parameters_by_table`.
-                # pyrefly: ignore[missing-attribute]
-            ) in lookup.named_parameters_by_table():
+            for table_name, tbe_slice in cast(
+                GroupedEmbeddingsLookup, lookup
+            ).named_parameters_by_table():
                 # for virtual table, currently we don't expose id tensor and bucket tensor
                 # because they are not updated in real time, and they are created on the fly
                 # whenever state_dict is called

--- a/torchrec/distributed/embeddingbag.py
+++ b/torchrec/distributed/embeddingbag.py
@@ -37,7 +37,10 @@ from torch.distributed._tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel
 from torchrec.distributed.comm import get_local_size
-from torchrec.distributed.embedding_lookup import PartiallyMaterializedTensor
+from torchrec.distributed.embedding_lookup import (
+    GroupedPooledEmbeddingsLookup,
+    PartiallyMaterializedTensor,
+)
 from torchrec.distributed.embedding_sharding import (
     EmbeddingSharding,
     EmbeddingShardingContext,
@@ -113,6 +116,7 @@ from torchrec.modules.embedding_configs import (
 from torchrec.modules.embedding_modules import (
     EmbeddingBagCollection,
     EmbeddingBagCollectionInterface,
+    should_skip_data_parallel_grad_sync,
 )
 from torchrec.optim.fused import EmptyFusedOptimizer, FusedOptimizerModule
 from torchrec.optim.keyed import CombinedOptimizer, KeyedOptimizer
@@ -639,6 +643,10 @@ class ShardedEmbeddingBagCollection(
         # pyrefly: ignore [missing-attribute]
         super().__init__(qcomm_codecs_registry=qcomm_codecs_registry)
         self._module_fqn = module_fqn
+        # Opt-out of the DATA_PARALLEL DDP gradient reducer (see embedding_modules).
+        self._skip_data_parallel_grad_sync: bool = should_skip_data_parallel_grad_sync(
+            module
+        )
         # Normalize to lowercase for case-insensitive matching
         self._sharded_module_order_overwrite: Optional[List[str]] = (
             [s.lower() for s in sharded_module_order_overwrite]
@@ -815,6 +823,9 @@ class ShardedEmbeddingBagCollection(
         """
         Initialize data parallel for the embedding bag collection.
         """
+        # Opt-out: skip the DDP wrap; the raw DP lookup forwards on its own.
+        if self._skip_data_parallel_grad_sync:
+            return
         for i, (sharding, lookup) in enumerate(
             zip(self._embedding_shardings, self._lookups)
         ):
@@ -1213,8 +1224,9 @@ class ShardedEmbeddingBagCollection(
 
         for lookup, sharding in zip(self._lookups, self._embedding_shardings):
             if isinstance(sharding, DpPooledEmbeddingSharding):
-                # unwrap DDP
-                lookup = lookup.module
+                # mark_data_parallel_skip_grad_sync modules are never wrapped.
+                while isinstance(lookup, DistributedDataParallel):
+                    lookup = lookup.module
             else:
                 # save local_shards for transforming MP params to DTensor
                 for key, v in lookup.state_dict().items():
@@ -1246,12 +1258,9 @@ class ShardedEmbeddingBagCollection(
                         self._model_parallel_name_to_local_shards[table_name].extend(
                             v.local_shards()
                         )
-            for (
-                table_name,
-                tbe_slice,
-                #  `named_parameters_by_table`.
-                # pyrefly: ignore [missing-attribute]
-            ) in lookup.named_parameters_by_table():
+            for table_name, tbe_slice in cast(
+                GroupedPooledEmbeddingsLookup, lookup
+            ).named_parameters_by_table():
                 # for virtual table, currently we don't expose id tensor and bucket tensor
                 # because they are not updated in real time, and they are created on the fly
                 # whenever state_dict is called

--- a/torchrec/distributed/tests/test_dp_grad_sync_optout.py
+++ b/torchrec/distributed/tests/test_dp_grad_sync_optout.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# This test exercises DATA_PARALLEL replication and the DDP-wrap decision, which
+# are device-independent; run it CPU/gloo-only so it needs no GPU. CUDA is hidden
+# per-test (see the class below) to keep MultiProcessContext on its CPU path
+# without mutating the process-wide env at import time.
+import os
+import unittest
+from typing import cast, List
+from unittest.mock import patch
+
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel
+from torchrec.distributed.embedding import (
+    EmbeddingCollectionSharder,
+    ShardedEmbeddingCollection,
+)
+from torchrec.distributed.embeddingbag import (
+    EmbeddingBagCollectionSharder,
+    ShardedEmbeddingBagCollection,
+)
+from torchrec.distributed.model_parallel import DistributedModelParallel
+from torchrec.distributed.sharding_plan import (
+    construct_module_sharding_plan,
+    data_parallel,
+)
+from torchrec.distributed.test_utils.multi_process import (
+    MultiProcessContext,
+    MultiProcessTestBase,
+)
+from torchrec.distributed.types import ModuleSharder, ShardingEnv, ShardingPlan
+from torchrec.modules.embedding_configs import EmbeddingBagConfig, EmbeddingConfig
+from torchrec.modules.embedding_modules import (
+    EmbeddingBagCollection,
+    EmbeddingCollection,
+    mark_data_parallel_skip_grad_sync,
+    should_skip_data_parallel_grad_sync,
+)
+from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from torchrec.test_utils import skip_if_asan_class
+
+_TABLE_NAME = "table_0"
+_FEATURE_NAME = "feature_0"
+_EMBEDDING_DIM = 8
+_NUM_EMBEDDINGS = 16
+
+
+def _build_ebc(device: torch.device) -> EmbeddingBagCollection:
+    return EmbeddingBagCollection(
+        tables=[
+            EmbeddingBagConfig(
+                name=_TABLE_NAME,
+                embedding_dim=_EMBEDDING_DIM,
+                num_embeddings=_NUM_EMBEDDINGS,
+                feature_names=[_FEATURE_NAME],
+            )
+        ],
+        device=device,
+    )
+
+
+def _build_ec(device: torch.device) -> EmbeddingCollection:
+    return EmbeddingCollection(
+        tables=[
+            EmbeddingConfig(
+                name=_TABLE_NAME,
+                embedding_dim=_EMBEDDING_DIM,
+                num_embeddings=_NUM_EMBEDDINGS,
+                feature_names=[_FEATURE_NAME],
+            )
+        ],
+        device=device,
+    )
+
+
+def _input_kjt(device: torch.device) -> KeyedJaggedTensor:
+    return KeyedJaggedTensor(
+        keys=[_FEATURE_NAME],
+        values=torch.tensor([1, 2, 3], dtype=torch.long, device=device),
+        lengths=torch.tensor([2, 1], dtype=torch.long, device=device),
+    )
+
+
+def _dp_lookups(dmp: DistributedModelParallel) -> List[nn.Module]:
+    """Lookups of the FIRST sharded embedding module found in the DMP. Each DMP in
+    this test wraps exactly one EBC/EC, so returning the first match is sufficient."""
+    for submodule in dmp.modules():
+        if isinstance(
+            submodule, (ShardedEmbeddingBagCollection, ShardedEmbeddingCollection)
+        ):
+            # pyre-ignore[7]: private but stable attribute used for the assertion
+            return list(submodule._lookups)
+    raise AssertionError("no sharded embedding module found in DMP")
+
+
+def _resolve(output: object) -> object:
+    return output.wait() if hasattr(output, "wait") else output
+
+
+def _shard_dp(
+    module: nn.Module,
+    sharder: ModuleSharder[nn.Module],
+    ctx: MultiProcessContext,
+    device: torch.device,
+) -> DistributedModelParallel:
+    module_sharding_plan = construct_module_sharding_plan(
+        module,
+        per_param_sharding={_TABLE_NAME: data_parallel()},
+        local_size=ctx.local_size,
+        world_size=ctx.world_size,
+        device_type=device.type,
+    )
+    return DistributedModelParallel(
+        module=module,
+        plan=ShardingPlan({"": module_sharding_plan}),
+        # pyre-ignore[6]: ctx.pg is typed Optional[ProcessGroup]; MultiProcessContext
+        # always initializes it before this call, so it is non-None here.
+        env=ShardingEnv.from_process_group(ctx.pg),
+        sharders=[sharder],
+        device=device,
+    )
+
+
+def _run_dp_grad_sync_optout(
+    rank: int,
+    world_size: int,
+    backend: str,
+    is_ebc: bool,
+) -> None:
+    with MultiProcessContext(rank, world_size, backend) as ctx:
+        # Force CPU/gloo: DATA_PARALLEL replication and the DDP-wrap decision are
+        # device-independent, and this keeps the test runnable without GPUs.
+        device = torch.device("cpu")
+
+        default_module = _build_ebc(device) if is_ebc else _build_ec(device)
+
+        frozen_module = _build_ebc(device) if is_ebc else _build_ec(device)
+        # Opt the frozen copy out of the DATA_PARALLEL DDP gradient reducer.
+        mark_data_parallel_skip_grad_sync(frozen_module)
+
+        sharder = cast(
+            ModuleSharder[nn.Module],
+            EmbeddingBagCollectionSharder() if is_ebc else EmbeddingCollectionSharder(),
+        )
+
+        default_dmp = _shard_dp(default_module, sharder, ctx, device)
+        frozen_dmp = _shard_dp(frozen_module, sharder, ctx, device)
+
+        # Regression guard: the default DP module still gets a DDP reducer.
+        default_lookups = _dp_lookups(default_dmp)
+        assert any(
+            isinstance(lookup, DistributedDataParallel) for lookup in default_lookups
+        ), "default DATA_PARALLEL module must keep the DistributedDataParallel wrap"
+
+        # The frozen/opt-out module has raw lookups (no DDP, no reducer/buckets).
+        frozen_lookups = _dp_lookups(frozen_dmp)
+        assert not any(
+            isinstance(lookup, DistributedDataParallel) for lookup in frozen_lookups
+        ), "opt-out DATA_PARALLEL module must skip the DistributedDataParallel wrap"
+
+        # The unwrapped DP lookup still forwards correctly (DDP is only needed
+        # for the backward all-reduce). Check the pooled (EBC) forward against a
+        # local (unsharded) reference that mirrors the sharded module's actual
+        # replicated weight -- the sharded module re-inits in reset_parameters,
+        # so copy its state, not the source module's. The embedding kernels have
+        # no deterministic CUDA variant, so relax the deterministic guard.
+        if is_ebc:
+            weight_key = f"embedding_bags.{_TABLE_NAME}.weight"
+            local_module = _build_ebc(device)
+            local_module.load_state_dict(
+                {weight_key: frozen_dmp.state_dict()[weight_key].cpu()}
+            )
+            kjt = _input_kjt(device)
+            # Relax the deterministic guard only around the forward (embedding kernels
+            # have no deterministic CPU/CUDA variant), then restore it -- the flag is
+            # process-global even inside this MultiProcessContext subprocess.
+            prev_deterministic = torch.are_deterministic_algorithms_enabled()
+            torch.use_deterministic_algorithms(False)
+            try:
+                with torch.inference_mode():
+                    frozen_out = _resolve(frozen_dmp(kjt))
+                    local_out = local_module(kjt)
+                torch.testing.assert_close(
+                    # pyre-ignore[16]: _resolve() returns object; the EBC forward output
+                    # (KeyedTensor) exposes .values().
+                    frozen_out.values(),
+                    # pyre-ignore[16]: local EBC forward returns a KeyedTensor (.values()).
+                    local_out.values(),
+                )
+            finally:
+                torch.use_deterministic_algorithms(prev_deterministic)
+
+
+@skip_if_asan_class
+class DataParallelGradSyncOptOutTest(MultiProcessTestBase):
+    def _run(self, is_ebc: bool) -> None:
+        # Hide CUDA only for this test (not at module import, which would leak into
+        # other test modules). The spawned workers inherit the env before they import
+        # torch, forcing MultiProcessContext onto its CPU/gloo path.
+        with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": ""}):
+            self._run_multi_process_test(
+                callable=_run_dp_grad_sync_optout,
+                world_size=2,
+                backend="gloo",
+                is_ebc=is_ebc,
+            )
+
+    def test_ebc_dp_skip_grad_sync(self) -> None:
+        self._run(is_ebc=True)
+
+    def test_ec_dp_skip_grad_sync(self) -> None:
+        self._run(is_ebc=False)
+
+
+class MarkDataParallelSkipGradSyncTest(unittest.TestCase):
+    """Unit tests for the marker helpers (no sharding / distributed setup needed)."""
+
+    def test_unmarked_module_returns_false(self) -> None:
+        # A module never passed to mark_data_parallel_skip_grad_sync opts in to the
+        # default (DDP reducer kept), so should_skip_data_parallel_grad_sync is False.
+        module = _build_ebc(torch.device("cpu"))
+        self.assertFalse(should_skip_data_parallel_grad_sync(module))
+
+    def test_marked_module_returns_true(self) -> None:
+        module = _build_ebc(torch.device("cpu"))
+        mark_data_parallel_skip_grad_sync(module)
+        self.assertTrue(should_skip_data_parallel_grad_sync(module))
+
+    def test_unsharded_module_does_not_warn(self) -> None:
+        module = _build_ebc(torch.device("cpu"))
+        with self.assertNoLogs("torchrec.modules.embedding_modules", level="WARNING"):
+            mark_data_parallel_skip_grad_sync(module)
+
+    def test_already_sharded_module_warns(self) -> None:
+        # Marking after sharding is a no-op: the marker is read once at shard time.
+        # `_lookups` (set by ShardedEmbeddingModule) stands in for a sharded module
+        # so this stays a unit test with no distributed setup. Assigned through
+        # object.__setattr__ because nn.Module.__setattr__ is typed to accept only
+        # Module | Tensor, while the real attribute is a plain List[nn.Module].
+        module = _build_ebc(torch.device("cpu"))
+        object.__setattr__(module, "_lookups", [])
+        with self.assertLogs(
+            "torchrec.modules.embedding_modules", level="WARNING"
+        ) as cm:
+            mark_data_parallel_skip_grad_sync(module)
+        self.assertIn("already-sharded", cm.output[0])
+        # Still sets the attribute -- the warning is advisory, not a guard.
+        self.assertTrue(should_skip_data_parallel_grad_sync(module))

--- a/torchrec/modules/embedding_modules.py
+++ b/torchrec/modules/embedding_modules.py
@@ -8,6 +8,7 @@
 # pyre-strict
 
 import abc
+import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -20,6 +21,37 @@ from torchrec.modules.embedding_configs import (
 )
 from torchrec.sparse.jagged_tensor import JaggedTensor, KeyedJaggedTensor, KeyedTensor
 from torchrec.sparse.tensor_dict import maybe_td_to_kjt
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# TEMPORARY: out-of-band marker, not part of the module API. Opts an unsharded
+# EBC/EC out of the DATA_PARALLEL DDP gradient reducer, for forward-only modules
+# whose grad buckets would be dead.
+MODULE_ATTR_DATA_PARALLEL_SKIP_GRAD_SYNC: str = "_torchrec_data_parallel_skip_grad_sync"
+
+
+def mark_data_parallel_skip_grad_sync(module: nn.Module) -> None:
+    """Opt ``module`` out of the DATA_PARALLEL DDP gradient reducer once sharded.
+
+    Set by the caller on the *unsharded* module before ``DistributedModelParallel``
+    and read once at shard time; setting it after sharding has no effect.
+    """
+    # ShardedEmbeddingModule sets `_lookups`, so its presence means sharding already
+    # happened and this marker will never be read.
+    if hasattr(module, "_lookups"):
+        logger.warning(
+            "mark_data_parallel_skip_grad_sync() called on an already-sharded %s; "
+            "the marker is read at shard time, so this has no effect.",
+            type(module).__name__,
+        )
+    setattr(module, MODULE_ATTR_DATA_PARALLEL_SKIP_GRAD_SYNC, True)
+
+
+def should_skip_data_parallel_grad_sync(module: nn.Module) -> bool:
+    """Whether ``module`` was marked via ``mark_data_parallel_skip_grad_sync``."""
+    return bool(getattr(module, MODULE_ATTR_DATA_PARALLEL_SKIP_GRAD_SYNC, False))
 
 
 @torch.fx.wrap


### PR DESCRIPTION
Summary: Add an opt-out for the per-table DATA_PARALLEL `DistributedDataParallel` gradient reducer on embedding modules. Marking a source module with `mark_data_parallel_skip_grad_sync(module)` makes its DATA_PARALLEL lookups in `ShardedEmbeddingBagCollection` / `ShardedEmbeddingCollection` replicate WITHOUT the DDP wrap -- intended for frozen / forward-only modules that never run backward, where the reducer's grad buckets would only ever hold zeros. The raw DP lookup forwards correctly on its own (DDP is only needed for the backward all-reduce). Default is unchanged: absent the marker the DDP wrap is created exactly as before, so trained modules are byte-identical.

Reviewed By: spmex, TroyGarden

Differential Revision: D113473115


