### PR TITLE
Create All-Gather Primitive Benchmark (#4504)

### DIFF
--- a/torchrec/distributed/benchmark/benchmark_primitive.py
+++ b/torchrec/distributed/benchmark/benchmark_primitive.py
@@ -28,6 +28,11 @@ exchanges float tensors rather than sparse indices. The third is ``reduce_scatte
 reduce-scatter performance of ``PooledEmbeddingsReduceScatter`` (from ``dist_data.py``) --
 the collective ``output_dist`` uses instead of the A2A for row-wise / table-row-wise
 sharding, summing each rank's partial pooled embeddings and scattering the batch dimension.
+The fourth is ``all_gather``, the all-gather performance of ``PooledEmbeddingsAllGather``
+(from ``dist_data.py``) -- the inverse of ``reduce_scatter`` (each rank contributes its
+batch slice and receives the full gathered batch). Unlike the others it is not a forward
+``output_dist`` for any sharder; it is exercised in TorchRec as the reduce-scatter backward
+and 2D fully-sharded weight reconstruction.
 
 A follow-up launcher binary will call ``runner`` explicitly with options to run on
 MAST or locally.
@@ -41,6 +46,7 @@ import torch
 from torchrec.distributed.benchmark.base import benchmark_func, BenchmarkResult
 from torchrec.distributed.dist_data import (
     KJTAllToAll,
+    PooledEmbeddingsAllGather,
     PooledEmbeddingsAllToAll,
     PooledEmbeddingsReduceScatter,
 )
@@ -502,6 +508,147 @@ def _benchmark_reduce_scatter(
     return result
 
 
+def _make_all_gather_input(
+    batch_size: int,
+    dim: int,
+    values_dtype: torch.dtype,
+    device: torch.device,
+    world_size: int,
+) -> torch.Tensor:
+    """Build this rank's input for ``PooledEmbeddingsAllGather``.
+
+    Returns a ``[batch_size // world_size, dim]`` tensor -- this rank's slice of the global
+    batch. all-gather concatenates every rank's slice, so each rank ends up with the full
+    ``[batch_size, dim]`` result (the inverse of reduce-scatter). Content is random -- only
+    the transport size matters for this benchmark, not the values.
+    """
+    return torch.rand(
+        (batch_size // world_size, dim), dtype=values_dtype, device=device
+    )
+
+
+def _run_all_gather(
+    _batch_inputs: List[Any],
+    *,
+    ag: PooledEmbeddingsAllGather,
+    local_embs: torch.Tensor,
+) -> None:
+    """One measured iteration: full all-gather, then touch the output.
+
+    Rank alignment against the straggler effect is handled by ``PerfWrapper`` (it barriers
+    before each iteration, outside the timing window); this function only runs the
+    collective. ``PooledEmbeddingsAllGather`` returns a single-stage awaitable -- one
+    ``wait()`` gathers every rank's ``local_embs`` slice into the full ``[batch_size, dim]``
+    tensor (the inverse of ``PooledEmbeddingsReduceScatter``). ``numel()`` only reads the
+    output's shape metadata: no data read, no kernel, and -- like ``wait()`` on CUDA -- no
+    host sync (the collective runs async on the stream). The input tensor is reused across
+    iterations.
+
+    So we ``torch.cuda.synchronize()`` at the end to actually block the host on the
+    collective inside the measured region; that is what makes the wall-clock timer reflect
+    end-to-end collective latency (GPU-event timing is unaffected either way).
+    """
+    out = ag(local_embs).wait()
+    out.numel()
+    if local_embs.is_cuda:
+        torch.cuda.synchronize(local_embs.device)
+
+
+def _benchmark_all_gather(
+    ctx: SingleProcessContext,
+    rank: int,
+    world_size: int,
+    **kwargs: Any,
+) -> BenchmarkResult:
+    """``PooledEmbeddingsAllGather`` (dense pooled-embedding all-gather) benchmark.
+
+    Builds this rank's ``[batch_size // world_size, dim]`` batch slice, then measures the
+    latency of gathering every rank's slice into the full ``[batch_size, dim]`` tensor
+    through ``PooledEmbeddingsAllGather`` (the ``dist_data.py`` module) over ``ctx.pg`` --
+    the inverse of ``reduce_scatter``. This collective is not a forward ``output_dist`` for
+    any sharder; in TorchRec it shows up as the reduce-scatter backward (row-wise / grid)
+    and 2D fully-sharded weight reconstruction. Correctness of the gathered output is
+    intentionally not verified.
+
+    Args:
+        ctx: live single-process context (device + process group) injected by the
+            process runner; use ``ctx.device`` / ``ctx.pg`` directly.
+        rank: this process' global rank.
+        world_size: total number of ranks.
+        **kwargs: benchmark options:
+            batch_size (int): global batch size (rows of the *gathered* output) -- must be
+                divisible by ``world_size`` (each rank contributes ``batch_size //
+                world_size`` rows). Default 32 * 1024.
+            dim (int): embedding width. The headline transport size is ``batch_size * dim``
+                (with the defaults, ``32768 * 3072 * 4B ~= 400 MB`` of float32 gathered,
+                comparable to ``kt_a2a`` / ``reduce_scatter``). Default 3072.
+            values_dtype (torch.dtype): dtype of the embedding tensor; must be a floating
+                dtype. Default float32.
+            num_benchmarks (int): number of measured iterations. Default 20.
+            num_profiles (int): number of profiled iterations (requires profile_dir).
+                Default 0.
+            profile_dir (str): directory for chrome traces; empty disables profiling.
+            name (str): human-readable benchmark name. Default "all_gather".
+
+    Returns:
+        This rank's ``BenchmarkResult``.
+    """
+    batch_size: int = int(kwargs.get("batch_size", 32 * 1024))
+    dim: int = int(kwargs.get("dim", 3072))
+    values_dtype: torch.dtype = kwargs.get("values_dtype", torch.float32)
+    num_benchmarks: int = int(kwargs.get("num_benchmarks", 20))
+    num_profiles: int = int(kwargs.get("num_profiles", 0))
+    profile_dir: str = str(kwargs.get("profile_dir", ""))
+    name: str = str(kwargs.get("name", "all_gather"))
+
+    pg: Optional[torch.distributed.ProcessGroup] = ctx.pg
+    assert pg is not None, "ctx.pg must be initialized by the process runner"
+    assert batch_size % world_size == 0, (
+        f"batch_size ({batch_size}) must be divisible by world_size ({world_size}): "
+        "PooledEmbeddingsAllGather gathers an equal batch slice from each rank."
+    )
+
+    local_embs = _make_all_gather_input(
+        batch_size=batch_size,
+        dim=dim,
+        values_dtype=values_dtype,
+        device=ctx.device,
+        world_size=world_size,
+    )
+    ag = PooledEmbeddingsAllGather(pg)
+
+    logger.info(
+        "rank=%d local_rank=%d host=%s running all-gather benchmark: batch_size=%d "
+        "dim=%d device=%s",
+        rank,
+        ctx.local_rank,
+        socket.gethostname(),
+        batch_size,
+        dim,
+        ctx.device,
+    )
+
+    result = benchmark_func(
+        name=name,
+        rank=rank,
+        world_size=world_size,
+        func_to_benchmark=_run_all_gather,
+        bench_inputs=[],
+        prof_inputs=[],
+        benchmark_func_kwargs={"ag": ag, "local_embs": local_embs},
+        num_profiles=num_profiles,
+        num_benchmarks=num_benchmarks,
+        profile_dir=profile_dir,
+        device_type=ctx.device.type,
+        pg=pg,
+    )
+
+    if rank == 0:
+        logger.info("all-gather benchmark result:\n%s", result)
+
+    return result
+
+
 # Registry of available primitive benchmarks, keyed by the ``primitive`` flag.
 # Add new primitive benchmarks here -- each is called as
 # ``fn(ctx, rank, world_size, **kwargs)`` and returns a per-rank ``BenchmarkResult``.
@@ -509,6 +656,7 @@ _BENCHMARKS: Dict[str, Callable[..., BenchmarkResult]] = {
     "kjt_a2a": _benchmark_kjt_a2a,
     "kt_a2a": _benchmark_kt_a2a,
     "reduce_scatter": _benchmark_reduce_scatter,
+    "all_gather": _benchmark_all_gather,
 }
 
 


### PR DESCRIPTION
Summary:

Adds an **all-gather** primitive benchmark for `PooledEmbeddingsAllGather` (from `dist_data.py`).

### Key Changes
- Extends `benchmark_primitive.py` with an all-gather benchmark.
- Measures `PooledEmbeddingsAllGather` efficiency in gathering batch slices from all ranks into a full batch.
- Complements reduce-scatter by covering the inverse communication pattern.

### Impact
Enables more complete evaluation and optimization of TorchRec distributed performance.

Reviewed By: TroyGarden

Differential Revision: D113968555
