### PR TITLE
Remove syncs from segment candidate metrics

### DIFF
--- a/torchrec/metrics/gauc.py
+++ b/torchrec/metrics/gauc.py
@@ -103,10 +103,16 @@ def get_auc_states(
     predictions: torch.Tensor,
     weights: torch.Tensor,
     num_candidates: torch.Tensor,
+    max_num_candidates_cpu: Optional[torch.Tensor] = None,
 ) -> Dict[str, torch.Tensor]:
 
     # predictions, labels: [n_task, n_sample]
-    max_length = int(num_candidates.max().item())
+    if max_num_candidates_cpu is not None:
+        if max_num_candidates_cpu.device.type != "cpu":
+            raise RecMetricException("max_num_candidates_cpu must be on CPU")
+        max_length = int(max_num_candidates_cpu.item())
+    else:
+        max_length = int(num_candidates.max().item())
     predictions_perm = predictions.permute(1, 0)
     labels_perm = labels.permute(1, 0)
     weights_perm = weights.permute(1, 0)
@@ -173,6 +179,7 @@ class GAUCMetricComputation(RecMetricComputation):
         labels: torch.Tensor,
         weights: Optional[torch.Tensor],
         num_candidates: torch.Tensor,
+        max_num_candidates_cpu: Optional[torch.Tensor] = None,
         **kwargs: Dict[str, Any],
     ) -> None:
         if predictions is None or weights is None:
@@ -180,7 +187,13 @@ class GAUCMetricComputation(RecMetricComputation):
                 "Inputs 'predictions' and 'weights' should not be None for GAUCMetricComputation update"
             )
 
-        states = get_auc_states(labels, predictions, weights, num_candidates)
+        states = get_auc_states(
+            labels,
+            predictions,
+            weights,
+            num_candidates,
+            max_num_candidates_cpu,
+        )
         num_samples = predictions.shape[-1]
 
         for state_name, state_value in states.items():

--- a/torchrec/metrics/tests/test_gauc.py
+++ b/torchrec/metrics/tests/test_gauc.py
@@ -60,6 +60,78 @@ class GAUCMetricValueTest(unittest.TestCase):
             tasks=[DefaultTaskInfo],
         )
 
+    def test_max_num_candidates_cpu_matches_legacy(self) -> None:
+        test_cases = [
+            (
+                "exact_bound",
+                torch.tensor([[0.9, 0.8, 0.7, 0.6, 0.5]]),
+                torch.tensor([[1, 0, 1, 1, 0]]),
+                torch.tensor([[1, 1, 1, 1, 1]]),
+                torch.tensor([3, 2]),
+                3,
+            ),
+            (
+                "loose_bound",
+                torch.tensor([[0.3, 0.9, 0.1, 0.8, 0.2, 0.8, 0.7, 0.6, 0.5, 0.5]]),
+                torch.tensor([[1, 1, 1, 0, 0, 1, 0, 1, 1, 0]]),
+                torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]),
+                torch.tensor([2, 3, 3, 2]),
+                8,
+            ),
+            (
+                "zero_weights_and_tied_predictions",
+                torch.tensor([[0.8, 0.8, 0.3, 0.2]]),
+                torch.tensor([[1, 0, 1, 0]]),
+                torch.tensor([[1, 0, 1, 1]]),
+                torch.tensor([2, 2]),
+                6,
+            ),
+        ]
+
+        for (
+            name,
+            predictions,
+            labels,
+            weights,
+            num_candidates,
+            max_num_candidates,
+        ) in test_cases:
+            with self.subTest(name=name):
+                legacy = GAUCMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=100,
+                    tasks=[DefaultTaskInfo],
+                )
+                optimized = GAUCMetric(
+                    world_size=1,
+                    my_rank=0,
+                    batch_size=100,
+                    tasks=[DefaultTaskInfo],
+                )
+                batches = {
+                    "predictions": {"DefaultTask": predictions},
+                    "labels": {"DefaultTask": labels},
+                    "num_candidates": num_candidates,
+                    "weights": {"DefaultTask": weights},
+                }
+
+                legacy.update(**batches)
+                optimized.update(
+                    **batches,
+                    max_num_candidates_cpu=torch.tensor(max_num_candidates),
+                )
+
+                legacy_result = legacy.compute()
+                optimized_result = optimized.compute()
+                self.assertEqual(legacy_result.keys(), optimized_result.keys())
+                for key, legacy_value in legacy_result.items():
+                    torch.testing.assert_close(
+                        optimized_result[key],
+                        legacy_value,
+                        equal_nan=True,
+                    )
+
     def test_calc_gauc_simple(self) -> None:
         self.predictions["DefaultTask"] = torch.tensor([[0.9, 0.8, 0.7, 0.6, 0.5]])
         self.labels["DefaultTask"] = torch.tensor([[1, 0, 1, 1, 0]])
@@ -69,6 +141,7 @@ class GAUCMetricValueTest(unittest.TestCase):
             "predictions": self.predictions,
             "labels": self.labels,
             "num_candidates": self.num_candidates,
+            "max_num_candidates_cpu": torch.tensor(4),
             "weights": self.weights,
         }
 


### PR DESCRIPTION
Summary:
Add a flag-gated fixed-shape candidate-count path for segment metrics. Reuse a CPU-resident max-candidate bound for GAUC so the compiled update path avoids CUDA scalar reads and data-dependent indexing.

Preserve the existing behavior when `ENABLE_SEGMENT_METRICS_NUM_CANDIDATES_OPT` is disabled.

Differential Revision: D113910954


